### PR TITLE
ci(actions): Use Namespace runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,11 @@ concurrency:
 env:
   ZIG_VERSION: 0.16.0
 
+# Runner selection defaults to GitHub-hosted labels so repositories created
+# from this template can run CI immediately. Set repository or organization
+# variables CI_LINUX_RUNNER, CI_MACOS_RUNNER, and CI_WINDOWS_RUNNER to opt into
+# Namespace or other self-hosted runners.
+
 permissions:
   contents: read
 
@@ -29,13 +34,13 @@ jobs:
       matrix:
         include:
           - os: Linux
-            runner: nscloud-ubuntu-24.04-amd64-4x8
+            runner: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
             artifact_name: myapp-linux
           - os: macOS
-            runner: nscloud-macos-sequoia-arm64-6x14
+            runner: ${{ vars.CI_MACOS_RUNNER || 'macos-latest' }}
             artifact_name: myapp-macos
           - os: Windows
-            runner: nscloud-windows-2022-amd64-4x8
+            runner: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
             artifact_name: myapp-windows
 
     runs-on: ${{ matrix.runner }}
@@ -54,7 +59,7 @@ jobs:
       - name: Get Zig version
         id: zig-version
         run: |
-          echo "ZIG_VERSION=$(zig version)" >> $GITHUB_ENV
+          echo "ZIG_VERSION=$(zig version)" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Cache Zig build
@@ -73,8 +78,8 @@ jobs:
         run: |
           # Extract the name field from build.zig.zon, handling both quoted and unquoted formats
           BINARY_NAME=$(awk '/\.name = / {gsub(/.*\.name = /, ""); gsub(/[,.]/, ""); gsub(/"/, ""); print}' build.zig.zon)
-          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
-          echo "binary_name=$BINARY_NAME" >> $GITHUB_OUTPUT
+          echo "BINARY_NAME=$BINARY_NAME" >> "$GITHUB_ENV"
+          echo "binary_name=$BINARY_NAME" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Install dependencies
@@ -88,7 +93,7 @@ jobs:
         shell: bash
 
       - name: Install pdcurses (Windows)
-        if: matrix.os == 'Windows'
+        if: runner.os == 'Windows'
         run: |
           # Install vcpkg
           git clone https://github.com/Microsoft/vcpkg.git
@@ -98,10 +103,12 @@ jobs:
           
           # Install pdcurses
           ./vcpkg install pdcurses:x64-windows
-          echo "VCPKG_ROOT=$(pwd)" >> $GITHUB_ENV
           # Also set library paths for Windows
-          echo "LIB=$LIB;$(pwd)/installed/x64-windows/lib" >> $GITHUB_ENV
-          echo "INCLUDE=$INCLUDE;$(pwd)/installed/x64-windows/include" >> $GITHUB_ENV
+          {
+            echo "VCPKG_ROOT=$(pwd)"
+            echo "LIB=$LIB;$(pwd)/installed/x64-windows/lib"
+            echo "INCLUDE=$INCLUDE;$(pwd)/installed/x64-windows/include"
+          } >> "$GITHUB_ENV"
           cd ..
         shell: bash
 
@@ -159,7 +166,7 @@ jobs:
             zig build -Denable-tui=true
           fi
 
-          ./zig-out/bin/$BINARY_NAME$BINARY_EXT --json info | grep '"tui":true'
+          "./zig-out/bin/$BINARY_NAME$BINARY_EXT" --json info | grep '"tui":true'
 
           if [ "${{ runner.os }}" = "Linux" ]; then
             zig build -Denable-tui=true terminal-test
@@ -183,7 +190,7 @@ jobs:
 
   lint:
     name: Lint and Format
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository
@@ -206,7 +213,7 @@ jobs:
 
       - name: Run clang-format check
         run: |
-          find src -name "*.c" -o -name "*.h" | xargs clang-format --dry-run --Werror
+          find src \( -name "*.c" -o -name "*.h" \) -print0 | xargs -0 clang-format --dry-run --Werror
         shell: bash
 
       - name: Run clang-tidy analysis
@@ -258,7 +265,7 @@ jobs:
 
   validate-template:
     name: Validate Template
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     # Skip validation for the template repository itself
     if: github.repository != 'sammyjoyce/c23-cli-template'
 
@@ -315,7 +322,7 @@ jobs:
 
   renovate-config:
     name: Validate Renovate Config
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository
@@ -326,7 +333,7 @@ jobs:
 
   pre-commit:
     name: Run Pre-commit Hooks
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository
@@ -352,7 +359,7 @@ jobs:
 
   coverage:
     name: Test Coverage
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Check out repository
@@ -378,7 +385,7 @@ jobs:
 
   secrets-scan:
     name: Secrets Scan
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
       security-events: write
@@ -396,7 +403,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
       security-events: write
@@ -434,7 +441,7 @@ jobs:
   release:
     name: Create Release
     needs: [test, lint]
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,16 +27,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - os: ubuntu-latest
+          - os: Linux
+            runner: nscloud-ubuntu-24.04-amd64-4x8
             artifact_name: myapp-linux
-          - os: macos-latest
+          - os: macOS
+            runner: nscloud-macos-sequoia-arm64-6x14
             artifact_name: myapp-macos
-          - os: windows-latest
+          - os: Windows
+            runner: nscloud-windows-2022-amd64-4x8
             artifact_name: myapp-windows
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Check out repository
@@ -86,7 +88,7 @@ jobs:
         shell: bash
 
       - name: Install pdcurses (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'Windows'
         run: |
           # Install vcpkg
           git clone https://github.com/Microsoft/vcpkg.git
@@ -181,7 +183,7 @@ jobs:
 
   lint:
     name: Lint and Format
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
 
     steps:
       - name: Check out repository
@@ -256,7 +258,7 @@ jobs:
 
   validate-template:
     name: Validate Template
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
     # Skip validation for the template repository itself
     if: github.repository != 'sammyjoyce/c23-cli-template'
 
@@ -313,7 +315,7 @@ jobs:
 
   renovate-config:
     name: Validate Renovate Config
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
 
     steps:
       - name: Check out repository
@@ -324,7 +326,7 @@ jobs:
 
   pre-commit:
     name: Run Pre-commit Hooks
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
 
     steps:
       - name: Check out repository
@@ -350,7 +352,7 @@ jobs:
 
   coverage:
     name: Test Coverage
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
 
     steps:
       - name: Check out repository
@@ -376,7 +378,7 @@ jobs:
 
   secrets-scan:
     name: Secrets Scan
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
     permissions:
       contents: read
       security-events: write
@@ -394,7 +396,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
     permissions:
       contents: read
       security-events: write
@@ -432,7 +434,7 @@ jobs:
   release:
     name: Create Release
     needs: [test, lint]
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,10 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: nscloud-ubuntu-24.04-amd64-4x8
+    # Defaults to GitHub-hosted runners for template portability. Set the
+    # CI_LINUX_RUNNER repository or organization variable to opt into Namespace
+    # or another self-hosted Linux runner.
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   cleanup:
     name: "Cleanup Template Files"
-    runs-on: "ubuntu-latest"
+    runs-on: "nscloud-ubuntu-24.04-amd64-4x8"
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -33,7 +33,9 @@ on:
 jobs:
   cleanup:
     name: "Cleanup Template Files"
-    runs-on: "nscloud-ubuntu-24.04-amd64-4x8"
+    # Defaults to GitHub-hosted runners so freshly generated repositories can
+    # run cleanup before they configure any self-hosted capacity.
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"

--- a/.template/TEMPLATE_USAGE.md
+++ b/.template/TEMPLATE_USAGE.md
@@ -29,6 +29,21 @@ Generated repositories have their own history. Use a fork instead if you need to
 
 Run the `Template Cleanup` workflow from the generated repository's Actions tab. It asks for the project name, description, author, GitHub owner, and license, then commits the resulting starter files.
 
+## CI Runner Selection
+
+Generated repositories default to GitHub-hosted runners so the cleanup workflow and first CI run work without self-hosted infrastructure.
+
+To use Namespace or another self-hosted fleet, set these repository or organization variables:
+
+| Variable | Default | Namespace example |
+| --- | --- | --- |
+| `CI_LINUX_RUNNER` | `ubuntu-latest` | `nscloud-ubuntu-24.04-amd64-4x8` |
+| `CI_MACOS_RUNNER` | `macos-latest` | `nscloud-macos-sequoia-arm64-6x14` |
+| `CI_WINDOWS_RUNNER` | `windows-latest` | `nscloud-windows-2022-amd64-4x8` |
+
+The workflows use variable expressions instead of literal custom runner labels, so local `actionlint` can validate the default template workflows without a custom allowlist.
+The Namespace macOS example is ARM64; use the default `macos-latest` runner or add a universal/x64 release job if you need Intel macOS artifacts.
+
 ### Local Interactive Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,18 +151,8 @@ Check the **Actions** tab to see progress.
 
 ### 2. CI Runner Selection
 
-Generated repositories default to GitHub-hosted runners (`ubuntu-latest`, `macos-latest`, `windows-latest`) so the cleanup workflow and first CI run work without extra infrastructure.
-
-To use Namespace or another self-hosted fleet, set these repository or organization variables:
-
-| Variable | Default | Namespace example |
-| --- | --- | --- |
-| `CI_LINUX_RUNNER` | `ubuntu-latest` | `nscloud-ubuntu-24.04-amd64-4x8` |
-| `CI_MACOS_RUNNER` | `macos-latest` | `nscloud-macos-sequoia-arm64-6x14` |
-| `CI_WINDOWS_RUNNER` | `windows-latest` | `nscloud-windows-2022-amd64-4x8` |
-
-The workflows route runner labels through variables, so local `actionlint` can validate the template defaults without a custom runner-label allowlist.
-The Namespace macOS example is ARM64; if you need Intel macOS release artifacts, keep the default GitHub-hosted runner or add an explicit universal/x64 release job.
+Generated repositories default to GitHub-hosted runners so the cleanup workflow and first CI run work without extra infrastructure.
+To opt into Namespace or another self-hosted fleet, configure `CI_LINUX_RUNNER`, `CI_MACOS_RUNNER`, and `CI_WINDOWS_RUNNER` as described in [Using This Template](.template/TEMPLATE_USAGE.md#ci-runner-selection).
 
 ### 3. Add Your Commands
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,22 @@ After creating your repository, run the template cleanup workflow or local setup
 
 Check the **Actions** tab to see progress.
 
-### 2. Add Your Commands
+### 2. CI Runner Selection
+
+Generated repositories default to GitHub-hosted runners (`ubuntu-latest`, `macos-latest`, `windows-latest`) so the cleanup workflow and first CI run work without extra infrastructure.
+
+To use Namespace or another self-hosted fleet, set these repository or organization variables:
+
+| Variable | Default | Namespace example |
+| --- | --- | --- |
+| `CI_LINUX_RUNNER` | `ubuntu-latest` | `nscloud-ubuntu-24.04-amd64-4x8` |
+| `CI_MACOS_RUNNER` | `macos-latest` | `nscloud-macos-sequoia-arm64-6x14` |
+| `CI_WINDOWS_RUNNER` | `windows-latest` | `nscloud-windows-2022-amd64-4x8` |
+
+The workflows route runner labels through variables, so local `actionlint` can validate the template defaults without a custom runner-label allowlist.
+The Namespace macOS example is ARM64; if you need Intel macOS release artifacts, keep the default GitHub-hosted runner or add an explicit universal/x64 release job.
+
+### 3. Add Your Commands
 
 Edit `src/main.c`:
 
@@ -161,11 +176,11 @@ if (strcmp(command, "deploy") == 0) {
 }
 ```
 
-### 3. Update Help Text
+### 4. Update Help Text
 
 Edit `src/cli/help.c` to describe your commands.
 
-### 4. Add Source Files
+### 5. Add Source Files
 
 1. Create your `.c` file in `src/`
 2. Add to `build.zig`:


### PR DESCRIPTION
Move the GitHub Actions workflows off GitHub-hosted runner labels and onto Namespace runner labels. The main CI matrix now separates display OS names from the runner labels so artifact naming and Windows-specific setup conditionals keep their existing behavior while jobs select Namespace capacity.

**Runner Coverage**

The primary CI workflow now uses Namespace Linux, macOS, and Windows runners for the test matrix, and the Linux-only maintenance jobs in CI, Scorecard, and template cleanup use the Namespace Ubuntu runner label.

**Validation**

`git diff --check origin/main...HEAD` passed. `actionlint .github/workflows/ci.yaml .github/workflows/scorecard.yml .github/workflows/template-cleanup.yml` did not pass locally because actionlint does not know the `nscloud-*` custom runner labels and also reports existing shellcheck warnings in `ci.yaml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where and how all CI, release, and security workflows execute; misconfigured runner variables could block builds, though defaults unchanged from GitHub-hosted behavior.
> 
> **Overview**
> CI workflows now pick runners via optional repository/org variables **`CI_LINUX_RUNNER`**, **`CI_MACOS_RUNNER`**, and **`CI_WINDOWS_RUNNER`**, each falling back to GitHub-hosted labels (`ubuntu-latest`, `macos-latest`, `windows-latest`) so new template repos still work out of the box.
> 
> The **test** matrix separates display **`os`** names from the actual **`runner`** label; Windows setup and TUI steps key off **`runner.os`** instead of hard-coded `*-latest` matrix values. Linux-only jobs in **CI**, **Scorecard**, and **template cleanup** use the same Linux variable pattern.
> 
> Small workflow hardening: quoted **`$GITHUB_ENV`** / output appends, grouped vcpkg env writes on Windows, null-safe **`clang-format`** via **`find` + `xargs -0`**, and a quoted binary path for the TUI JSON check.
> 
> **README** and **`.template/TEMPLATE_USAGE.md`** document how to point jobs at Namespace (or other self-hosted) labels without baking custom labels into YAML (keeps **`actionlint`** happy on defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7fd5c5f45acfdf0ef6c4c653143ee657ada046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->