### PR TITLE
docs: Rewrite documentation for accuracy and progressive disclosure

### DIFF
--- a/.template/README.md
+++ b/.template/README.md
@@ -1,71 +1,50 @@
 # Template Files
 
-This directory contains the template variable replacement system used when creating new projects from this template repository.
+This directory holds the variable-replacement system that turns the template into a fresh project. It is removed from generated repositories during cleanup.
 
 ## Contents
 
-- `template-vars.json` - Centralized configuration for all template variables
-- `replacer.sh` - Core replacement engine for automatic variable replacement and transformations
-- `setup.sh` - Interactive or non-interactive setup and cleanup script
-- `TEMPLATE_README.md` - The generated-project README installed during setup
-- `TEMPLATE_USAGE.md` - Comprehensive guide for using this template
-- `TEMPLATE_SUPPORT.md` - Support information for template issues
-- `README.md` - This documentation file
+| File | Purpose |
+| --- | --- |
+| `template-vars.json` | Source of truth for every template variable, its placeholders, and validation |
+| `replacer.sh` | Replacement engine: detects values, applies case transforms, swaps placeholders |
+| `setup.sh` | Interactive or non-interactive setup that runs the replacer and optional cleanup |
+| `TEMPLATE_README.md` | The README installed into the generated project |
+| `TEMPLATE_USAGE.md` | The full "using this template" guide |
+| `TEMPLATE_SUPPORT.md` | Support notes for template (not generated-project) issues |
+| `README.md` | This file |
 
-## Features
+## How replacement works
 
-### Smart Variable Detection
+- **Value detection.** Each variable reads explicit environment values first, then falls back to its configured sources (git metadata, repository name, current year), then to a default.
+- **Case transforms.** `replacer.sh` derives the forms it needs: `snake_case`, `kebab_case`, `pascal_case`, `lower_case`, and `upper_case`.
+- **Validation.** Each variable carries a regex so a bad value fails fast.
+- **Safety.** `--dry-run` previews every change, and excluded paths (`.git`, `.template`, `zig-out`, `.zig-cache`, vendored code) are never touched.
 
-- Reads explicit environment values first
-- Falls back to local Git metadata, repository names, and defaults
-- Falls back to sensible defaults when detection fails
-- Supports multiple data sources per variable
+## For new projects
 
-### Case Transformations
+When you create a project from this template:
 
-- `snake_case`: my_project_name
-- `kebab-case`: my-project-name
-- `PascalCase`: MyProjectName
-- `camelCase`: myProjectName
+1. Run the **Template Cleanup** workflow from the Actions tab, or run setup locally.
+2. Setup installs `TEMPLATE_README.md` as the project README.
+3. Setup runs `replacer.sh` to substitute every variable.
+4. Template-only files are removed when cleanup is requested.
 
-### Validation & Safety
-
-- Regex-based validation ensures correct formatting
-- Dry run mode to preview changes
-- Excludes sensitive directories (.git, node_modules, etc.)
-
-### Flexible Usage
-
-- **Automatic**: Uses detected values
-- **Interactive**: Prompts for each value
-- **Dry Run**: Preview changes without making them
-
-## For New Projects
-
-When you create a new project from this template:
-
-1. Run the `Template Cleanup` workflow from the Actions tab, or run setup locally.
-2. Setup installs the generated-project README.
-3. Setup executes `replacer.sh` to replace all variables.
-4. Template-specific files are removed when cleanup is requested.
-
-If automatic cleanup fails:
+If automatic cleanup did not run:
 
 ```bash
-# Run interactively
+# Interactive
 ./.template/setup.sh
 
-# Or run without prompts and remove template-only files
+# Non-interactive, and remove template-only files
 ./.template/setup.sh --non-interactive --cleanup
 ```
 
-Setup requires `jq`, `sd`, and `zig`. Interactive setup also requires `gum`.
+Setup needs `jq`, `sd`, and `zig`. Interactive setup also needs `gum`.
 
-## For Template Maintainers
+## For template maintainers
 
-### Adding New Variables
-
-Edit `template-vars.json`:
+Add or change variables in `template-vars.json`. Each entry uses this shape:
 
 ```json
 {
@@ -73,7 +52,7 @@ Edit `template-vars.json`:
     "NEW_VAR": {
       "placeholders": ["OLD_TEXT"],
       "description": "What this variable represents",
-      "source": "repository_name",
+      "sources": ["repository_name"],
       "transform": "kebab_case",
       "validation": "^[a-z][a-z0-9-]*$"
     }
@@ -81,21 +60,22 @@ Edit `template-vars.json`:
 }
 ```
 
-### Testing Changes
+`sources` is an ordered list; the first one that resolves wins. Available sources:
+
+| Source | Resolves to |
+| --- | --- |
+| `repository_name` | The repository name (from Git or GitHub) |
+| `repository_description` | The repository description |
+| `repository_owner` | The GitHub owner or organization |
+| `git_user_name` | `git config user.name` |
+| `git_user_email` | `git config user.email` |
+| `current_year` | The current calendar year |
+| `license` | The detected license, where supported |
+
+Preview changes before committing them:
 
 ```bash
-# Test in dry run mode
-./.template/replacer.sh --dry-run
+./.template/replacer.sh --dry-run -v
 ```
 
-### Variable Sources
-
-- `repository_name`: From Git or GitHub
-- `repository_owner`: GitHub username/organization
-- `git_user_name`: From git config
-- `git_user_email`: From git config
-- `current_year`: Current year
-- `license`: Detected from LICENSE where supported
-- `static`: Fixed value in config
-
-This directory keeps template infrastructure separate from project files, making it easy to maintain and update the template without affecting the actual project structure.
+Prefer specific placeholders such as `myapp` or `https://github.com/yourusername/yourproject` over short common words, so replacement never touches unrelated text.

--- a/.template/TEMPLATE_README.md
+++ b/.template/TEMPLATE_README.md
@@ -4,38 +4,33 @@ A ready-to-use C23 TUI + CLI starter.
 
 ## Features
 
-- C23 command-line application skeleton built with Zig 0.16.0.
+- C23 command-line skeleton built with Zig 0.16.0.
 - Human-readable and JSON output modes for automation-friendly commands.
 - Layered configuration from config files, environment, and CLI flags.
-- Live OpenCLI contract from `myapp opencli`, checked against `opencli.json`.
-- Optional ncurses/PDCurses TUI build with windows, menus, dialogs, and progress bars.
-- Optional `tui-menu-lib` static library target for the reusable TUI menu.
-- Small module layout that keeps CLI routing, core state, I/O, TUI, and utilities separate.
-- Zig build steps for build, run, test, terminal-test, check, format, and cleanup.
-- C23 terminal scenario harness for non-interactive CLI contracts and optional Ghostty VT-backed TUI tests.
+- A live OpenCLI contract (`myapp opencli`) checked against `opencli.json`.
+- Optional ncurses/PDCurses TUI with windows, menus, dialogs, and progress bars.
+- Optional `tui-menu-lib` static library exposing the reusable TUI menu.
+- A small module layout that keeps CLI routing, core state, I/O, TUI, and utilities separate.
+- Build, run, test, terminal-test, check, format, and clean steps in `build.zig`.
+- A C23 scenario harness for CLI contracts, plus optional Ghostty VT-backed TUI tests.
 
 ## Requirements
 
 - Zig 0.16.0.
 - A system C toolchain for libc and optional platform libraries.
-- ncurses development headers on Linux/macOS when building with `-Denable-tui=true`.
-- PDCurses on Windows when building with `-Denable-tui=true`.
+- ncurses development headers (Linux/macOS) or PDCurses (Windows) when building with `-Denable-tui=true`.
 - Optional `libghostty-vt` development files for PTY-backed TUI scenario tests.
 
 ## Build
 
 ```bash
-zig build
-zig build -Doptimize=ReleaseSafe
-zig build -Denable-tui=true
-zig build tui-menu-lib
+zig build                          # debug
+zig build -Doptimize=ReleaseSafe   # optimized
+zig build -Denable-tui=true        # with the ncurses TUI
+zig build tui-menu-lib             # the reusable TUI menu static library
 ```
 
-The default binary name is `myapp`. You can override it without editing source:
-
-```bash
-zig build -Dapp-name=myapp
-```
+The binary is named `myapp`; override it without editing source via `-Dapp-name=...`.
 
 ## Run
 
@@ -53,30 +48,20 @@ zig build -Dapp-name=myapp
 Build with TUI support before launching the interactive showcase:
 
 ```bash
-zig build -Denable-tui=true
-./zig-out/bin/myapp menu
+zig build -Denable-tui=true run -- menu
 ```
 
-## Test And Check
+## Test and check
 
 ```bash
-zig build test
-zig build terminal-test
-zig build -Denable-tui=true terminal-test
-zig build check
-zig build fmt-check
+zig build test            # unit tests + CLI contract tests
+zig build terminal-test   # the above, plus PTY/TUI scenarios when available
+zig build check           # fmt-check + tests (the CI gate)
 ```
 
-The Zig tests keep fast build-integrated smoke coverage and verify that
-`myapp opencli` matches `opencli.json`. The terminal scenario tests exercise
-non-interactive CLI contracts through a C23 runner on every host. When built
-with `-Denable-tui=true` and `libghostty-vt` is available, they also drive the
-ncurses menu through a pseudo-terminal.
+`zig build test` verifies that `myapp opencli` still matches `opencli.json`. PTY-backed TUI tests need `libghostty-vt`; they skip cleanly when it is absent, or pass `-Dterminal-backend=ghostty` to require them.
 
-PTY-backed TUI tests skip cleanly when `libghostty-vt` is not installed. Use
-`-Dterminal-backend=ghostty` to require Ghostty VT and fail if it is missing.
-
-## Project Layout
+## Project layout
 
 ```text
 .
@@ -85,67 +70,42 @@ PTY-backed TUI tests skip cleanly when `libghostty-vt` is not installed. Use
 |-- opencli.json
 |-- src/
 |   |-- main.c
-|   |-- cli/
-|   |-- core/
-|   |-- io/
-|   |-- tui/
-|   `-- utils/
+|   |-- cli/      command parsing, help, and the command table
+|   |-- core/     configuration and typed errors
+|   |-- io/       text and JSON output
+|   |-- tui/      ncurses windows, menus, dialogs, progress (opt-in)
+|   `-- utils/    logging, colors, secret zeroing
 |-- test/
-|   |-- cli_contract_runner.c
-|   |-- cli_contract_cases.c
-|   |-- cli_contract_helpers.c
-|   |-- terminal_vt_runner.c
-|   |-- terminal_vt_scenarios.c
-|   `-- terminal_vt_session.c
 |-- docs/
 `-- examples/
 ```
 
-## Add A Command
+## Add a command
 
-Add the handler in a command source file:
+Write a handler with the standard signature:
 
 ```c
 app_error app_cmd_status(const app_config_t *config, int argc, char **argv) {
   (void)argc;
   (void)argv;
-  app_output(config, "status ok", false);
+  app_output("status ok", config, false);
   return APP_SUCCESS;
 }
 ```
 
-Then update:
+Then update `src/cli/commands.c` (metadata and dispatch), regenerate `opencli.json` from `myapp opencli`, and add coverage to `test/cli_contract_cases.c`. See `examples/adding-a-command.md`.
 
-- `src/cli/commands.c` for command metadata and dispatch.
-- `opencli.json` from the live `myapp opencli` output.
-- `test/cli_contract_cases.c` for contract coverage.
-- `test/terminal_vt_scenarios.c` for PTY/TUI behavior when needed.
+## Customize the TUI
 
-## Customize The TUI
-
-The reusable TUI helpers live under `src/tui/`:
-
-- `tui.c` owns ncurses lifecycle, windows, bounded text, and dialogs.
-- `tui_menu.c` and `tui_menu_model.c` own the reusable modal menu.
-- `tui_progress.c` owns progress window rendering.
-- `tui_app.c` wires examples together for the `menu` command.
-
-Keep raw curses calls inside the TUI layer where practical. That keeps command handlers easy to test without a terminal.
+The TUI helpers live under `src/tui/`: `tui.c` owns the ncurses lifecycle, windows, and dialogs; `tui_menu.c` / `tui_menu_model.c` own the reusable modal menu; `tui_progress.c` owns progress rendering; `tui_app.c` wires the `menu` command's showcase. Keep raw curses calls inside this layer so command handlers stay testable without a terminal. See `examples/custom-tui.md`.
 
 ## Configuration
 
-Configuration precedence is:
-
-1. Command-line flags.
-2. Environment variables.
-3. Configuration file.
-4. Defaults.
-
-Default config paths are:
+Precedence is CLI flags > environment variables > config file > defaults. Default config paths:
 
 - `~/.config/myapp/config.json` on Linux/macOS.
 - `%USERPROFILE%\AppData\Local\myapp\config.json` on Windows.
 
 ## License
 
-MIT. Update `LICENSE` if your generated project uses a different license.
+MIT. Update `LICENSE` if your project uses a different license.

--- a/.template/TEMPLATE_SUPPORT.md
+++ b/.template/TEMPLATE_SUPPORT.md
@@ -1,23 +1,28 @@
 # Template Support
 
-For issues with the template itself (not your generated project):
+This page is for problems with the **template itself**, not with a project you generated from it.
 
-- **Check existing issues**: [c23-cli-template/issues](https://github.com/sammyjoyce/c23-cli-template/issues)
-- **Create new issue**: Use the issue templates provided
-- **Your project issues**: Use your own repository's issue tracker
+- **Search existing issues:** [c23-cli-template/issues](https://github.com/sammyjoyce/c23-cli-template/issues)
+- **Open a new issue:** use the provided issue templates.
+- **Problems in your generated project:** use that repository's own issue tracker.
 
-## Quick Fixes
+## Quick fixes
 
-**Template cleanup didn't run?**
+**Cleanup did not run.** Check the **Template Cleanup** run in the Actions tab, then run it locally:
 
-- Check Actions tab for the workflow status
-- Run manually: `.template/setup.sh`
-- Run without prompts: `.template/setup.sh --non-interactive --cleanup`
+```bash
+./.template/setup.sh                              # interactive
+./.template/setup.sh --non-interactive --cleanup  # no prompts
+```
 
-**Placeholders still visible?**
+**Placeholders are still visible.** Setup installs a fresh project README and runs `replacer.sh`, which swaps the template placeholders for your values:
 
-The cleanup script replaces:
+| Placeholder | Becomes |
+| --- | --- |
+| `myapp` (and `yourproject`) | your project's kebab-case name |
+| `https://github.com/yourusername/yourproject` | your GitHub owner and repository |
+| `Your Name` | the configured author name |
+| `you@example.com` | the configured author email |
+| `~/.config/myapp` | `~/.config/<your_project_snake>` |
 
-- `myapp` to your repository name
-- `yourusername` to your GitHub username
-- `sammyjoyce` to your GitHub username
+If some are still present, re-run setup, or preview what would change with `./.template/replacer.sh --dry-run -v`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Initial template: C23 sources under `src/`, Zig 0.16 build system, opt-in ncurses/PDCurses TUI behind `-Denable-tui=true`.
-- Live OpenCLI contract — `myapp opencli` prints the spec, and `zig build test` fails if it drifts from `opencli.json`.
+- Live OpenCLI contract. `myapp opencli` prints the spec, and `zig build test` fails if it drifts from `opencli.json`.
 - Reusable `tui-menu-lib` static library target with installed headers.
 - Three test layers: in-process unit tests (`zig build unit-test`), CLI contract tests, and Ghostty-VT-backed PTY/TUI scenarios.
 - GitHub Actions CI on Linux, macOS, and Windows, plus `clang-tidy`, `cppcheck`, Gitleaks, OpenSSF Scorecard, SBOM generation, and pinned action versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,22 @@
 # Changelog
 
-All notable changes to this template will be documented in this file.
+All notable changes to this template are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
-- Initial template structure with C/Zig build system
-- GitHub Actions CI workflow for automated testing
-- Comprehensive documentation (README, CONTRIBUTING, etc.)
-- Issue and PR templates for better collaboration
-- Code formatting configuration (.clang-format)
-- Example code structure with modular organization
-- Test framework setup
-- Template cleanup script for easy customization
-- Security policy and reporting guidelines
-- Automated dependency management with Dependabot
-- Development container configuration
-- VS Code workspace settings
-
-### Changed
-
-- Nothing yet
-
-### Deprecated
-
-- Nothing yet
-
-### Removed
-
-- Nothing yet
-
-### Fixed
-
-- Nothing yet
-
-### Security
-
-- Nothing yet
-
-## [1.0.0] - 2025-01-27
+## [0.1.0]
 
 ### Added
 
-- Initial release of the C/Zig project template
-- Basic project structure with src/, test/, docs/ directories
-- Build configuration using Zig build system
-- GitHub Actions CI/CD pipeline
-- Community health files (README, LICENSE, CONTRIBUTING)
-- Code formatting and linting setup
-- Example implementations and tests
+- Initial template: C23 sources under `src/`, Zig 0.16 build system, opt-in ncurses/PDCurses TUI behind `-Denable-tui=true`.
+- Live OpenCLI contract — `myapp opencli` prints the spec, and `zig build test` fails if it drifts from `opencli.json`.
+- Reusable `tui-menu-lib` static library target with installed headers.
+- Three test layers: in-process unit tests (`zig build unit-test`), CLI contract tests, and Ghostty-VT-backed PTY/TUI scenarios.
+- GitHub Actions CI on Linux, macOS, and Windows, plus `clang-tidy`, `cppcheck`, Gitleaks, OpenSSF Scorecard, SBOM generation, and pinned action versions.
+- Template cleanup workflow plus `.template/setup.sh` and `replacer.sh` for customizing a generated project.
+- Nix dev shell, devcontainer, pre-commit configuration (clang-format, markdownlint, conventional-commit), and Dependabot.
 
-[Unreleased]: https://github.com/yourusername/yourrepo/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/yourusername/yourrepo/releases/tag/v1.0.0
+[Unreleased]: https://github.com/yourusername/yourproject/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/yourusername/yourproject/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,9 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the maintainer [@sammyjoyce](https://github.com/sammyjoyce) on GitHub.
+For incidents that need GitHub's involvement, you can also use their
+[report abuse](https://github.com/contact/report-abuse) form.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,9 @@ Local pre-commit hooks (install with `pre-commit install`) run clang-format, mar
 
 ## Coding standards
 
-`.clang-format` is the source of truth; `zig build fmt` applies it.
+For C and C++, `.clang-format` is the source of truth — clang-format applies it
+through the pre-commit hook and the CI **Lint and Format** job. For `build.zig`
+and any Zig sources, `zig build fmt` runs the Zig formatter.
 
 Conventions in this codebase:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,317 +1,172 @@
-# Contributing to CLI Application Starter
+# Contributing
 
-Thank you for your interest in contributing to this project! This document provides guidelines and instructions for contributing.
+Thanks for contributing. This page covers how to report an issue, set up locally, and send a PR that passes CI.
 
-## Code of Conduct
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-By participating in this project, you agree to be respectful and constructive in all interactions.
-
-## How to Contribute
-
-### Reporting Issues
-
-Before creating an issue, please:
-
-- Check existing issues to avoid duplicates
-- Use the issue templates when available
-- Include as much relevant information as possible
-
-When reporting bugs, include:
-
-- Your operating system and version
-- Zig version (run `zig version`)
-- Steps to reproduce the issue
-- Expected vs actual behavior
-- Any error messages or logs
-
-### Suggesting Features
-
-Feature requests are welcome! Please:
-
-- Check if the feature has already been requested
-- Explain the use case and why it would be valuable
-- Consider if it aligns with the project's goals
-
-### Pull Requests
-
-1. **Fork the repository** and create your branch from `main`
-2. **Follow the coding style** used throughout the project
-3. **Write tests** for new functionality
-4. **Update documentation** as needed
-5. **Ensure all tests pass** by running `zig build test`
-6. **Format your code** with `clang-format`
-7. **Write clear commit messages** following conventional commits
-
-#### Commit Message Format
-
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-Types:
-
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `test`: Test additions or modifications
-- `chore`: Maintenance tasks
-- `perf`: Performance improvements
-
-Examples:
-
-```
-feat(cli): add new command for file processing
-fix(config): handle missing config file gracefully
-docs(readme): update installation instructions
-```
-
-### Development Setup
-
-1. **Install Zig 0.16.0** (current stable release):
-
-   ```bash
-   # Using zvm (recommended)
-   zvm install 0.16.0
-   zvm use 0.16.0
-
-   # Or download directly
-   # Visit https://ziglang.org/download/
-   ```
-
-2. **Clone your fork**:
-
-   ```bash
-   git clone https://github.com/yourusername/yourproject.git
-   cd yourproject
-   ```
-
-3. **Install platform dependencies**:
-
-   ```bash
-   # macOS
-   brew install ncurses
-
-   # Ubuntu/Debian
-   sudo apt-get install libncurses-dev clang-format clang-tidy
-
-   # Fedora/RHEL
-   sudo dnf install ncurses-devel clang-tools-extra
-
-   # Windows (using vcpkg)
-   git clone https://github.com/Microsoft/vcpkg.git
-   cd vcpkg && bootstrap-vcpkg.bat
-   vcpkg install pdcurses:x64-windows
-   ```
-
-4. **Run local quality checks** (recommended):
-
-   ```bash
-   zig build fmt-check
-   zig build check
-   git diff --check
-   find src test \( -name "*.c" -o -name "*.h" \) -print0 | xargs -0 clang-format --dry-run --Werror
-
-   # Optional documentation lint, available in the Nix dev shell
-   markdownlint "**/*.md" --ignore ".template/**" --ignore ".github/**" --ignore "zig-pkg/**"
-   ```
-
-5. **Alternative: Use the Nix dev shell**:
-
-   ```bash
-   nix develop
-   ```
-
-   The flake provides Zig, C tooling, and markdown lint tooling.
-
-6. **Alternative: Use Devcontainer** (recommended for consistency):
-
-   This project includes a devcontainer configuration for VS Code that provides a consistent development environment.
-   - Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code
-   - Open the project in VS Code
-   - When prompted, choose "Reopen in Container"
-   - The container will automatically install all dependencies
-
-### Understanding the Build System
-
-This project uses Zig as its build system. If you're new to Zig, see our [Zig Primer for C Developers](docs/ZIG_PRIMER.md).
-
-#### Quick Build Commands
+## Quick start
 
 ```bash
-# Build the project (debug mode)
-zig build
+# Fork, clone, branch
+git clone https://github.com/<your-user>/c23-cli-template
+cd c23-cli-template
+git checkout -b your-change
 
-# Build with optimizations
-zig build -Doptimize=ReleaseSafe
+# Build and test
+zig build check                                # fmt-check + tests (the CI gate)
+zig build -Denable-tui=true terminal-test      # if you touched the TUI
 
-# Run the application
-zig build run -- --help
-
-# Run tests
-zig build test
-
-# Check code without building
-zig build check
-
-# Cross-compile for Windows (from Linux/macOS)
-zig build -Dtarget=x86_64-windows
-
-# Install to a custom prefix
-zig build install --prefix ~/.local
+# Format, commit, push
+zig build fmt
+git commit -m "feat(scope): one-line summary"
+git push origin your-change
 ```
 
-#### Build Options
+Open a PR against `main`. CI runs `zig build check` on Linux, macOS, and Windows, plus `clang-tidy` and `cppcheck`.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-Doptimize=` | Build mode: `Debug`, `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall` | `Debug` |
-| `-Dtarget=` | Target triple (e.g., `x86_64-windows`, `aarch64-linux`) | Native |
-| `-Denable-tui=` | Enable TUI support | `false` |
-| `--prefix` | Installation directory | `zig-out` |
+## Reporting issues
 
-#### Adding New Source Files
+Before opening one, search [existing issues](https://github.com/sammyjoyce/c23-cli-template/issues). Use the templates when they apply, and include:
 
-1. Add your C file to the appropriate directory under `src/`
-2. Update `build.zig` to include the new file:
+- your operating system and version,
+- `zig version`,
+- the steps to reproduce,
+- the expected versus actual behavior, and
+- any error output or logs.
 
-   ```zig
-   exe.addCSourceFiles(.{
-       .files = &.{
-           // existing files...
-           "src/your_module/new_file.c",
-       },
-       .flags = &.{ "-std=c23", "-Wall", "-Wextra" },
-   });
-   ```
+## Suggesting features
 
-3. If adding a new module, update the architecture diagram in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+Open an issue describing the use case and how it fits the template's scope. Keep an eye on [docs/CONTRACTS.md](docs/CONTRACTS.md) — the supported seams document what's intentionally in or out.
 
-#### Build Troubleshooting
+## Setting up
 
-**Common Issues:**
+### Install Zig
 
-- **"Unable to find ncurses"**: Install the development package for your OS (see step 3 above)
-- **"C header not found"**: Check that all include paths are added in `build.zig`
-- **Cache issues**: Run `rm -rf zig-cache zig-out` and rebuild
-- **Windows DLL issues**: Ensure vcpkg bin directory is in PATH
-
-For more details, see the [Architecture Overview](docs/ARCHITECTURE.md).
-
-### Testing
-
-#### Running Tests
+Use [zvm](https://github.com/tristanisham/zvm) to install the pinned 0.16.0:
 
 ```bash
-# Run fast C23 CLI contract tests
-zig build test
-
-# Run end-to-end CLI terminal scenarios
-zig build terminal-test
-
-# Run terminal scenarios against a TUI-enabled build
-zig build -Denable-tui=true terminal-test
-
-# Run tests with different optimization levels
-zig build test -Doptimize=Debug
-zig build test -Doptimize=ReleaseSafe
-zig build test -Doptimize=ReleaseFast
+zvm install 0.16.0 && zvm use 0.16.0
 ```
 
-#### Writing Tests
+### Platform dependencies
 
-- Put fast build-integrated smoke and CLI contract coverage in `test/cli_contract_runner.c`
-- Put PTY-backed TUI and end-to-end terminal behavior in `test/terminal_vt_scenarios.c`
-- Prefer JSON-field assertions for automation-facing output
-- Ensure all existing tests pass
-- Test on multiple platforms if possible
-- Test error conditions and edge cases
+Only needed for `-Denable-tui=true` builds. (The default build links only libc.)
 
-See [docs/TESTING.md](docs/TESTING.md) for the terminal harness and key notation.
+| Platform | Install |
+| --- | --- |
+| macOS | `brew install ncurses` |
+| Ubuntu / Debian | `sudo apt-get install libncurses-dev clang-format clang-tidy` |
+| Fedora / RHEL | `sudo dnf install ncurses-devel clang-tools-extra` |
+| Windows | `vcpkg install pdcurses:x64-windows` |
 
-### Documentation
+### Alternative: Nix or devcontainer
 
-- Update README.md for user-facing changes
-- Add inline comments for complex logic
-- Keep examples up to date
+```bash
+nix develop                # Zig, C toolchain, libghostty-vt, markdownlint
+```
 
-## Coding Standards
+The repository also ships a devcontainer (open in VS Code, choose **Reopen in Container**) with the same dependencies pre-installed.
 
-### C Code Style
+## Build and test
 
-- Use 2 spaces for indentation
-- Opening braces on same line for functions
-- Use descriptive variable names
-- Add comments for complex logic
-- Keep functions focused and small
-- Follow the .clang-format configuration
+For every `-D` option and step — and why Zig is the build system — see [docs/ZIG_PRIMER.md](docs/ZIG_PRIMER.md). The day-to-day commands:
 
-Example:
+```bash
+zig build                                # debug build
+zig build -Doptimize=ReleaseSafe         # optimized
+zig build run -- hello Alice             # build + run with arguments
+zig build test                           # unit tests + CLI contract tests
+zig build terminal-test                  # the above + PTY/TUI scenarios when available
+zig build check                          # fmt-check + tests (the CI gate)
+zig build fmt                            # apply formatting
+zig build clean                          # remove zig-out + .zig-cache
+```
+
+Cross-compile with `-Dtarget=x86_64-windows` (or similar). The test layers and how to add to each are in [docs/TESTING.md](docs/TESTING.md).
+
+### Adding a source file
+
+Append the path to `base_sources` in `build.zig` (TUI-only files belong in `tui_sources`). The walkthrough is in [docs/ZIG_PRIMER.md#adding-a-c-file](docs/ZIG_PRIMER.md#adding-a-c-file).
+
+### Adding a command, or a TUI screen
+
+[examples/adding-a-command.md](examples/adding-a-command.md) is the full five-step flow (handler, command table, `opencli.json`, contract test, build). For interactive UIs, [examples/custom-tui.md](examples/custom-tui.md).
+
+## Pull requests
+
+1. Branch from `main`.
+2. Run `zig build check`.
+3. Use [Conventional Commits](https://www.conventionalcommits.org/) — a pre-commit hook validates the format:
+
+   ```
+   <type>(<scope>): <subject>
+   ```
+
+   Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `style`.
+
+   ```
+   feat(cli): add greet command
+   fix(config): handle a missing config file gracefully
+   docs(testing): document the unit-test step
+   ```
+
+4. Keep PRs focused. Update documentation when behavior changes (commands, flags, exit codes, the OpenCLI contract).
+
+Local pre-commit hooks (install with `pre-commit install`) run clang-format, markdownlint, and the conventional-commit validator. CI runs `zig build check` on three platforms plus `clang-tidy` and `cppcheck`.
+
+## Coding standards
+
+`.clang-format` is the source of truth — `zig build fmt` applies it.
+
+Conventions in this codebase:
+
+- Public APIs use the `app_` / `tui_` prefixes (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)).
+- Functions return `app_error` for typed failures; check return values and free on every path.
+- Buffers that held sensitive data go through `app_secret_zero()` before being freed.
+- Early-return on errors; keep the happy path flat.
 
 ```c
-app_error process_input(const char* input, size_t len) {
-  // Validate input parameters
+app_error process_input(const char *input, size_t len) {
   if (!input || len == 0) {
     return APP_ERROR_INVALID_ARG;
   }
 
-  // Process the input
-  app_buffer_t buffer = {0};
-  app_error err = process_data(input, len, &buffer);
-
-  if (err != APP_SUCCESS) {
-    free(buffer.data);
-    return err;
+  char *scratch = malloc(len);
+  if (!scratch) {
+    return APP_ERROR_MEMORY;
   }
 
-  // Clean up
-  free(buffer.data);
-  return APP_SUCCESS;
+  app_error err = APP_SUCCESS;
+  // ... work ...
+
+  app_secret_zero(scratch, len);
+  free(scratch);
+  return err;
 }
 ```
 
-### Error Handling
+## Where things live
 
-- Always check return values
-- Provide meaningful error messages
-- Clean up resources on error paths
-- Use early returns for error conditions
-
-### Memory Management
-
-- Free all allocated memory
-- Use `app_secret_zero()` before freeing buffers that held sensitive data
-- Check for allocation failures
-- Avoid memory leaks in error paths
-
-## Project Structure
-
-```
-cli-starter/
-├── src/              # Core implementation
-│   ├── main.c       # Entry point
-│   ├── core/        # Core functionality
-│   ├── cli/         # CLI interface
-│   ├── io/          # Input/Output
-│   └── utils/       # Utilities
-├── test/            # Test suite
-├── build.zig        # Build configuration
-└── build.zig.zon    # Build dependencies
+```text
+.
+├── src/
+│   ├── main.c
+│   ├── cli/        command parsing, help, command table
+│   ├── core/       configuration, typed errors
+│   ├── io/         text and JSON output
+│   ├── tui/        ncurses windows, menus, progress (opt-in)
+│   └── utils/      logging, colors, secret zeroing
+├── test/           unit tests + CLI contract + PTY/TUI scenarios
+├── build.zig
+├── opencli.json    the CLI contract
+└── docs/
 ```
 
-## Getting Help
+## Getting help
 
-- Check the [documentation](README.md)
-- Look through existing issues
-- Ask questions in issues with the "question" label
+- [docs/](docs/) — architecture, contracts, testing, Zig primer
+- [Existing issues](https://github.com/sammyjoyce/c23-cli-template/issues)
 
 ## License
 
-By contributing to this project, you agree that your contributions will be licensed under the MIT License.
+By contributing you agree your contributions are licensed under the MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Before opening one, search [existing issues](https://github.com/sammyjoyce/c23-c
 
 ## Suggesting features
 
-Open an issue describing the use case and how it fits the template's scope. Keep an eye on [docs/CONTRACTS.md](docs/CONTRACTS.md) — the supported seams document what's intentionally in or out.
+Open an issue describing the use case and how it fits the template's scope. Keep an eye on [docs/CONTRACTS.md](docs/CONTRACTS.md); the supported seams document what's intentionally in or out.
 
 ## Setting up
 
@@ -69,7 +69,7 @@ The repository also ships a devcontainer (open in VS Code, choose **Reopen in Co
 
 ## Build and test
 
-For every `-D` option and step — and why Zig is the build system — see [docs/ZIG_PRIMER.md](docs/ZIG_PRIMER.md). The day-to-day commands:
+For every `-D` option and step (and why Zig is the build system), see [docs/ZIG_PRIMER.md](docs/ZIG_PRIMER.md). The day-to-day commands:
 
 ```bash
 zig build                                # debug build
@@ -96,7 +96,7 @@ Append the path to `base_sources` in `build.zig` (TUI-only files belong in `tui_
 
 1. Branch from `main`.
 2. Run `zig build check`.
-3. Use [Conventional Commits](https://www.conventionalcommits.org/) — a pre-commit hook validates the format:
+3. Use [Conventional Commits](https://www.conventionalcommits.org/); a pre-commit hook validates the format:
 
    ```
    <type>(<scope>): <subject>
@@ -116,7 +116,7 @@ Local pre-commit hooks (install with `pre-commit install`) run clang-format, mar
 
 ## Coding standards
 
-`.clang-format` is the source of truth — `zig build fmt` applies it.
+`.clang-format` is the source of truth; `zig build fmt` applies it.
 
 Conventions in this codebase:
 
@@ -164,7 +164,7 @@ app_error process_input(const char *input, size_t len) {
 
 ## Getting help
 
-- [docs/](docs/) — architecture, contracts, testing, Zig primer
+- [docs/](docs/): architecture, contracts, testing, Zig primer
 - [Existing issues](https://github.com/sammyjoyce/c23-cli-template/issues)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/sammyjoyce/c23-cli-template/ci.yaml?style=for-the-badge&label=Build)](https://github.com/sammyjoyce/c23-cli-template/actions/workflows/ci.yaml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/c23-cli-template?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/c23-cli-template)
 
-A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this template**, run the cleanup script, and you have a cross-compiling C project with argument parsing, an optional ncurses TUI, end-to-end tests, and a hardened GitHub Actions pipeline.
+A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this
+template**, run the cleanup script, and you have a cross-compiling C project with
+argument parsing, an optional ncurses TUI, end-to-end tests, and a hardened GitHub
+Actions pipeline.
 
 [Use this template](https://github.com/sammyjoyce/c23-cli-template/generate) • [View Demo](https://github.com/sammyjoyce/c23-cli-template) • [Report Bug](https://github.com/sammyjoyce/c23-cli-template/issues)
 
@@ -54,8 +57,8 @@ zig build -Doptimize=ReleaseSafe
 # Build with the optional ncurses/PDCurses TUI
 zig build -Doptimize=ReleaseSafe -Denable-tui=true
 
-# Run
-./zig-out/bin/YOUR-REPO --help
+# Run (the default binary is named `myapp`; override with `-Dapp-name=`)
+./zig-out/bin/myapp --help
 ```
 
 ## Example Commands
@@ -100,27 +103,7 @@ $ zig build -Denable-tui=true run -- menu
 
 ## Project Layout
 
-```text
-your-cli/
-├── src/
-│   ├── main.c              # Entry point
-│   ├── core/               # Core functionality
-│   │   ├── config.c/h      # Configuration
-│   │   ├── error.c/h       # Error handling
-│   │   └── types.h         # Type definitions
-│   ├── cli/                # CLI interface
-│   │   ├── args.c/h        # Argument parsing
-│   │   └── help.c/h        # Help text
-│   ├── io/                 # Input/Output
-│   ├── tui/                # ncurses windows, menus, dialogs, progress bars
-│   └── utils/              # Utilities
-├── test/                   # C23 CLI tests + Ghostty VT terminal scenarios
-│   ├── cli_contract_runner.c # C23 CLI contract tests
-│   ├── cli_contract_helpers.c # Shared C integration-test helpers
-│   └── terminal_vt_*       # C PTY/TUI scenario harness
-├── build.zig               # Build config
-└── opencli.json            # CLI specification
-```
+See [docs/ARCHITECTURE.md#module-map](docs/ARCHITECTURE.md#module-map) for what each directory under `src/` owns, plus the representative public functions in each module.
 
 ## Customize It
 
@@ -141,33 +124,17 @@ Check the **Actions** tab to see progress.
 Generated repositories default to GitHub-hosted runners so the cleanup workflow and first CI run work without extra infrastructure.
 To opt into Namespace or another self-hosted fleet, configure `CI_LINUX_RUNNER`, `CI_MACOS_RUNNER`, and `CI_WINDOWS_RUNNER` as described in [Using This Template](.template/TEMPLATE_USAGE.md#ci-runner-selection).
 
-### 3. Add your commands
+### 3. Add a command
 
-Edit `src/main.c`:
+Commands are table-driven. Write a handler, register it in `src/cli/commands.c`,
+regenerate `opencli.json`, add a contract test, and add the new file to
+`base_sources` in `build.zig`. The full five-step flow is in
+[examples/adding-a-command.md](examples/adding-a-command.md).
 
-```c
-if (strcmp(command, "deploy") == 0) {
-    printf("Deploying application...\n");
-    // Your deployment logic
-    return APP_SUCCESS;
-}
-```
+Help text and the OpenCLI contract update automatically from the command table;
+you do not edit `help.c` by hand.
 
-### 4. Update help text
-
-Edit `src/cli/help.c` to describe your commands.
-
-### 5. Add source files
-
-1. Create your `.c` file in `src/`
-2. Add to `build.zig`:
-
-```zig
-const c_sources = [_][]const u8{
-    // ... existing files ...
-    "src/features/deploy.c",  // Your new file
-};
-```
+For TUI screens, see [examples/custom-tui.md](examples/custom-tui.md).
 
 ## Develop
 
@@ -193,22 +160,23 @@ This template provides several tools to enhance your development experience:
 
 ```bash
 # Build
-zig build                    # Debug build
-zig build -Doptimize=ReleaseSafe  # Release build
-zig build -Denable-tui=true  # Build with the TUI showcase
-zig build tui-menu-lib       # Build reusable TUI menu static library
+zig build                                  # Debug build
+zig build -Doptimize=ReleaseSafe           # Release build
+zig build -Denable-tui=true                # Build with the ncurses/PDCurses TUI
+zig build tui-menu-lib                     # Build the reusable TUI menu static library
 
 # Test
-zig build test              # Run fast C23 CLI contract tests
-zig build terminal-test     # Run terminal scenarios with the selected backend
-zig build -Denable-tui=true terminal-test  # Run TUI scenarios through Ghostty VT when available
-zig build -Dterminal-backend=ghostty terminal-test  # Require the C Ghostty VT test backend
-
-# Clean
-zig build clean             # Remove build artifacts
+zig build unit-test                        # In-process unit tests
+zig build test                             # Unit tests + CLI contract tests
+zig build terminal-test                    # The above + PTY/TUI scenarios when available
+zig build -Denable-tui=true terminal-test  # Run PTY/TUI scenarios against the TUI build
+zig build check                            # fmt-check + tests (the CI gate)
 
 # Format
-zig fmt build.zig          # Format build file
+zig build fmt                              # Format build.zig, src, test
+
+# Clean
+zig build clean                            # Remove zig-out and .zig-cache
 ```
 
 ### Configuration
@@ -232,7 +200,7 @@ The template wires up far more than the starter code. The full inventory:
 - **Modern C23** - Latest C standard through Zig's bundled C toolchain
 - **Zig Build System** - Fast, reliable builds with cross-compilation
 - **Minimal Dependencies** - Zig and libc by default; curses only for TUI builds
-- **Dynamic Binary Naming** - Extracts binary name from build.zig.zon
+- **Configurable binary name** - Set via `-Dapp-name=` (default `myapp`)
 
 ### CLI and TUI
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/sammyjoyce/c23-cli-template/ci.yaml?style=for-the-badge&label=Build)](https://github.com/sammyjoyce/c23-cli-template/actions/workflows/ci.yaml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/c23-cli-template?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/c23-cli-template)
 
-A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this template**, run the cleanup script, and you have a cross-compiling C project with argument parsing, an optional ncurses TUI, end-to-end tests, and a hardened GitHub Actions pipeline — ready to grow into your app.
+A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this template**, run the cleanup script, and you have a cross-compiling C project with argument parsing, an optional ncurses TUI, end-to-end tests, and a hardened GitHub Actions pipeline.
 
 [Use this template](https://github.com/sammyjoyce/c23-cli-template/generate) • [View Demo](https://github.com/sammyjoyce/c23-cli-template) • [Report Bug](https://github.com/sammyjoyce/c23-cli-template/issues)
 
@@ -266,7 +266,7 @@ The template wires up far more than the starter code. The full inventory:
 - **Devcontainer Support** - Consistent development environments
 - **Comprehensive Documentation** - Detailed guides and examples
 
-## Why This Stack?
+## Why this stack?
 
 - **C23** - Latest features: `typeof`, `_BitInt`, better type safety
 - **Zig Build** - Superior to Make/CMake, built-in cross-compilation
@@ -302,7 +302,7 @@ Start with [**Using This Template**](/.template/TEMPLATE_USAGE.md) for the full 
 
 ## Getting Help
 
-### Template Issues
+### Template issues
 
 For problems with the template itself:
 
@@ -310,7 +310,7 @@ For problems with the template itself:
 - Create a new issue
 - Read [template support](/.template/TEMPLATE_SUPPORT.md)
 
-### Your Project Issues
+### Your project issues
 
 For issues with your generated project:
 
@@ -318,7 +318,7 @@ For issues with your generated project:
 - Check Zig [documentation](https://ziglang.org/documentation/)
 - See C23 [reference](https://en.cppreference.com/w/c/23)
 
-## Projects Using This Template
+## Projects using this template
 
 > Using this template? [Add your project!](https://github.com/sammyjoyce/c23-cli-template/edit/main/README.md)
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ zig build -Denable-tui=true terminal-test  # Run PTY/TUI scenarios against the T
 zig build check                            # fmt-check + tests (the CI gate)
 
 # Format
-zig build fmt                              # Format build.zig, src, test
+zig build fmt                              # Format build.zig (Zig formatter; C uses clang-format via pre-commit + CI)
 
 # Clean
 zig build clean                            # Remove zig-out and .zig-cache

--- a/README.md
+++ b/README.md
@@ -7,50 +7,32 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/sammyjoyce/c23-cli-template/ci.yaml?style=for-the-badge&label=Build)](https://github.com/sammyjoyce/c23-cli-template/actions/workflows/ci.yaml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/c23-cli-template?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/c23-cli-template)
 
-## A ready-to-use C23 starter for command-line tools and terminal UIs
+A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this template**, run the cleanup script, and you have a cross-compiling C project with argument parsing, an optional ncurses TUI, end-to-end tests, and a hardened GitHub Actions pipeline — ready to grow into your app.
 
 [Use this template](https://github.com/sammyjoyce/c23-cli-template/generate) • [View Demo](https://github.com/sammyjoyce/c23-cli-template) • [Report Bug](https://github.com/sammyjoyce/c23-cli-template/issues)
 
 ---
 
-## ✨ Features
+## Highlights
 
-- 🚀 **Modern C23** - Latest C standard through Zig's bundled C toolchain
-- ⚡ **Zig Build System** - Fast, reliable builds with cross-compilation
-- 🏗️ **Well-Structured** - Organized project layout ready for growth
-- 🧪 **Testing Included** - C23 CLI contract tests plus PTY terminal scenario tests for CLI/TUI flows
-- 🎨 **Smart CLI** - Colored output, help text, argument parsing
-- 🖼️ **TUI Support** - ncurses/PDCurses integration for interactive terminal UIs
-- 🔧 **Configuration** - Layered config system (file → env → args)
-- 📦 **Minimal Dependencies** - Zig and libc by default; curses only for TUI builds
-- 🤖 **CI/CD Ready** - GitHub Actions workflow included
-- ⚡ **Caching** - Speeds up builds by caching Zig dependencies and build artifacts
-- 🔒 **Release Gating** - Ensures releases only happen on tags in main branch
-- 🛡️ **Security Scanning** - Gitleaks, OpenSSF Scorecard, and SBOM generation
-- 📦 **Artifact Management** - Unique artifact naming to avoid collisions
-- 🏷️ **Version Pinning** - Pinned GitHub Actions versions for reproducibility
-- 🚫 **Concurrency Control** - Cancels redundant CI runs on same branch
-- 📊 **Dynamic Binary Naming** - Extracts binary name from build.zig.zon
-- 🧹 **Template Cleanup** - Scripted cleanup of template-specific files and placeholders
-- 📚 **OpenCLI Compliant** - Standardized CLI behavior
-- 🔎 **Live CLI Contract** - `myapp opencli` prints the checked-in OpenCLI spec
-- 🧩 **Reusable TUI Menu** - Optional `tui-menu-lib` target for downstream C apps
-- 🔄 **Dependency Updates** - Automated updates with Dependabot/Renovate
-- 📝 **Markdown Linting** - Documentation checks in local tooling and CI
-- 🐳 **Devcontainer Support** - Consistent development environments
-- 📋 **Comprehensive Documentation** - Detailed guides and examples
+- **Modern C23, no compiler wrangling** - The latest C standard through Zig's bundled toolchain.
+- **CLI and TUI in one** - Argument parsing and colored output, plus an optional ncurses/PDCurses interface (`-Denable-tui=true`).
+- **Fast, cross-compiling builds** - The Zig build system replaces Make/CMake and targets other platforms out of the box.
+- **Tested end to end** - C23 CLI contract tests plus PTY-driven terminal scenarios that exercise real CLI/TUI behavior.
+- **Production CI/CD included** - GitHub Actions with security scanning, release gating, SBOMs, and pinned action versions.
+- **OpenCLI compliant** - A checked-in CLI contract your tool can print on demand with `myapp opencli`.
 
-## 🎯 Quick Start
+## Quick Start
 
-### Create Your Project
+### Create your project
 
-### Option 1: GitHub UI
+#### Option 1: GitHub UI
 
 1. Click ["Use this template"](https://github.com/sammyjoyce/c23-cli-template/generate)
 2. Name your repository
 3. Click "Create repository"
 
-### Option 2: GitHub CLI
+#### Option 2: GitHub CLI
 
 ```bash
 gh repo create my-cli \
@@ -59,7 +41,7 @@ gh repo create my-cli \
   --clone
 ```
 
-### Build & Run
+### Build and run
 
 ```bash
 # Clone your new repo
@@ -76,35 +58,9 @@ zig build -Doptimize=ReleaseSafe -Denable-tui=true
 ./zig-out/bin/YOUR-REPO --help
 ```
 
-## 📖 What's Included
+## Example Commands
 
-### Project Structure
-
-```text
-your-cli/
-├── src/
-│   ├── main.c              # Entry point
-│   ├── core/               # Core functionality
-│   │   ├── config.c/h      # Configuration
-│   │   ├── error.c/h       # Error handling
-│   │   └── types.h         # Type definitions
-│   ├── cli/                # CLI interface
-│   │   ├── args.c/h        # Argument parsing
-│   │   └── help.c/h        # Help text
-│   ├── io/                 # Input/Output
-│   ├── tui/                # ncurses windows, menus, dialogs, progress bars
-│   └── utils/              # Utilities
-├── test/                   # C23 CLI tests + Ghostty VT terminal scenarios
-│   ├── cli_contract_runner.c # C23 CLI contract tests
-│   ├── cli_contract_helpers.c # Shared C integration-test helpers
-│   └── terminal_vt_*       # C PTY/TUI scenario harness
-├── build.zig               # Build config
-└── opencli.json            # CLI specification
-```
-
-### Example Commands
-
-The template includes working examples:
+The template ships with working commands so you can confirm the build immediately:
 
 ```bash
 # Greeting command
@@ -142,26 +98,50 @@ $ zig build -Denable-tui=true run -- menu
 # Opens ncurses menus, dialogs, panels, and progress bars
 ```
 
-## 🛠️ Customization Guide
+## Project Layout
 
-### 1. After Creating Your Repo
+```text
+your-cli/
+├── src/
+│   ├── main.c              # Entry point
+│   ├── core/               # Core functionality
+│   │   ├── config.c/h      # Configuration
+│   │   ├── error.c/h       # Error handling
+│   │   └── types.h         # Type definitions
+│   ├── cli/                # CLI interface
+│   │   ├── args.c/h        # Argument parsing
+│   │   └── help.c/h        # Help text
+│   ├── io/                 # Input/Output
+│   ├── tui/                # ncurses windows, menus, dialogs, progress bars
+│   └── utils/              # Utilities
+├── test/                   # C23 CLI tests + Ghostty VT terminal scenarios
+│   ├── cli_contract_runner.c # C23 CLI contract tests
+│   ├── cli_contract_helpers.c # Shared C integration-test helpers
+│   └── terminal_vt_*       # C PTY/TUI scenario harness
+├── build.zig               # Build config
+└── opencli.json            # CLI specification
+```
 
-After creating your repository, run the template cleanup workflow or local setup script to:
+## Customize It
 
-- ✅ Replaces `myapp` with your project name
-- ✅ Updates all references and metadata
-- ✅ Preserves template structure
-- ✅ Removes template-specific files
-- ✅ Commit the changes
+### 1. After creating your repo
+
+Run the template cleanup workflow or local setup script. It will:
+
+- Replace `myapp` with your project name
+- Update all references and metadata
+- Preserve the template structure
+- Remove template-specific files
+- Commit the changes
 
 Check the **Actions** tab to see progress.
 
-### 2. CI Runner Selection
+### 2. CI runner selection
 
 Generated repositories default to GitHub-hosted runners so the cleanup workflow and first CI run work without extra infrastructure.
 To opt into Namespace or another self-hosted fleet, configure `CI_LINUX_RUNNER`, `CI_MACOS_RUNNER`, and `CI_WINDOWS_RUNNER` as described in [Using This Template](.template/TEMPLATE_USAGE.md#ci-runner-selection).
 
-### 3. Add Your Commands
+### 3. Add your commands
 
 Edit `src/main.c`:
 
@@ -173,11 +153,11 @@ if (strcmp(command, "deploy") == 0) {
 }
 ```
 
-### 4. Update Help Text
+### 4. Update help text
 
 Edit `src/cli/help.c` to describe your commands.
 
-### 5. Add Source Files
+### 5. Add source files
 
 1. Create your `.c` file in `src/`
 2. Add to `build.zig`:
@@ -189,7 +169,7 @@ const c_sources = [_][]const u8{
 };
 ```
 
-## 🧪 Development
+## Develop
 
 ### Prerequisites
 
@@ -201,7 +181,7 @@ const c_sources = [_][]const u8{
   - Fedora: `sudo dnf install ncurses-devel`
 - **[libghostty-vt](https://libghostty.tip.ghostty.org/index.html) tip/development API** - Optional outside Nix; enables the C Ghostty VT backend for PTY-backed terminal tests
 
-### Development Environment
+### Development environment
 
 This template provides several tools to enhance your development experience:
 
@@ -243,46 +223,84 @@ Your app supports config from multiple sources:
 Config files are flat JSON objects with boolean keys for `debug`, `quiet`,
 `verbose`, `no_color`, `json_output`, and `plain_output`.
 
-## 📚 Documentation
+## Everything Included
 
-### Getting Started
+The template wires up far more than the starter code. The full inventory:
 
-- 📖 [**Using This Template**](/.template/TEMPLATE_USAGE.md) - Detailed setup guide
-- 🚀 [**Quick Start Guide**](#-quick-start) - Get up and running quickly
-- 🔧 [**Prerequisites**](#prerequisites) - Platform-specific requirements
+### Language and build
 
-### Developer Resources
+- **Modern C23** - Latest C standard through Zig's bundled C toolchain
+- **Zig Build System** - Fast, reliable builds with cross-compilation
+- **Minimal Dependencies** - Zig and libc by default; curses only for TUI builds
+- **Dynamic Binary Naming** - Extracts binary name from build.zig.zon
 
-- 🏗️ [**Architecture Overview**](docs/ARCHITECTURE.md) - System design and module structure
-- 📜 [**Public Contracts**](docs/CONTRACTS.md) - Supported CLI and TUI seams
-- ⚡ [**Zig Primer for C Developers**](docs/ZIG_PRIMER.md) - Understanding the build system
-- 🧪 [**Testing CLI And TUI Behavior**](docs/TESTING.md) - End-to-end terminal scenario tests
-- 🤝 [**Contributing Guide**](CONTRIBUTING.md) - How to contribute to the project
-- 🧪 [**Advanced Usage Examples**](examples/advanced-usage.md) - Piping, scripting, and integration
+### CLI and TUI
 
-### Examples & Demos
+- **Smart CLI** - Colored output, help text, argument parsing
+- **TUI Support** - ncurses/PDCurses integration for interactive terminal UIs
+- **Reusable TUI Menu** - Optional `tui-menu-lib` target for downstream C apps
+- **Configuration** - Layered config system (file → env → args)
+- **OpenCLI Compliant** - Standardized CLI behavior
+- **Live CLI Contract** - `myapp opencli` prints the checked-in OpenCLI spec
 
-- 📝 [**Adding Commands**](examples/adding-a-command.md) - Extend the CLI
-- 🎨 [**Custom TUI Components**](examples/custom-tui.md) - Build interactive interfaces
-- ⚙️ [**Configuration Guide**](examples/config.json) - Config file examples
+### Testing and quality
 
-- 🎬 [**Demo Gallery**](docs/demos/README.md) - Animated demonstrations
+- **Testing Included** - C23 CLI contract tests plus PTY terminal scenario tests for CLI/TUI flows
+- **Markdown Linting** - Documentation checks in local tooling and CI
 
-### Project Information
+### CI/CD and releases
 
-- 🛡️ [**Security Policy**](SECURITY.md) - Reporting vulnerabilities
-- 📋 [**Code of Conduct**](CODE_OF_CONDUCT.md) - Community guidelines
-- 📝 [**Changelog**](CHANGELOG.md) - Version history
-- 📜 [**License**](LICENSE) - MIT License
+- **CI/CD Ready** - GitHub Actions workflow included
+- **Caching** - Speeds up builds by caching Zig dependencies and build artifacts
+- **Concurrency Control** - Cancels redundant CI runs on same branch
+- **Release Gating** - Ensures releases only happen on tags in main branch
+- **Artifact Management** - Unique artifact naming to avoid collisions
+- **Version Pinning** - Pinned GitHub Actions versions for reproducibility
+- **Security Scanning** - Gitleaks, OpenSSF Scorecard, and SBOM generation
+- **Dependency Updates** - Automated updates with Dependabot/Renovate
 
-## 🤔 Why This Stack?
+### Project and developer experience
+
+- **Well-Structured** - Organized project layout ready for growth
+- **Template Cleanup** - Scripted cleanup of template-specific files and placeholders
+- **Devcontainer Support** - Consistent development environments
+- **Comprehensive Documentation** - Detailed guides and examples
+
+## Why This Stack?
 
 - **C23** - Latest features: `typeof`, `_BitInt`, better type safety
 - **Zig Build** - Superior to Make/CMake, built-in cross-compilation
 - **ncurses/PDCurses** - Proven terminal UI primitives with a small wrapper API
 - **Minimal Dependencies** - Zig and libc by default, with curses behind `-Denable-tui=true`
 
-## 🆘 Getting Help
+## Documentation
+
+Start with [**Using This Template**](/.template/TEMPLATE_USAGE.md) for the full setup guide.
+
+### Developer resources
+
+- [**Architecture Overview**](docs/ARCHITECTURE.md) - System design and module structure
+- [**Public Contracts**](docs/CONTRACTS.md) - Supported CLI and TUI seams
+- [**Zig Primer for C Developers**](docs/ZIG_PRIMER.md) - Understanding the build system
+- [**Testing CLI And TUI Behavior**](docs/TESTING.md) - End-to-end terminal scenario tests
+- [**Contributing Guide**](CONTRIBUTING.md) - How to contribute to the project
+- [**Advanced Usage Examples**](examples/advanced-usage.md) - Piping, scripting, and integration
+
+### Examples and demos
+
+- [**Adding Commands**](examples/adding-a-command.md) - Extend the CLI
+- [**Custom TUI Components**](examples/custom-tui.md) - Build interactive interfaces
+- [**Configuration Guide**](examples/config.json) - Config file examples
+- [**Demo Gallery**](docs/demos/README.md) - Animated demonstrations
+
+### Project information
+
+- [**Security Policy**](SECURITY.md) - Reporting vulnerabilities
+- [**Code of Conduct**](CODE_OF_CONDUCT.md) - Community guidelines
+- [**Changelog**](CHANGELOG.md) - Version history
+- [**License**](LICENSE) - MIT License
+
+## Getting Help
 
 ### Template Issues
 
@@ -300,14 +318,14 @@ For issues with your generated project:
 - Check Zig [documentation](https://ziglang.org/documentation/)
 - See C23 [reference](https://en.cppreference.com/w/c/23)
 
-## 🌟 Projects Using This Template
+## Projects Using This Template
 
 > Using this template? [Add your project!](https://github.com/sammyjoyce/c23-cli-template/edit/main/README.md)
 
 - [Example CLI](https://github.com/example/cli) - Description
 - Your project here!
 
-## 📄 License
+## License
 
 This template is MIT licensed. See [LICENSE](LICENSE) for details.
 
@@ -319,4 +337,4 @@ When you use this template, you can choose any license for your project.
 
 [![Use this template](https://img.shields.io/badge/Use%20this-template-success?style=for-the-badge&logo=github)](https://github.com/sammyjoyce/c23-cli-template/generate)
 
-Made with ❤️ by the open source community
+Made by the open source community

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Actions pipeline.
 - **Modern C23, no compiler wrangling** - The latest C standard through Zig's bundled toolchain.
 - **CLI and TUI in one** - Argument parsing and colored output, plus an optional ncurses/PDCurses interface (`-Denable-tui=true`).
 - **Fast, cross-compiling builds** - The Zig build system replaces Make/CMake and targets other platforms out of the box.
-- **Tested end to end** - C23 CLI contract tests plus PTY-driven terminal scenarios that exercise real CLI/TUI behavior.
+- **Tested end to end** - Three test layers: in-process unit tests, C23 CLI contract tests, and PTY-driven terminal scenarios for real CLI/TUI behavior.
 - **Production CI/CD included** - GitHub Actions with security scanning, release gating, SBOMs, and pinned action versions.
 - **OpenCLI compliant** - A checked-in CLI contract your tool can print on demand with `myapp opencli`.
 
@@ -213,7 +213,7 @@ The template wires up far more than the starter code. The full inventory:
 
 ### Testing and quality
 
-- **Testing Included** - C23 CLI contract tests plus PTY terminal scenario tests for CLI/TUI flows
+- **Testing Included** - Three layers: in-process unit tests, C23 CLI contract tests, and PTY terminal scenarios for CLI/TUI flows
 - **Markdown Linting** - Documentation checks in local tooling and CI
 
 ### CI/CD and releases

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,17 +25,17 @@ This template is pre-1.0; security fixes land on `main` and ship in the next tag
 
 The repository ships these baseline defenses; review them and tighten if your threat model warrants:
 
-- **Memory hygiene** — `app_secret_zero()` overwrites sensitive buffers before they are freed, and the input path locks them out of swap where the platform supports it.
-- **Static analysis in CI** — `clang-tidy` and `cppcheck` run on every change.
-- **Supply chain in CI** — Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
-- **Runtime safety** — `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.
+- **Memory hygiene**. `app_secret_zero()` overwrites sensitive buffers before they are freed, and the input path locks them out of swap where the platform supports it.
+- **Static analysis in CI**. `clang-tidy` and `cppcheck` run on every change.
+- **Supply chain in CI**. Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
+- **Runtime safety**. `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.
 
 Compiler hardening (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, PIE/RELRO) is **not** enabled by default. Add the flags to `base_flags` in `build.zig` if you need them. See [docs/ARCHITECTURE.md#security-model](docs/ARCHITECTURE.md#security-model) for the full security model.
 
 ## Practices when adopting the template
 
-- Keep dependencies current — Dependabot is preconfigured.
-- Never commit secrets — Gitleaks runs in CI; the pre-commit configuration also catches large files and broken YAML.
+- Keep dependencies current; Dependabot is preconfigured.
+- Never commit secrets. Gitleaks runs in CI, and the pre-commit configuration also catches large files and broken YAML.
 - Treat the config file (`~/.config/<name>/config.json`) as user-private; prefer environment variables for runtime secrets.
 - Enable GitHub's code scanning and Dependabot alerts on your generated repository.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,67 +1,44 @@
 # Security Policy
 
-## Supported Versions
+## Reporting a vulnerability
 
-Use this section to tell people about which versions of your project are currently being supported with security updates.
+Please do not report security vulnerabilities through public GitHub issues.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+Use **GitHub Private Vulnerability Reporting** instead:
 
-## Reporting a Vulnerability
+1. Open the **Security** tab of the repository.
+2. Click **Report a vulnerability**.
+3. Include:
+   - what the issue is (memory safety, command injection, supply chain, denial of service, …);
+   - the affected file paths and the tag, branch, or commit;
+   - reproduction steps and any required configuration;
+   - a proof-of-concept if you have one;
+   - the impact you see.
 
-We take the security of our software seriously. If you believe you have found a security vulnerability in this template or any project generated from it, please report it to us as described below.
+You will get an acknowledgement within 48 hours and an initial assessment within 7 days. We will keep you updated, work with you on disclosure timing, and credit you in the advisory unless you prefer to remain anonymous.
 
-### How to Report a Security Vulnerability
+## Supported versions
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+This template is pre-1.0; security fixes land on `main` and ship in the next tagged release. The latest release is the supported one.
 
-Instead, please report them via one of the following methods:
+## What the template does already
 
-1. **Email**: Send an email to <security@yourorganization.com> with:
-   - Type of issue (e.g., buffer overflow, SQL injection, cross-site scripting, etc.)
-   - Full paths of source file(s) related to the manifestation of the issue
-   - The location of the affected source code (tag/branch/commit or direct URL)
-   - Any special configuration required to reproduce the issue
-   - Step-by-step instructions to reproduce the issue
-   - Proof-of-concept or exploit code (if possible)
-   - Impact of the issue, including how an attacker might exploit the issue
+The repository ships these baseline defenses; review them and tighten if your threat model warrants:
 
-2. **GitHub Security Advisories**: You can report a vulnerability privately through GitHub's Security Advisories feature:
-   - Navigate to the Security tab of this repository
-   - Click on "Report a vulnerability"
-   - Fill out the form with details about the vulnerability
+- **Memory hygiene** — `app_secret_zero()` overwrites sensitive buffers before they are freed, and the input path locks them out of swap where the platform supports it.
+- **Static analysis in CI** — `clang-tidy` and `cppcheck` run on every change.
+- **Supply chain in CI** — Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
+- **Runtime safety** — `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.
 
-### What to Expect
+Compiler hardening (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, PIE/RELRO) is **not** enabled by default. Add the flags to `base_flags` in `build.zig` if you need them. See [docs/ARCHITECTURE.md#security-model](docs/ARCHITECTURE.md#security-model) for the full security model.
 
-- **Acknowledgment**: We will acknowledge receipt of your vulnerability report within 48 hours
-- **Initial Assessment**: Within 7 days, we will provide an initial assessment of the vulnerability
-- **Updates**: We will keep you informed about our progress towards a fix and full announcement
-- **Credit**: We will credit you for the discovery when we announce the vulnerability (unless you prefer to remain anonymous)
+## Practices when adopting the template
 
-### Disclosure Policy
-
-- We ask that you give us reasonable time to address the issue before making any public disclosure
-- We will work with you to understand and resolve the issue quickly
-- Once the issue is resolved, we will publish a security advisory detailing the vulnerability and crediting the discoverer
-
-## Security Best Practices
-
-When using this template, please ensure you:
-
-1. Keep all dependencies up to date
-2. Review and understand all security configurations
-3. Never commit sensitive information (API keys, passwords, etc.)
-4. Use environment variables for configuration
-5. Enable GitHub's security features (Dependabot, code scanning, etc.)
-6. Regularly review security advisories for your dependencies
+- Keep dependencies current — Dependabot is preconfigured.
+- Never commit secrets — Gitleaks runs in CI; the pre-commit configuration also catches large files and broken YAML.
+- Treat the config file (`~/.config/<name>/config.json`) as user-private; prefer environment variables for runtime secrets.
+- Enable GitHub's code scanning and Dependabot alerts on your generated repository.
 
 ## Contact
 
-For any security-related questions or concerns, please contact:
-
-- Security Team: <security@yourorganization.com>
-- Project Maintainers: See CODEOWNERS file
-
-Thank you for helping keep this project and its users safe!
+GitHub Private Vulnerability Reporting (above) is the primary channel. For non-security maintainer contact, see [CODEOWNERS](.github/CODEOWNERS).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ The repository ships these baseline defenses; review them and tighten if your th
   (`mlock` / `VirtualLock`) is not wired in either.
 - **Static analysis in CI**. `clang-tidy` and `cppcheck` run on every change.
 - **Supply chain in CI**. Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
-- **Runtime safety**. `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.
+- **Compiler warnings.** C sources compile with `-Wall -Wextra -std=c23`. `-Doptimize=` selects the optimization level; no Zig runtime is linked into the C-only binary.
 
 Compiler hardening (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, PIE/RELRO) is
 **not** enabled by default. Add the flags to `base_flags` in `build.zig` if you need

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,10 @@ This template is pre-1.0; security fixes land on `main` and ship in the next tag
 
 The repository ships these baseline defenses; review them and tighten if your threat model warrants:
 
-- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for clearing sensitive buffers. The template ships it as a primitive but does not call it from any production path yet — invoke it where your code holds secrets. Memory locking (`mlock` / `VirtualLock`) is not wired in either.
+- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for
+  clearing sensitive buffers. The template ships it as a primitive but no production
+  path calls it yet; invoke it where your code holds secrets. Memory locking
+  (`mlock` / `VirtualLock`) is not wired in either.
 - **Static analysis in CI**. `clang-tidy` and `cppcheck` run on every change.
 - **Supply chain in CI**. Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
 - **Runtime safety**. `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ This template is pre-1.0; security fixes land on `main` and ship in the next tag
 
 The repository ships these baseline defenses; review them and tighten if your threat model warrants:
 
-- **Memory hygiene**. `app_secret_zero()` overwrites sensitive buffers before they are freed, and the input path locks them out of swap where the platform supports it.
+- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for clearing sensitive buffers. The template ships it as a primitive but does not call it from any production path yet — invoke it where your code holds secrets. Memory locking (`mlock` / `VirtualLock`) is not wired in either.
 - **Static analysis in CI**. `clang-tidy` and `cppcheck` run on every change.
 - **Supply chain in CI**. Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
 - **Runtime safety**. `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,9 @@ Use **GitHub Private Vulnerability Reporting** instead:
    - a proof-of-concept if you have one;
    - the impact you see.
 
-You will get an acknowledgement within 48 hours and an initial assessment within 7 days. We will keep you updated, work with you on disclosure timing, and credit you in the advisory unless you prefer to remain anonymous.
+You will get an acknowledgement within 48 hours and an initial assessment within 7
+days. We will keep you updated, work with you on disclosure timing, and credit you in
+the advisory unless you prefer to remain anonymous.
 
 ## Supported versions
 
@@ -30,7 +32,10 @@ The repository ships these baseline defenses; review them and tighten if your th
 - **Supply chain in CI**. Gitleaks secret scanning, OpenSSF Scorecard, SBOM generation, and pinned GitHub Actions versions.
 - **Runtime safety**. `Debug` and `ReleaseSafe` builds keep Zig's runtime safety checks; C sources compile with `-Wall -Wextra -std=c23`.
 
-Compiler hardening (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, PIE/RELRO) is **not** enabled by default. Add the flags to `base_flags` in `build.zig` if you need them. See [docs/ARCHITECTURE.md#security-model](docs/ARCHITECTURE.md#security-model) for the full security model.
+Compiler hardening (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, PIE/RELRO) is
+**not** enabled by default. Add the flags to `base_flags` in `build.zig` if you need
+them. See [docs/ARCHITECTURE.md#security-model](docs/ARCHITECTURE.md#security-model)
+for the full security model.
 
 ## Practices when adopting the template
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ For the build options, steps, and how to add a source file, see the [Zig Primer]
 | Concern | Linux / macOS | Windows |
 | --- | --- | --- |
 | Terminal UI | ncurses (`ncursesw`) | pdcurses |
-| Secret memory | zero + lock out of swap where supported | zero + `VirtualLock` where supported |
+| Secret memory | `app_secret_zero()` helper (not wired by default) | `app_secret_zero()` helper (not wired by default) |
 | Config path | `~/.config/myapp/config.json` | `%USERPROFILE%\AppData\Local\myapp\config.json` |
 | Binary name | `myapp` | `myapp.exe` |
 
@@ -88,7 +88,7 @@ Cross-compilation is a `-Dtarget=` flag away because Zig ships every target's he
 
 The template's defenses are the ones actually wired into the code and CI, not compiler hardening flags. Those are left for you to opt into.
 
-- **Memory hygiene.** Sensitive buffers are overwritten with `app_secret_zero()` before they are freed, and the input path locks them out of swap where the platform supports it (`mlock` / `VirtualLock`).
+- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for clearing sensitive buffers. The template ships it as a primitive but does not call it from any production path yet — invoke it where your code holds secrets. Memory locking (`mlock` / `VirtualLock`) is not wired in either.
 - **Runtime safety.** The default and `ReleaseSafe` builds keep Zig's runtime safety checks. C sources compile with `-Wall -Wextra -std=c23`.
 - **Static analysis in CI.** GitHub Actions runs `clang-tidy` and `cppcheck` over the C sources on every change.
 - **Supply chain in CI.** Gitleaks secret scanning, an OpenSSF Scorecard run, SBOM generation, and pinned action versions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,10 @@ Cross-compilation is a `-Dtarget=` flag away because Zig ships every target's he
 
 The template's defenses are the ones actually wired into the code and CI, not compiler hardening flags. Those are left for you to opt into.
 
-- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for clearing sensitive buffers. The template ships it as a primitive but does not call it from any production path yet — invoke it where your code holds secrets. Memory locking (`mlock` / `VirtualLock`) is not wired in either.
+- **Secret-zeroing helper.** `src/utils/memory.h` exports `app_secret_zero()` for
+  clearing sensitive buffers. The template ships it as a primitive but no production
+  path calls it yet; invoke it where your code holds secrets. Memory locking
+  (`mlock` / `VirtualLock`) is not wired in either.
 - **Runtime safety.** The default and `ReleaseSafe` builds keep Zig's runtime safety checks. C sources compile with `-Wall -Wextra -std=c23`.
 - **Static analysis in CI.** GitHub Actions runs `clang-tidy` and `cppcheck` over the C sources on every change.
 - **Supply chain in CI.** Gitleaks secret scanning, an OpenSSF Scorecard run, SBOM generation, and pinned action versions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ The command table is the seam to extend. `commands.c` registers the built-in com
 5. On failure a handler returns an `app_error` value (see `core/error.c`). `app_strerror()` describes it, and the numeric code becomes the exit status. The public codes are listed in `opencli.json`.
 6. Commands that need the terminal UI (`menu`, and `doctor --deep`) call `tui_init()` and always pair it with `tui_cleanup()`, including on interrupt.
 
-The stable shape of this surface — commands, flags, exit codes, JSON envelopes — is documented in [CONTRACTS.md](CONTRACTS.md).
+The stable shape of this surface (commands, flags, exit codes, JSON envelopes) is documented in [CONTRACTS.md](CONTRACTS.md).
 
 ## Build system
 
@@ -73,7 +73,7 @@ Cross-compilation is a `-Dtarget=` flag away because Zig ships every target's he
 
 ## Security model
 
-The template's defenses are the ones actually wired into the code and CI — not compiler hardening flags, which are left for you to opt into.
+The template's defenses are the ones actually wired into the code and CI, not compiler hardening flags. Those are left for you to opt into.
 
 - **Memory hygiene.** Sensitive buffers are overwritten with `app_secret_zero()` before they are freed, and the input path locks them out of swap where the platform supports it (`mlock` / `VirtualLock`).
 - **Runtime safety.** The default and `ReleaseSafe` builds keep Zig's runtime safety checks. C sources compile with `-Wall -Wextra -std=c23`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,10 @@ A map of how a project generated from this template is put together: the layers,
 
 ## The mental model
 
-It is a small, layered C23 program. `main.c` parses arguments, resolves configuration, looks up a command in a table, and runs its handler. Handlers write text (or JSON with `--json`) through one I/O layer and signal failure with a typed error code that becomes the process exit status.
+It is a small, layered C23 program. `main.c` parses arguments, resolves configuration,
+looks up a command in a table, and runs its handler. Handlers write text (or JSON with
+`--json`) through one I/O layer and signal failure with a typed error code that becomes
+the process exit status.
 
 The interactive ncurses interface is a separate layer that only compiles when you pass `-Denable-tui=true`. The default build is a plain libc CLI with no curses dependency.
 
@@ -41,12 +44,18 @@ Each directory under `src/` owns one concern. The functions below are representa
 | `tui` | `tui.c`, `tui_menu.c`, `tui_menu_model.c`, `tui_progress.c`, `tui_app.c` | ncurses lifecycle, modal menus, progress bars, and the demo showcase (compiled only with `-Denable-tui=true`) | `tui_init()`, `tui_cleanup()`, `tui_show_menu()`, `tui_progress_create()` |
 | `utils` | `colors.c`, `logging.c`, `memory.c` | Cross-cutting helpers: color setup, leveled logging, secret zeroing | `app_log_init()`, `app_secret_zero()` |
 
-The command table is the seam to extend. `commands.c` registers the built-in commands, and each lives in its own file (`commands_basic.c` for `hello`/`echo`, plus `commands_info.c`, `commands_doctor.c`, `commands_menu.c`, `commands_opencli.c`). See [examples/adding-a-command.md](../examples/adding-a-command.md).
+The command table is the seam to extend. `commands.c` registers the built-in commands,
+and each lives in its own file (`commands_basic.c` for `hello`/`echo`, plus
+`commands_info.c`, `commands_doctor.c`, `commands_menu.c`, `commands_opencli.c`). See
+[examples/adding-a-command.md](../examples/adding-a-command.md).
 
 ## Request lifecycle
 
 1. `main()` initializes logging and creates an `app_config_t`.
-2. The CLI layer reads argv. Immediate-exit options (`--help`, `--version`) are handled first by `app_args_handle_immediate_exit()`. Global flags (`--debug`, `--quiet`, `--verbose`, `--json`, `--plain`, `--no-color`, `--config`) update the config; the remaining tokens become the command name and its arguments.
+2. The CLI layer reads argv. Immediate-exit options (`--help`, `--version`) are handled
+   first by `app_args_handle_immediate_exit()`. Global flags (`--debug`, `--quiet`,
+   `--verbose`, `--json`, `--plain`, `--no-color`, `--config`) update the config; the
+   remaining tokens become the command name and its arguments.
 3. Configuration is resolved by precedence: **CLI args > environment > config file > defaults**.
 4. `app_command_find()` looks up the command. Its handler runs and writes output through `app_output()` / the `app_json_*` helpers.
 5. On failure a handler returns an `app_error` value (see `core/error.c`). `app_strerror()` describes it, and the numeric code becomes the exit status. The public codes are listed in `opencli.json`.
@@ -56,7 +65,11 @@ The stable shape of this surface (commands, flags, exit codes, JSON envelopes) i
 
 ## Build system
 
-`build.zig` compiles the C sources with Zig's bundled Clang. The base binary is the file list in the `base_sources` array; the `tui_sources` are appended only when `-Denable-tui=true`, which also defines `ENABLE_TUI=1` and links `ncursesw` (or `pdcurses` on Windows). A separate `tui-menu-lib` step builds the reusable menu primitive as a static library with installed headers.
+`build.zig` compiles the C sources with Zig's bundled Clang. The base binary is the
+file list in the `base_sources` array; the `tui_sources` are appended only when
+`-Denable-tui=true`, which also defines `ENABLE_TUI=1` and links `ncursesw` (or
+`pdcurses` on Windows). A separate `tui-menu-lib` step builds the reusable menu
+primitive as a static library with installed headers.
 
 For the build options, steps, and how to add a source file, see the [Zig Primer](ZIG_PRIMER.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,352 +1,94 @@
 # Architecture Overview
 
-This document provides a comprehensive overview of the C23 CLI Template architecture, designed to help new contributors understand the codebase structure and build system.
+A map of how a project generated from this template is put together: the layers, the real modules, how a command runs, and where to add your own code.
 
-## Table of Contents
+- [The mental model](#the-mental-model)
+- [Module map](#module-map)
+- [Request lifecycle](#request-lifecycle)
+- [Build system](#build-system)
+- [Platform differences](#platform-differences)
+- [Security model](#security-model)
+- [Where to add code](#where-to-add-code)
 
-- [High-Level Architecture](#high-level-architecture)
-- [Module Structure](#module-structure)
-- [Build System](#build-system)
-- [Data Flow](#data-flow)
-- [Platform Abstraction](#platform-abstraction)
-- [Security Architecture](#security-architecture)
+## The mental model
 
-## High-Level Architecture
+It is a small, layered C23 program. `main.c` parses arguments, resolves configuration, looks up a command in a table, and runs its handler. Handlers write text (or JSON with `--json`) through one I/O layer and signal failure with a typed error code that becomes the process exit status.
 
-```mermaid
-graph TB
-    subgraph "User Space"
-        USER[User Input]
-        TERM[Terminal Output]
-    end
-
-    subgraph "Application Layer"
-        MAIN[main.c<br/>Entry Point]
-        CLI[CLI Module<br/>args.c/help.c]
-        CORE[Core Module<br/>config.c/error.c]
-        TUI[TUI Module<br/>tui.c/tui_app.c/tui_menu.c/progress.c]
-        IO[I/O Module<br/>input.c/output.c]
-    end
-
-    subgraph "Utility Layer"
-        UTILS[Utils Module<br/>colors.c/logging.c/memory.c]
-    end
-
-    subgraph "Platform Layer"
-        NCURSES[ncurses<br/>Linux/macOS]
-        PDCURSES[pdcurses<br/>Windows]
-        LIBC[Platform libc]
-    end
-
-    USER --> MAIN
-    MAIN --> CLI
-    CLI --> CORE
-    CLI --> TUI
-    CORE --> IO
-    TUI --> IO
-    IO --> UTILS
-    TUI --> NCURSES
-    TUI --> PDCURSES
-    UTILS --> LIBC
-    IO --> TERM
-```
-
-## Module Structure
-
-### Core Modules
-
-```mermaid
-graph LR
-    subgraph "src/cli"
-        ARGS[args.c<br/>Argument Parsing]
-        HELP[help.c<br/>Help Generation]
-    end
-
-    subgraph "src/core"
-        CONFIG[config.c<br/>Configuration]
-        ERROR[error.c<br/>Error Handling]
-        TYPES[types.h<br/>Core Types]
-    end
-
-    subgraph "src/io"
-        INPUT[input.c<br/>User Input]
-        OUTPUT[output.c<br/>Formatted Output]
-    end
-
-    subgraph "src/tui"
-        TUIDEF[tui.c<br/>TUI Primitives]
-        TUIMENU[tui_menu.c<br/>Menu Component]
-        TUIAPP[tui_app.c<br/>Starter Showcase]
-        PROGRESS[tui_progress.c<br/>Progress Bars]
-    end
-
-    subgraph "src/utils"
-        COLORS[colors.c<br/>Color Definitions]
-        LOGGING[logging.c<br/>Logging System]
-        MEMORY[memory.c<br/>Secret Zeroing]
-    end
-
-    ARGS --> CONFIG
-    ARGS --> ERROR
-    TUIDEF --> COLORS
-    TUIAPP --> TUIDEF
-    TUIAPP --> TUIMENU
-    TUIMENU --> TUIDEF
-    TUIDEF --> OUTPUT
-    CONFIG --> LOGGING
-    INPUT --> MEMORY
-```
-
-### Module Responsibilities
-
-| Module | Purpose | Key Functions |
-|--------|---------|---------------|
-| **cli** | Command-line argument parsing and help generation | `parse_args()`, `print_help()` |
-| **core** | Core application logic and configuration | `load_config()`, `handle_error()` |
-| **io** | Input/output operations with formatting | `read_input()`, `write_output()` |
-| **tui** | Terminal UI components and rendering | `init_tui()`, `show_progress()` |
-| **utils** | Cross-cutting utilities and helpers | `app_secret_zero()`, `app_log_*()` |
-
-## Build System
-
-### Zig Build Pipeline
+The interactive ncurses interface is a separate layer that only compiles when you pass `-Denable-tui=true`. The default build is a plain libc CLI with no curses dependency.
 
 ```mermaid
 graph TD
-    subgraph "Build Inputs"
-        BUILDZIG[build.zig<br/>Build Script]
-        BUILDZON[build.zig.zon<br/>Dependencies]
-        CSRC[C Source Files<br/>src/**/*.c]
-        CHDR[C Headers<br/>src/**/*.h]
-    end
-
-    subgraph "Zig Build Process"
-        PARSE[Parse build.zig]
-        DEPS[Fetch Dependencies<br/>aro, etc.]
-        COMPILE[Compile C23 Code<br/>via Zig CC]
-        LINK[Link Binary<br/>+ Platform Libs]
-        TEST[Run C23 CLI Tests<br/>test/cli_contract_runner.c]
-        TERMTEST[Run Terminal Scenarios<br/>test/terminal_vt_*.c]
-    end
-
-    subgraph "Build Outputs"
-        BIN[zig-out/bin/myapp<br/>Executable]
-        TESTOUT[Test Results]
-        CACHE[zig-cache/<br/>Build Cache]
-    end
-
-    BUILDZIG --> PARSE
-    BUILDZON --> DEPS
-    CSRC --> COMPILE
-    CHDR --> COMPILE
-    PARSE --> COMPILE
-    DEPS --> COMPILE
-    COMPILE --> LINK
-    LINK --> BIN
-    PARSE --> TEST
-    LINK --> TERMTEST
-    TEST --> TESTOUT
-    TERMTEST --> TESTOUT
-    COMPILE --> CACHE
+    USER[argv + stdin] --> MAIN[main.c]
+    MAIN --> CLI["cli/ - parse args, dispatch"]
+    CLI --> CMD["cli/commands_*.c - handlers"]
+    CMD --> CORE["core/ - config, errors"]
+    CMD --> IO["io/ - text + JSON output"]
+    CMD -. "menu, doctor --deep" .-> TUI["tui/ - ncurses, opt-in"]
+    CORE --> UTILS["utils/ - logging, colors, memory"]
+    IO --> TERM[stdout / stderr]
+    TUI --> CURSES[ncurses / pdcurses]
 ```
 
-### Build Commands
+## Module map
 
-```bash
-# Development build
-zig build
+Each directory under `src/` owns one concern. The functions below are representative entry points, not the full surface; read the matching header for the rest.
 
-# Run fast C23 CLI contract tests
-zig build test
+| Module | Files | Responsibility | Representative functions |
+| --- | --- | --- | --- |
+| `cli` | `args.c`, `help.c`, `commands.c`, `commands_*.c`, `opencli_contract.c` | Parse argv, apply global flags, find and dispatch commands, render help, expose the OpenCLI contract | `app_args_handle_immediate_exit()`, `app_commands()`, `app_command_find()`, `app_print_concise_help()` |
+| `core` | `config.c`, `config_json.c`, `error.c`, `types.h` | Layered configuration, the flag table, and typed errors | `app_config_create()`, `app_config_load_env()`, `app_config_get_flag()`, `app_strerror()` |
+| `io` | `input.c`, `output.c` | Read stdin/files; write human text and versioned JSON | `app_read_input_from_stdin()`, `app_output()`, `app_json_write_string()` |
+| `tui` | `tui.c`, `tui_menu.c`, `tui_menu_model.c`, `tui_progress.c`, `tui_app.c` | ncurses lifecycle, modal menus, progress bars, and the demo showcase (compiled only with `-Denable-tui=true`) | `tui_init()`, `tui_cleanup()`, `tui_show_menu()`, `tui_progress_create()` |
+| `utils` | `colors.c`, `logging.c`, `memory.c` | Cross-cutting helpers: color setup, leveled logging, secret zeroing | `app_log_init()`, `app_secret_zero()` |
 
-# Run end-to-end terminal scenario tests
-zig build terminal-test
+The command table is the seam to extend. `commands.c` registers the built-in commands, and each lives in its own file (`commands_basic.c` for `hello`/`echo`, plus `commands_info.c`, `commands_doctor.c`, `commands_menu.c`, `commands_opencli.c`). See [examples/adding-a-command.md](../examples/adding-a-command.md).
 
-# Run PTY-backed TUI scenarios
-zig build -Denable-tui=true terminal-test
+## Request lifecycle
 
-# Release build
-zig build -Doptimize=ReleaseSafe
+1. `main()` initializes logging and creates an `app_config_t`.
+2. The CLI layer reads argv. Immediate-exit options (`--help`, `--version`) are handled first by `app_args_handle_immediate_exit()`. Global flags (`--debug`, `--quiet`, `--verbose`, `--json`, `--plain`, `--no-color`, `--config`) update the config; the remaining tokens become the command name and its arguments.
+3. Configuration is resolved by precedence: **CLI args > environment > config file > defaults**.
+4. `app_command_find()` looks up the command. Its handler runs and writes output through `app_output()` / the `app_json_*` helpers.
+5. On failure a handler returns an `app_error` value (see `core/error.c`). `app_strerror()` describes it, and the numeric code becomes the exit status. The public codes are listed in `opencli.json`.
+6. Commands that need the terminal UI (`menu`, and `doctor --deep`) call `tui_init()` and always pair it with `tui_cleanup()`, including on interrupt.
 
-# Install to prefix
-zig build install --prefix ~/.local
+The stable shape of this surface — commands, flags, exit codes, JSON envelopes — is documented in [CONTRACTS.md](CONTRACTS.md).
 
-# Check without building
-zig build check
-```
+## Build system
 
-## Data Flow
+`build.zig` compiles the C sources with Zig's bundled Clang. The base binary is the file list in the `base_sources` array; the `tui_sources` are appended only when `-Denable-tui=true`, which also defines `ENABLE_TUI=1` and links `ncursesw` (or `pdcurses` on Windows). A separate `tui-menu-lib` step builds the reusable menu primitive as a static library with installed headers.
 
-### Command Processing Flow
+For the build options, steps, and how to add a source file, see the [Zig Primer](ZIG_PRIMER.md).
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Main
-    participant CLI
-    participant Core
-    participant TUI
-    participant IO
+## Platform differences
 
-    User->>Main: ./myapp command args
-    Main->>CLI: parse_args(argc, argv)
-    CLI->>Core: validate_command()
+| Concern | Linux / macOS | Windows |
+| --- | --- | --- |
+| Terminal UI | ncurses (`ncursesw`) | pdcurses |
+| Secret memory | zero + lock out of swap where supported | zero + `VirtualLock` where supported |
+| Config path | `~/.config/myapp/config.json` | `%USERPROFILE%\AppData\Local\myapp\config.json` |
+| Binary name | `myapp` | `myapp.exe` |
 
-    alt Valid Command
-        Core->>TUI: init_tui()
-        TUI->>IO: setup_terminal()
-        Core->>Core: execute_command()
-        Core->>TUI: update_display()
-        TUI->>IO: render_output()
-        IO->>User: Display Result
-    else Invalid Command
-        Core->>CLI: get_help_text()
-        CLI->>IO: print_error()
-        IO->>User: Show Error + Help
-    end
+Cross-compilation is a `-Dtarget=` flag away because Zig ships every target's headers and libc; no second toolchain to install.
 
-    Main->>TUI: cleanup_tui()
-    Main->>User: Exit(status)
-```
+## Security model
 
-## Platform Abstraction
+The template's defenses are the ones actually wired into the code and CI — not compiler hardening flags, which are left for you to opt into.
 
-### Cross-Platform Strategy
+- **Memory hygiene.** Sensitive buffers are overwritten with `app_secret_zero()` before they are freed, and the input path locks them out of swap where the platform supports it (`mlock` / `VirtualLock`).
+- **Runtime safety.** The default and `ReleaseSafe` builds keep Zig's runtime safety checks. C sources compile with `-Wall -Wextra -std=c23`.
+- **Static analysis in CI.** GitHub Actions runs `clang-tidy` and `cppcheck` over the C sources on every change.
+- **Supply chain in CI.** Gitleaks secret scanning, an OpenSSF Scorecard run, SBOM generation, and pinned action versions.
 
-```mermaid
-graph TD
-    subgraph "Application Code"
-        APP[Platform-Agnostic Code]
-    end
+Compiler-level hardening (`-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2`, PIE/RELRO) is **not** enabled by default. If your threat model needs it, add the flags to `base_flags` in `build.zig`.
 
-    subgraph "Abstraction Layer"
-        ABS[Platform Abstractions<br/>#ifdef guards]
-    end
+## Where to add code
 
-    subgraph "Linux/macOS"
-        UNIX[POSIX APIs]
-        NC[ncurses]
-        MLOCK[mlock()]
-    end
-
-    subgraph "Windows"
-        WIN[Win32 APIs]
-        PDC[pdcurses]
-        VLOCK[VirtualLock()]
-    end
-
-    APP --> ABS
-    ABS -->|__linux__ or __APPLE__| UNIX
-    ABS -->|_WIN32| WIN
-    UNIX --> NC
-    WIN --> PDC
-    UNIX --> MLOCK
-    WIN --> VLOCK
-```
-
-### Platform-Specific Features
-
-| Feature | Linux/macOS | Windows |
-|---------|-------------|---------|
-| **Terminal UI** | ncurses | pdcurses |
-| **Secure Memory** | mlock/munlock | VirtualLock/VirtualUnlock |
-| **Config Path** | ~/.config/myapp/ | %APPDATA%\myapp\ |
-| **Path Separator** | / | \ |
-| **Binary Extension** | (none) | .exe |
-
-## Security Architecture
-
-### Security Layers
-
-```mermaid
-graph TB
-    subgraph "Input Validation"
-        ARGVAL[Argument Validation]
-        INPUTSAN[Input Sanitization]
-        BUFCHECK[Buffer Overflow Protection]
-    end
-
-    subgraph "Memory Security"
-        SECMEM[Secret Buffer Hygiene]
-        ZEROMEM[Explicit Zeroing<br/>app_secret_zero()]
-        CANARY[Stack Canaries<br/>-fstack-protector]
-    end
-
-    subgraph "Build Security"
-        RELRO[RELRO<br/>Read-Only Relocations]
-        NX[NX/DEP<br/>No-Execute]
-        PIE[PIE/ASLR<br/>Position Independent]
-    end
-
-    ARGVAL --> SECMEM
-    INPUTSAN --> SECMEM
-    BUFCHECK --> ZEROMEM
-    SECMEM --> RELRO
-    ZEROMEM --> NX
-    CANARY --> PIE
-```
-
-### Security Features
-
-1. **Input Validation**
-   - All command-line arguments are validated
-   - Buffer sizes are checked before operations
-   - String operations use safe variants
-
-2. **Memory Protection**
-   - Sensitive data locked in memory (where supported)
-   - Memory zeroed before deallocation
-   - Stack protection enabled by default
-
-3. **Build Hardening**
-   - Position-independent executables (PIE)
-   - Stack canaries enabled
-   - Fortify source macros used
-
-## Development Workflow
-
-### Typical Development Cycle
-
-```mermaid
-graph LR
-    subgraph "Development"
-        EDIT[Edit Code]
-        BUILD[zig build]
-        TEST[zig build test]
-        TERMTEST[zig build terminal-test]
-        RUN[./zig-out/bin/myapp]
-    end
-
-    subgraph "Quality Checks"
-        FORMAT[clang-format]
-        LINT[clang-tidy]
-        MARKDOWN[markdownlint]
-    end
-
-    subgraph "CI/CD"
-        PUSH[git push]
-        CI[GitHub Actions]
-        RELEASE[Release Build]
-    end
-
-    EDIT --> BUILD
-    BUILD --> TEST
-    TEST --> TERMTEST
-    TERMTEST --> RUN
-    RUN --> EDIT
-
-    EDIT --> FORMAT
-    FORMAT --> LINT
-    LINT --> MARKDOWN
-    MARKDOWN --> PUSH
-
-    PUSH --> CI
-    CI --> RELEASE
-```
-
-## Next Steps
-
-- See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed build instructions
-- See [TESTING.md](TESTING.md) for CLI and PTY-backed TUI scenario tests
-- Check [examples/](../examples/) for usage examples
-- Review [build.zig](../build.zig) for build configuration details
+| You want to… | Start here |
+| --- | --- |
+| Add a command | [examples/adding-a-command.md](../examples/adding-a-command.md), then register it in `src/cli/commands.c` |
+| Add a config flag | `src/core/config.c` (the flag table) and `src/core/config_json.c` |
+| Add a new exit code | `src/core/error.c`, then regenerate `opencli.json` (see [CONTRACTS.md](CONTRACTS.md)) |
+| Build a TUI screen | [examples/custom-tui.md](../examples/custom-tui.md) and `src/tui/` |
+| Add a source file to the build | the `base_sources` array in `build.zig` (see [ZIG_PRIMER.md](ZIG_PRIMER.md)) |
+| Test any of the above | [TESTING.md](TESTING.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,7 +92,7 @@ The template's defenses are the ones actually wired into the code and CI, not co
   clearing sensitive buffers. The template ships it as a primitive but no production
   path calls it yet; invoke it where your code holds secrets. Memory locking
   (`mlock` / `VirtualLock`) is not wired in either.
-- **Runtime safety.** The default and `ReleaseSafe` builds keep Zig's runtime safety checks. C sources compile with `-Wall -Wextra -std=c23`.
+- **Compiler warnings.** C sources compile with `-Wall -Wextra -std=c23`. `-Doptimize=` selects the optimization level; no Zig runtime is linked into the C-only binary.
 - **Static analysis in CI.** GitHub Actions runs `clang-tidy` and `cppcheck` over the C sources on every change.
 - **Supply chain in CI.** Gitleaks secret scanning, an OpenSSF Scorecard run, SBOM generation, and pinned action versions.
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,58 +1,53 @@
 # Public Contracts
 
-This template is an opinionated reference app built on two reusable seams:
-
-- a machine-readable CLI contract
-- a small C TUI menu primitive
+This template is an opinionated reference app built on two reusable seams: a machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a stability promise — the surfaces listed as *supported* are safe to build automation or downstream code on; everything else (help wording, colors, file layout, internal helpers) can change without notice.
 
 Keep mechanism in these seams. Keep local workflow policy in the generated app.
 
-## CLI Contract
+## CLI contract
 
-`opencli.json` is the checked-in CLI contract. The live binary prints the same
-contract with:
+`opencli.json` is the checked-in CLI contract, and the binary prints the same document:
 
 ```bash
 myapp opencli
 ```
 
-`zig build test` fails when `myapp opencli` and `opencli.json` drift, so command
-and flag metadata must be updated in the C tables before the spec changes.
-The canonical data path is:
+`zig build test` fails when `myapp opencli` and `opencli.json` drift, so command and flag metadata must change in the C tables *before* the spec does. The canonical sources:
 
-- `src/cli/opencli_contract.c` for OpenCLI info, conventions, root arguments,
-  extra examples, and top-level metadata
-- `src/cli/commands.c` for built-in `--help`/`--version` metadata, command
-  names, summaries, global value options such as `--config`, command
-  arguments, command-specific options, examples, and terminal requirements
-- `src/core/config.c` for global flag metadata
-- `src/core/error.c` for public exit codes and descriptions
+| Source | Owns |
+| --- | --- |
+| `src/cli/opencli_contract.c` | OpenCLI info, conventions, root arguments, extra examples, top-level metadata |
+| `src/cli/commands.c` | `--help`/`--version` metadata, command names and summaries, global value options such as `--config`, command arguments and options, examples, terminal requirements |
+| `src/core/config.c` | Global flag metadata |
+| `src/core/error.c` | Public exit codes and descriptions |
 
-Regenerate the checked-in artifact with `zig build run -- opencli >
-opencli.json`, then run `zig build test`.
+After editing those tables, regenerate the artifact and re-run the tests:
 
-Supported automation surface:
+```bash
+zig build run -- opencli > opencli.json
+zig build test
+```
+
+**Supported (stable to depend on):**
 
 - global options before the command
-- command names, command arguments, command-specific options, and examples in
-  `opencli.json`
-- public exit codes listed in `opencli.json`
+- command names, arguments, options, and examples in `opencli.json`
+- public exit codes in `opencli.json`
 - `--json` responses that include `format_version`
-- `myapp opencli` always writes the schema document directly; `--json opencli`
-  is rejected so callers do not confuse it with command result envelopes
-- stdout for command output and stderr for errors or diagnostics
+- `myapp opencli` always writes the schema document; `--json opencli` is rejected so callers do not confuse it with a command-result envelope
+- stdout for command output, stderr for errors and diagnostics
 - config precedence: CLI args > environment > config file > defaults
 
-Private or unstable surface:
+**Private (may change without notice):**
 
-- exact help text, examples prose, spacing, and colors
-- log line wording and timing
-- internal `app_error` values that are not listed as public exit codes
-- source file layout and private helper functions
+- exact help text, example prose, spacing, and colors
+- log wording and timing
+- internal `app_error` values not listed as public exit codes
+- source layout and private helper functions
 
-## TUI Menu Contract
+## TUI menu contract
 
-`zig build tui-menu-lib` builds the narrow reusable TUI primitive and installs:
+`zig build tui-menu-lib` builds the narrow reusable primitive and installs:
 
 ```text
 zig-out/lib/libtui-menu.a
@@ -63,26 +58,26 @@ zig-out/include/c23-cli-template/tui/tui_menu.h
 zig-out/include/c23-cli-template/tui/tui_progress.h
 ```
 
-Supported menu surface:
+**Supported:**
 
-- `tui_init()` / `tui_cleanup()` lifecycle from `tui.h`
+- the `tui_init()` / `tui_cleanup()` lifecycle from `tui.h`
 - `tui_show_menu()` from `tui_menu.h`
 - `tui_menu_config_t`, `tui_menu_item_t`, and `tui_menu_result_t`
-- documented pointer lifetime rules in `tui_menu.h`
-- separators, disabled items, mnemonics, search, numeric jumps, resize handling,
-  and interrupt handling
+- the pointer-lifetime rules documented in `tui_menu.h`
+- separators, disabled items, mnemonics, search, numeric jumps, resize handling, and interrupt handling
 
-Private or unstable surface:
+**Private:**
 
-- `tui_menu_internal.h`
-- `tui_menu_state_t` internals
+- `tui_menu_internal.h` and `tui_menu_state_t` internals
 - cell-by-cell rendering details
 - exact footer/help text inside the alternate screen
-- terminal test snapshots, except where a test names a specific invariant
+- terminal-test snapshots, except where a test names a specific invariant
 
-## Not Yet
+## Not yet
 
-Do not add a plugin API, stable ABI promise, headless service, or broad TUI
-framework until multiple generated projects need the same unsupported behavior.
-Prefer a CLI/spec addition or a small library function before any in-process
-extension system.
+Do not add a plugin API, stable ABI promise, headless service, or broad TUI framework until multiple generated projects need the same unsupported behavior. Prefer a CLI/spec addition or a small library function before any in-process extension system.
+
+## See also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) - where these seams sit in the codebase
+- [TESTING.md](TESTING.md) - the tests that enforce the CLI contract

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,6 +1,10 @@
 # Public Contracts
 
-This template is an opinionated reference app built on two reusable seams: a machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a stability promise. The surfaces listed as *supported* are safe to build automation or downstream code on; everything else (help wording, colors, file layout, internal helpers) can change without notice.
+This template is an opinionated reference app built on two reusable seams: a
+machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a
+stability promise. The surfaces listed as *supported* are safe to build automation or
+downstream code on; everything else (help wording, colors, file layout, internal
+helpers) can change without notice.
 
 Keep mechanism in these seams. Keep local workflow policy in the generated app.
 
@@ -75,7 +79,9 @@ zig-out/include/c23-cli-template/tui/tui_progress.h
 
 ## Not yet
 
-Do not add a plugin API, stable ABI promise, headless service, or broad TUI framework until multiple generated projects need the same unsupported behavior. Prefer a CLI/spec addition or a small library function before any in-process extension system.
+Do not add a plugin API, stable ABI promise, headless service, or broad TUI framework
+until multiple generated projects need the same unsupported behavior. Prefer a CLI/spec
+addition or a small library function before any in-process extension system.
 
 ## See also
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,6 +1,6 @@
 # Public Contracts
 
-This template is an opinionated reference app built on two reusable seams: a machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a stability promise — the surfaces listed as *supported* are safe to build automation or downstream code on; everything else (help wording, colors, file layout, internal helpers) can change without notice.
+This template is an opinionated reference app built on two reusable seams: a machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a stability promise. The surfaces listed as *supported* are safe to build automation or downstream code on; everything else (help wording, colors, file layout, internal helpers) can change without notice.
 
 Keep mechanism in these seams. Keep local workflow policy in the generated app.
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -2,21 +2,21 @@
 
 ## Maintainers
 
-- Sam Joyce (@sammyjoyce) - Creator and maintainer
+- Sam Joyce ([@sammyjoyce](https://github.com/sammyjoyce)) - creator and maintainer
 
 ## Contributors
 
-<!-- Add contributors here -->
+<!-- Add yourself here when you contribute. -->
 
 ## Acknowledgements
 
-This project was made possible by the open source community and the following projects:
+This template builds on the work of:
 
-- [Zig](https://ziglang.org/) - The Zig programming language
-- [ncurses](https://invisible-island.net/ncurses/) - Terminal UI library
-- [PDCurses](https://pdcurses.org/) - Curses implementation for Windows
-- [GitHub Actions](https://github.com/features/actions) - CI/CD platform
-- [markdownlint](https://github.com/DavidAnson/markdownlint) - Markdown linting
-- [Devcontainers](https://containers.dev/) - Development containers
+- [Zig](https://ziglang.org/) - build system and bundled C compiler
+- [ncurses](https://invisible-island.net/ncurses/) and [PDCurses](https://pdcurses.org/) - terminal UI primitives
+- [libghostty-vt](https://libghostty.tip.ghostty.org/index.html) - terminal emulation for the PTY/TUI tests
+- [GitHub Actions](https://github.com/features/actions) - CI/CD
+- [markdownlint](https://github.com/DavidAnson/markdownlint) - documentation linting
+- [Dev Containers](https://containers.dev/) - reproducible development environments
 
-For information on how to contribute, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to get involved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,18 @@
 # Documentation
 
-This directory contains project documentation.
+Developer documentation for working on a project generated from this template. Start here, then jump to the guide that matches your task.
 
-## Structure
+| Guide | Read it when you want to… |
+| --- | --- |
+| [Architecture Overview](ARCHITECTURE.md) | Understand how the modules fit together and where to add code |
+| [Zig Primer for C Developers](ZIG_PRIMER.md) | Drive the Zig build system with no prior Zig experience |
+| [Testing CLI and TUI Behavior](TESTING.md) | Write and run the CLI contract and PTY/TUI scenario tests |
+| [Public Contracts](CONTRACTS.md) | Know which CLI and TUI seams are stable to build on |
+| [Contributors](CONTRIBUTORS.md) | See maintainers, acknowledgements, and how to contribute |
 
-- API documentation
-- User guides
-- Developer documentation
-- Testing guides
-- Architecture decisions
+## Elsewhere in the repo
 
-## Guides
-
-- [Architecture Overview](ARCHITECTURE.md)
-- [Public Contracts](CONTRACTS.md)
-- [Testing CLI And TUI Behavior](TESTING.md)
-- [Zig Primer For C Developers](ZIG_PRIMER.md)
-
-Documentation will be added as the project develops.
+- [README](../README.md) - project overview and quick start
+- [CONTRIBUTING](../CONTRIBUTING.md) - workflow, branch, and commit conventions
+- [examples/](../examples/) - task-focused how-tos: add a command, build a TUI, scripting
+- [Using This Template](../.template/TEMPLATE_USAGE.md) - first-run setup for a freshly generated repo

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,70 +1,44 @@
-# Testing CLI And TUI Behavior
+# Testing CLI and TUI Behavior
 
-This template includes two test layers so projects can test both ordinary CLI commands and interactive terminal UI flows.
+The template ships three test layers so a generated project can cover ordinary command behavior and interactive terminal UI flows from day one.
 
-## Tooling Direction
-
-The terminal-testing landscape has a few useful families:
-
-| Tool family | Examples | Strengths | Tradeoffs |
+| Layer | How it runs | What it asserts | Lives in |
 | --- | --- | --- | --- |
-| Recording/rendering | `evp`, VHS | Great for docs, demos, and visual regression artifacts | Optimized for recordings, not assertions as the primary workflow |
-| Headless terminal daemons/CLIs | `headless-terminal`, Phantom, Termscope | Real PTY plus parsed terminal screen, good waits, screenshots, sometimes cell/style data | Newer tools, often not packaged everywhere, may add daemon/build complexity |
-| Library-first test drivers | Bombadil terminal experiments, Termless, `tui-driver`, `ptytest` | Nice assertion APIs inside host-language tests | Often tied to a specific host-language ecosystem |
-| Classic command tests | Cram, Bats, Expect | Mature and easy to run in CI | Raw output matching can miss alternate-screen/cursor details |
+| Unit tests | In-process, linked against the real sources | Logic inside `config`, `error`, `tui_menu_model`, and other modules | `test/unit_*.c` |
+| CLI contract tests | The built binary as a subprocess | Exit codes, JSON fields, durable output, `myapp opencli` matching `opencli.json` | `test/cli_contract_*.c` |
+| PTY/TUI scenarios | The binary in a real PTY via libghostty-vt | Rendered screen snapshots, input and resize handling | `test/terminal_vt_*.c` |
 
-The template now has one optional PTY terminal backend:
+The first two run everywhere with no extra dependencies. The third needs libghostty-vt and is optional.
 
-- The **Ghostty VT backend** is a C runner split across `test/terminal_vt_*.c`.
-  It owns PTY/TUI scenario coverage when libghostty-vt is available. It runs the
-  app in a real PTY, feeds output through
-  [`libghostty-vt`](https://libghostty.tip.ghostty.org/index.html), snapshots the
-  virtual terminal with Ghostty's formatter API, and drives deterministic input
-  plus resize sequences. This follows the same shape as the Bombadil terminal
-  experiment, but keeps the implementation in C and uses Ghostty's C API rather
-  than Rust wrappers.
-
-`zig build terminal-test` uses `-Dterminal-backend=auto` by default: auto selects
-Ghostty VT when `pkg-config` can find libghostty-vt and its headers expose the
-Terminal and Formatter APIs. Use `-Dterminal-backend=ghostty` to require Ghostty
-VT on POSIX hosts. CLI contracts run through a C23 test executable on every
-host, so machines without libghostty-vt still exercise non-interactive behavior
-without a fallback scripting runtime.
-
-## Commands
-
-Fast C23 CLI contract tests:
+## Running the tests
 
 ```bash
-zig build test
+zig build unit-test       # just the in-process unit tests
+zig build test            # unit tests + CLI contract tests
+zig build terminal-test   # the above, plus PTY/TUI scenarios when available
+zig build check           # fmt-check + tests (the gate CI runs)
 ```
 
-End-to-end terminal scenario tests:
-
-```bash
-zig build terminal-test
-```
-
-TUI-enabled terminal scenarios:
+PTY/TUI scenarios only run when the TUI is built and a terminal backend is present:
 
 ```bash
 zig build -Denable-tui=true terminal-test
 ```
 
-If you use the Nix dev shell, the required Zig and C tooling plus nixpkgs
-`libghostty-vt` are already wired into `PATH` and `pkg-config`:
+## The Ghostty VT backend
+
+`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the Ghostty VT backend when `pkg-config` finds libghostty-vt and its headers expose the Terminal and Formatter APIs. The backend is a C runner (`test/terminal_vt_*.c`) that runs the app in a real PTY, feeds output through [`libghostty-vt`](https://libghostty.tip.ghostty.org/index.html), snapshots the virtual terminal with Ghostty's formatter API, and drives deterministic input and resize sequences.
+
+Use `-Dterminal-backend=ghostty` to *require* it on POSIX hosts (the build fails if libghostty-vt is missing). Without the backend, `zig build terminal-test` still runs the unit and CLI contract suites and skips PTY/TUI coverage.
+
+The Nix dev shell wires Zig, the C toolchain, and nixpkgs `libghostty-vt` into `PATH` and `pkg-config`:
 
 ```bash
 nix develop
 zig build -Denable-tui=true terminal-test
 ```
 
-Outside Nix, install a libghostty-vt build with the development
-[Terminal](https://libghostty.tip.ghostty.org/group__terminal.html) and
-[Formatter](https://libghostty.tip.ghostty.org/group__formatter.html) APIs so
-`pkg-config` can find `libghostty-vt.pc`.
-
-If libghostty-vt is installed outside a standard linker path, pass its prefix:
+Outside Nix, install a libghostty-vt build that exposes the development [Terminal](https://libghostty.tip.ghostty.org/group__terminal.html) and [Formatter](https://libghostty.tip.ghostty.org/group__formatter.html) APIs so `pkg-config` can find `libghostty-vt.pc`. If it lives outside a standard path, pass its prefix:
 
 ```bash
 zig build -Denable-tui=true terminal-test \
@@ -72,59 +46,46 @@ zig build -Denable-tui=true terminal-test \
   -Dghostty-vt-prefix=/path/to/ghostty
 ```
 
-CLI scenarios run through `test/cli_contract_runner.c` on every backend. With
-Ghostty VT selected, the C backend adds PTY/TUI coverage using libghostty-vt.
-Without Ghostty VT, `zig build terminal-test` still runs the C23 CLI contract
-suite and skips PTY/TUI coverage unless `-Dterminal-backend=ghostty` was
-requested.
+## Writing unit tests
 
-CI runs non-interactive terminal scenarios on Linux, macOS, and Windows through
-`zig build check`; these CLI contracts live in `test/cli_contract_runner.c` and run
-regardless of whether Ghostty is installed. Linux CI builds libghostty-vt from
-the Ghostty flake, then runs
-`zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test` after the
-TUI build so PTY-backed TUI coverage is required there. macOS and Windows still
-build the TUI binary and run the `--json info` smoke check, but they do not run
-PTY-backed scenarios by default.
+Unit tests link a subset of the production sources directly, so they exercise modules like `core/config.c`, `core/error.c`, and `tui/tui_menu_model.c` without spawning a process. Add cases to `test/unit_config_tests.c` or `test/unit_tui_menu_tests.c` (or a new file registered in the `unit-test` sources in `build.zig`), then run `zig build unit-test`.
 
-## Writing CLI Scenario Tests
+Reach for a unit test when you can call a function and check its result directly. Reach for a CLI contract test when the behavior is only observable from the outside (exit code, stdout, JSON).
 
-Add durable CLI contract checks to `test/cli_contract_runner.c`. The Ghostty C
-runner is intentionally scoped to PTY/TUI behavior so CLI contracts have one
-source of truth.
+## Writing CLI scenario tests
+
+Add cases to `test/cli_contract_cases.c`; the runner in `test/cli_contract_runner.c` executes them against the built binary. Keep the CLI suite the single source of truth for non-interactive behavior — the Ghostty runner is scoped to PTY/TUI only.
 
 Prefer stable contracts over incidental prose:
 
 - Assert exit status.
 - Assert JSON fields for automation-facing commands.
 - Keep `myapp opencli` byte-for-byte aligned with `opencli.json`.
-- Keep human-output assertions focused on durable words, not full paragraphs.
-- Use `NO_COLOR=1` or `--plain` when colors are not under test.
+- Match durable words, not whole paragraphs.
+- Use `NO_COLOR=1` or `--plain` when color is not under test.
 
-## Writing TUI Scenario Tests
+## Writing TUI scenario tests
 
-The Ghostty VT backend currently has fixed C scenarios for the template's demo
-menu, including a deterministic input/resize smoke test. Add project-specific
-Ghostty scenarios in `test/terminal_vt_scenarios.c` when you need cell-accurate
-screen snapshots or resize coverage.
+The Ghostty VT backend has fixed C scenarios for the demo menu, including a deterministic input/resize smoke test. Add project-specific scenarios in `test/terminal_vt_scenarios.c` when you need cell-accurate screen snapshots or resize coverage.
 
-Keep PTY-backed TUI scenarios in `test/terminal_vt_scenarios.c`. Prefer small
-step tables (`expect`, `send`, `resize`, `wait`) over long branch ladders so new
-screens do not require a second harness.
+Prefer small step tables (`expect`, `send`, `resize`, `wait`) over long branch ladders, so a new screen does not require a second harness.
 
-## When To Reach For A Richer Tool
+## What CI runs
 
-Keep the built-in Ghostty VT runner for most project tests. It already gives you
-a real PTY, modern VT parsing, formatter-backed snapshots, scrollback support,
-and terminal resize coverage without adding a daemon or Rust wrapper.
+CI runs `zig build check` on Linux, macOS, and Windows, so the unit and CLI contract suites are enforced on every platform. Linux additionally builds libghostty-vt from the Ghostty flake and runs `zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test`, making PTY-backed TUI coverage a required gate there. macOS and Windows build the TUI binary and run the `--json info` smoke check, but do not run PTY scenarios by default.
 
-Consider an adapter around `headless-terminal`, Phantom, Termscope, Termless, or
-an external fuzzer when you need one of these:
+## Choosing a richer tool
 
-- PNG/SVG screenshots as review artifacts.
-- Cell-level color/style assertions beyond plain text snapshots.
-- Cross-emulator compatibility checks.
-- Detached sessions that a human or agent can watch live.
-- Long-running property-based exploration with many randomized action sequences.
+The built-in Ghostty VT runner covers most project needs: a real PTY, modern VT parsing, formatter-backed snapshots, scrollback, and resize coverage, with no daemon or Rust wrapper. Keep it as the default.
 
-Those are valuable capabilities, but they are heavier than most template users need on day one.
+Consider an adapter around an external tool when you need something it does not provide:
+
+| You need… | Look at |
+| --- | --- |
+| PNG/SVG screenshots as review artifacts | recording tools like `evp`, VHS |
+| Cell-level color/style assertions | `headless-terminal`, Phantom, Termscope |
+| Cross-emulator compatibility checks | the same headless terminal CLIs |
+| Detached sessions a human or agent can watch live | Phantom, Termscope |
+| Property-based exploration of many input sequences | an external fuzzer over the PTY |
+
+These are heavier than most template users need on day one, which is why they are not wired in by default.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,7 +54,7 @@ Reach for a unit test when you can call a function and check its result directly
 
 ## Writing CLI scenario tests
 
-Add cases to `test/cli_contract_cases.c`; the runner in `test/cli_contract_runner.c` executes them against the built binary. Keep the CLI suite the single source of truth for non-interactive behavior — the Ghostty runner is scoped to PTY/TUI only.
+Add cases to `test/cli_contract_cases.c`; the runner in `test/cli_contract_runner.c` executes them against the built binary. Keep the CLI suite the single source of truth for non-interactive behavior; the Ghostty runner is scoped to PTY/TUI only.
 
 Prefer stable contracts over incidental prose:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,9 +27,17 @@ zig build -Denable-tui=true terminal-test
 
 ## The Ghostty VT backend
 
-`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the Ghostty VT backend when `pkg-config` finds libghostty-vt and its headers expose the Terminal and Formatter APIs. The backend is a C runner (`test/terminal_vt_*.c`) that runs the app in a real PTY, feeds output through [`libghostty-vt`](https://libghostty.tip.ghostty.org/index.html), snapshots the virtual terminal with Ghostty's formatter API, and drives deterministic input and resize sequences.
+`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the
+Ghostty VT backend when `pkg-config` finds libghostty-vt and its headers expose the
+Terminal and Formatter APIs. The backend is a C runner (`test/terminal_vt_*.c`) that
+runs the app in a real PTY, feeds output through
+[`libghostty-vt`](https://libghostty.tip.ghostty.org/index.html), snapshots the virtual
+terminal with Ghostty's formatter API, and drives deterministic input and resize
+sequences.
 
-Use `-Dterminal-backend=ghostty` to *require* it on POSIX hosts (the build fails if libghostty-vt is missing). Without the backend, `zig build terminal-test` still runs the unit and CLI contract suites and skips PTY/TUI coverage.
+Use `-Dterminal-backend=ghostty` to *require* it on POSIX hosts (the build fails if
+libghostty-vt is missing). Without the backend, `zig build terminal-test` still runs the
+unit and CLI contract suites and skips PTY/TUI coverage.
 
 The Nix dev shell wires Zig, the C toolchain, and nixpkgs `libghostty-vt` into `PATH` and `pkg-config`:
 
@@ -38,7 +46,11 @@ nix develop
 zig build -Denable-tui=true terminal-test
 ```
 
-Outside Nix, install a libghostty-vt build that exposes the development [Terminal](https://libghostty.tip.ghostty.org/group__terminal.html) and [Formatter](https://libghostty.tip.ghostty.org/group__formatter.html) APIs so `pkg-config` can find `libghostty-vt.pc`. If it lives outside a standard path, pass its prefix:
+Outside Nix, install a libghostty-vt build that exposes the development
+[Terminal](https://libghostty.tip.ghostty.org/group__terminal.html) and
+[Formatter](https://libghostty.tip.ghostty.org/group__formatter.html) APIs so
+`pkg-config` can find `libghostty-vt.pc`. If it lives outside a standard path, pass its
+prefix:
 
 ```bash
 zig build -Denable-tui=true terminal-test \
@@ -48,13 +60,19 @@ zig build -Denable-tui=true terminal-test \
 
 ## Writing unit tests
 
-Unit tests link a subset of the production sources directly, so they exercise modules like `core/config.c`, `core/error.c`, and `tui/tui_menu_model.c` without spawning a process. Add cases to `test/unit_config_tests.c` or `test/unit_tui_menu_tests.c` (or a new file registered in the `unit-test` sources in `build.zig`), then run `zig build unit-test`.
+Unit tests link a subset of the production sources directly, so they exercise modules
+like `core/config.c`, `core/error.c`, and `tui/tui_menu_model.c` without spawning a
+process. Add cases to `test/unit_config_tests.c` or `test/unit_tui_menu_tests.c` (or a
+new file registered in the `unit-test` sources in `build.zig`), then run `zig build
+unit-test`.
 
 Reach for a unit test when you can call a function and check its result directly. Reach for a CLI contract test when the behavior is only observable from the outside (exit code, stdout, JSON).
 
 ## Writing CLI scenario tests
 
-Add cases to `test/cli_contract_cases.c`; the runner in `test/cli_contract_runner.c` executes them against the built binary. Keep the CLI suite the single source of truth for non-interactive behavior; the Ghostty runner is scoped to PTY/TUI only.
+Add cases to `test/cli_contract_cases.c`; the runner in `test/cli_contract_runner.c`
+executes them against the built binary. Keep the CLI suite the single source of truth
+for non-interactive behavior; the Ghostty runner is scoped to PTY/TUI only.
 
 Prefer stable contracts over incidental prose:
 
@@ -66,13 +84,21 @@ Prefer stable contracts over incidental prose:
 
 ## Writing TUI scenario tests
 
-The Ghostty VT backend has fixed C scenarios for the demo menu, including a deterministic input/resize smoke test. Add project-specific scenarios in `test/terminal_vt_scenarios.c` when you need cell-accurate screen snapshots or resize coverage.
+The Ghostty VT backend has fixed C scenarios for the demo menu, including a
+deterministic input/resize smoke test. Add project-specific scenarios in
+`test/terminal_vt_scenarios.c` when you need cell-accurate screen snapshots or resize
+coverage.
 
 Prefer small step tables (`expect`, `send`, `resize`, `wait`) over long branch ladders, so a new screen does not require a second harness.
 
 ## What CI runs
 
-CI runs `zig build check` on Linux, macOS, and Windows, so the unit and CLI contract suites are enforced on every platform. Linux additionally builds libghostty-vt from the Ghostty flake and runs `zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test`, making PTY-backed TUI coverage a required gate there. macOS and Windows build the TUI binary and run the `--json info` smoke check, but do not run PTY scenarios by default.
+CI runs `zig build check` on Linux, macOS, and Windows, so the unit and CLI contract
+suites are enforced on every platform. Linux additionally builds libghostty-vt from the
+Ghostty flake and runs `zig build -Denable-tui=true -Dterminal-backend=ghostty
+terminal-test`, making PTY-backed TUI coverage a required gate there. macOS and Windows
+build the TUI binary and run the `--json info` smoke check, but do not run PTY
+scenarios by default.
 
 ## Choosing a richer tool
 

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -82,10 +82,11 @@ pub fn build(b: *std.Build) void {
             },
             .flags = &base_flags,
         });
-        if (target.result.os.tag == .windows)
-            exe.root_module.linkSystemLibrary("pdcurses", .{})
-        else
+        if (target.result.os.tag == .windows) {
+            exe.root_module.linkSystemLibrary("pdcurses", .{});
+        } else {
             exe.root_module.linkSystemLibrary("ncursesw", .{});
+        }
     }
 
     b.installArtifact(exe);

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -28,7 +28,7 @@ commands and the `build.zig` structure you will actually touch.
 zig build                         # build + install the binary to zig-out/bin/
 zig build run -- hello Alice      # build, then run with arguments after --
 zig build test                    # CLI contract tests + in-process unit tests
-zig build -Doptimize=ReleaseSafe  # optimized build with safety checks
+zig build -Doptimize=ReleaseSafe  # optimized build
 zig build -Denable-tui=true run -- menu   # build with the TUI and open the demo menu
 ```
 
@@ -106,7 +106,7 @@ Pass these as `-D<name>=<value>` on any `zig build` command.
 
 | Option | Values (default) | Effect |
 | --- | --- | --- |
-| `-Doptimize=` | `Debug` (default), `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall` | Optimization and runtime-safety level |
+| `-Doptimize=` | `Debug` (default), `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall` | C optimization level (no Zig runtime is linked into this C-only binary) |
 | `-Dtarget=` | e.g. `x86_64-windows`, `aarch64-macos` | Cross-compile target |
 | `-Denable-tui=` | `true` / `false` (default `false`) | Compile the ncurses TUI and link curses |
 | `-Dapp-name=` | string (default `myapp`) | Application and binary name |

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -34,7 +34,7 @@ A `justfile` wraps the common ones if you prefer: `just build`, `just check`, `j
 
 ## How this build.zig is organized
 
-The script builds **one executable from a list of C files** — there is no Zig source in the binary. This excerpt is simplified from the real `build.zig`; open that file for the full source list and flag handling.
+The script builds **one executable from a list of C files.** There is no Zig source in the binary. This excerpt is simplified from the real `build.zig`; open that file for the full source list and flag handling.
 
 ```zig
 const std = @import("std");
@@ -184,15 +184,15 @@ b.installArtifact(exe);
 
 ## Troubleshooting
 
-**`zig: command not found`** — install Zig 0.16.0. The simplest route is [zvm](https://github.com/tristanisham/zvm): `zvm install 0.16.0 && zvm use 0.16.0`.
+**`zig: command not found`**. Install Zig 0.16.0. The simplest route is [zvm](https://github.com/tristanisham/zvm): `zvm install 0.16.0 && zvm use 0.16.0`.
 
-**ncurses/PDCurses headers or library not found** — only happens with `-Denable-tui=true`. Install the dev package (`apt install libncurses-dev`, `brew install ncurses`, `dnf install ncurses-devel`), or point at a custom install with `-Dcurses-prefix=/path`.
+**ncurses/PDCurses headers or library not found.** Only happens with `-Denable-tui=true`. Install the dev package (`apt install libncurses-dev`, `brew install ncurses`, `dnf install ncurses-devel`), or point at a custom install with `-Dcurses-prefix=/path`.
 
-**libghostty-vt not found for terminal tests** — the PTY/TUI backend is optional. See [TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build test` and the CLI portion of `terminal-test` still run.
+**libghostty-vt not found for terminal tests.** The PTY/TUI backend is optional. See [TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build test` and the CLI portion of `terminal-test` still run.
 
-**Stale build** — `zig build clean` removes `zig-out` and `.zig-cache`. (Equivalent: `rm -rf zig-out .zig-cache`.)
+**Stale build.** `zig build clean` removes `zig-out` and `.zig-cache`. (Equivalent: `rm -rf zig-out .zig-cache`.)
 
-**Need to see what the compiler is doing** — `zig build --verbose` shows commands; `zig build --verbose-cc` shows the C compiler invocations.
+**Need to see what the compiler is doing.** `zig build --verbose` shows commands; `zig build --verbose-cc` shows the C compiler invocations.
 
 ## A real custom build step
 

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -1,6 +1,8 @@
 # Zig Primer for C Developers
 
-You do not need to know Zig to work on this project. Zig is only the build system: it replaces Make or CMake, and it bundles the C compiler. This guide covers the handful of commands and the `build.zig` structure you will actually touch.
+You do not need to know Zig to work on this project. Zig is only the build system: it
+replaces Make or CMake, and it bundles the C compiler. This guide covers the handful of
+commands and the `build.zig` structure you will actually touch.
 
 - [Why Zig here?](#why-zig-here)
 - [The commands you actually need](#the-commands-you-actually-need)
@@ -34,7 +36,9 @@ A `justfile` wraps the common ones if you prefer: `just build`, `just check`, `j
 
 ## How this build.zig is organized
 
-The script builds **one executable from a list of C files.** There is no Zig source in the binary. This excerpt is simplified from the real `build.zig`; open that file for the full source list and flag handling.
+The script builds **one executable from a list of C files.** There is no Zig source in
+the binary. This excerpt is simplified from the real `build.zig`; open that file for
+the full source list and flag handling.
 
 ```zig
 const std = @import("std");
@@ -69,7 +73,13 @@ pub fn build(b: *std.Build) void {
 
     if (enable_tui) {
         exe.root_module.addCSourceFiles(.{
-            .files = &.{ "src/tui/tui.c", "src/tui/tui_menu.c", "src/tui/tui_progress.c" },
+            .files = &.{
+                "src/tui/tui.c",
+                "src/tui/tui_app.c",
+                "src/tui/tui_menu.c",
+                "src/tui/tui_menu_model.c",
+                "src/tui/tui_progress.c",
+            },
             .flags = &base_flags,
         });
         if (target.result.os.tag == .windows)
@@ -186,9 +196,14 @@ b.installArtifact(exe);
 
 **`zig: command not found`**. Install Zig 0.16.0. The simplest route is [zvm](https://github.com/tristanisham/zvm): `zvm install 0.16.0 && zvm use 0.16.0`.
 
-**ncurses/PDCurses headers or library not found.** Only happens with `-Denable-tui=true`. Install the dev package (`apt install libncurses-dev`, `brew install ncurses`, `dnf install ncurses-devel`), or point at a custom install with `-Dcurses-prefix=/path`.
+**ncurses/PDCurses headers or library not found.** Only happens with
+`-Denable-tui=true`. Install the dev package (`apt install libncurses-dev`, `brew
+install ncurses`, `dnf install ncurses-devel`), or point at a custom install with
+`-Dcurses-prefix=/path`.
 
-**libghostty-vt not found for terminal tests.** The PTY/TUI backend is optional. See [TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build test` and the CLI portion of `terminal-test` still run.
+**libghostty-vt not found for terminal tests.** The PTY/TUI backend is optional. See
+[TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build
+test` and the CLI portion of `terminal-test` still run.
 
 **Stale build.** `zig build clean` removes `zig-out` and `.zig-cache`. (Equivalent: `rm -rf zig-out .zig-cache`.)
 

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -1,254 +1,170 @@
 # Zig Primer for C Developers
 
-This guide helps C developers understand how Zig is used as the build system for this C23 project.
+You do not need to know Zig to work on this project. Zig is only the build system: it replaces Make or CMake, and it bundles the C compiler. This guide covers the handful of commands and the `build.zig` structure you will actually touch.
 
-## Table of Contents
-
-- [Why Zig for a C Project?](#why-zig-for-a-c-project)
-- [Zig as a C Compiler](#zig-as-a-c-compiler)
-- [Understanding build.zig](#understanding-buildzig)
-- [Understanding build.zig.zon](#understanding-buildzigzon)
-- [Common Build Tasks](#common-build-tasks)
-- [Zig vs Make/CMake](#zig-vs-makecmake)
+- [Why Zig here?](#why-zig-here)
+- [The commands you actually need](#the-commands-you-actually-need)
+- [How this build.zig is organized](#how-this-buildzig-is-organized)
+- [Build options](#build-options)
+- [Build steps](#build-steps)
+- [Adding a C file](#adding-a-c-file)
+- [Cross-compiling](#cross-compiling)
+- [Zig vs Make and CMake](#zig-vs-make-and-cmake)
 - [Troubleshooting](#troubleshooting)
+- [Resources](#resources)
 
-## Why Zig for a C Project?
+## Why Zig here?
 
-Zig provides several advantages as a build system for C projects:
+- **One toolchain, every target.** `zig cc` bundles Clang/LLVM plus the headers and libc for every platform, so cross-compilation is a flag, not a second toolchain.
+- **The build script is just code.** `build.zig` is Zig, not a bespoke macro language, so logic like "only compile the TUI when a flag is set" is an ordinary `if`.
+- **Caching and parallelism are automatic.** Incremental rebuilds and parallel compilation come for free.
+- **It is still your C.** The sources are C23. Zig compiles and links them; it does not change how you write them.
 
-1. **Cross-compilation out of the box** - No need for separate toolchains
-2. **Built-in C compiler** - Zig bundles Clang/LLVM
-3. **Dependency management** - Via build.zig.zon
-4. **Caching** - Intelligent incremental builds
-5. **No separate build language** - Build scripts are written in Zig
-
-## Zig as a C Compiler
-
-Zig can compile C code directly:
+## The commands you actually need
 
 ```bash
-# Compile a C file
-zig cc hello.c -o hello
-
-# With C23 standard
-zig cc -std=c23 hello.c -o hello
-
-# Cross-compile for Windows from Linux
-zig cc -target x86_64-windows hello.c -o hello.exe
+zig build                         # build + install the binary to zig-out/bin/
+zig build run -- hello Alice      # build, then run with arguments after --
+zig build test                    # CLI contract tests + in-process unit tests
+zig build -Doptimize=ReleaseSafe  # optimized build with safety checks
+zig build -Denable-tui=true run -- menu   # build with the TUI and open the demo menu
 ```
 
-### Zig CC vs GCC/Clang
+A `justfile` wraps the common ones if you prefer: `just build`, `just check`, `just test-fast`, `just clean`. Run `just help` to list them.
 
-| Feature | Zig CC | GCC/Clang |
-|---------|--------|-----------|
-| Cross-compilation | Built-in | Requires separate toolchains |
-| C23 Support | Yes (via LLVM) | Yes |
-| Optimization | -O0 to -O3 | -O0 to -O3 |
-| Debug Info | -g | -g |
-| Static Analysis | Basic | Extensive |
+## How this build.zig is organized
 
-## Understanding build.zig
-
-The `build.zig` file is like a `Makefile` or `CMakeLists.txt`, but written in Zig:
+The script builds **one executable from a list of C files** — there is no Zig source in the binary. This excerpt is simplified from the real `build.zig`; open that file for the full source list and flag handling.
 
 ```zig
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    // Target and optimization options
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Create executable from C sources
+    const app_name = b.option([]const u8, "app-name", "Application and binary name") orelse "myapp";
+    const enable_tui = b.option(bool, "enable-tui", "Enable the ncurses/PDCurses TUI") orelse false;
+
     const exe = b.addExecutable(.{
-        .name = "myapp",
+        .name = app_name,
         .root_module = b.createModule(.{
-            .root_source_file = null,
+            .root_source_file = null, // a C program: no Zig root file
             .target = target,
             .optimize = optimize,
             .link_libc = true,
         }),
     });
+    exe.root_module.addIncludePath(b.path("src"));
 
-    // Add C source files
-    exe.root_module.addCSourceFiles(.{
-        .files = &.{
-            "src/main.c",
-            "src/cli/args.c",
-            "src/cli/help.c",
-            // ... more files
-        },
-        .flags = &.{
-            "-std=c23",
-            "-Wall",
-            "-Wextra",
-            "-pedantic",
-        },
-    });
+    const base_sources = [_][]const u8{
+        "src/main.c",
+        "src/core/config.c",
+        // ... full list lives in build.zig
+    };
+    // The real script also appends -DAPP_VERSION, -DAPP_NAME, -DAPP_GIT_COMMIT,
+    // and -DENABLE_TUI=1 (when enabled) to these flags.
+    const base_flags = [_][]const u8{ "-Wall", "-Wextra", "-std=c23", "-D_GNU_SOURCE" };
+    exe.root_module.addCSourceFiles(.{ .files = &base_sources, .flags = &base_flags });
 
-    // Link libraries
-    if (target.result.os.tag == .windows) {
-        exe.root_module.linkSystemLibrary("pdcurses", .{});
-    } else {
-        exe.root_module.linkSystemLibrary("ncursesw", .{});
+    if (enable_tui) {
+        exe.root_module.addCSourceFiles(.{
+            .files = &.{ "src/tui/tui.c", "src/tui/tui_menu.c", "src/tui/tui_progress.c" },
+            .flags = &base_flags,
+        });
+        if (target.result.os.tag == .windows)
+            exe.root_module.linkSystemLibrary("pdcurses", .{})
+        else
+            exe.root_module.linkSystemLibrary("ncursesw", .{});
     }
 
-    // Install the executable
     b.installArtifact(exe);
 }
 ```
 
-### Key Concepts
+The pieces to recognize:
 
-1. **Build Function**: The `pub fn build()` is the entry point
-2. **Build Object**: `b` provides all build functionality
-3. **Artifacts**: Executables, libraries, etc.
-4. **Steps**: Build tasks that can depend on each other
+- **`b`** is the build graph. You add artifacts (executables, libraries) and steps to it.
+- **`b.createModule`** with `root_source_file = null` and `link_libc = true` is how a C program is declared in modern Zig. Source files attach to `exe.root_module`, not to `exe` directly.
+- **`base_sources` / `base_flags`** are plain arrays. Adding a file means editing an array (see [Adding a C file](#adding-a-c-file)).
+- **`b.option(...)`** declares the `-D...` flags listed below.
 
-### Common Patterns
+## Build options
 
-```zig
-// Adding include directories
-exe.root_module.addIncludePath(b.path("src"));
-exe.root_module.addIncludePath(b.path("vendor/include"));
+Pass these as `-D<name>=<value>` on any `zig build` command.
 
-// Platform-specific code
-if (target.result.os.tag == .windows) {
-    c_flags.append(b.allocator, "-DPLATFORM_WINDOWS=1") catch @panic("OOM");
-} else if (target.result.os.tag == .linux) {
-    c_flags.append(b.allocator, "-DPLATFORM_LINUX=1") catch @panic("OOM");
-}
+| Option | Values (default) | Effect |
+| --- | --- | --- |
+| `-Doptimize=` | `Debug` (default), `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall` | Optimization and runtime-safety level |
+| `-Dtarget=` | e.g. `x86_64-windows`, `aarch64-macos` | Cross-compile target |
+| `-Denable-tui=` | `true` / `false` (default `false`) | Compile the ncurses TUI and link curses |
+| `-Dapp-name=` | string (default `myapp`) | Application and binary name |
+| `-Dversion=` | string (default `0.1.0`) | Version baked into the binary |
+| `-Dcurses-prefix=` | path | Override the ncurses/PDCurses install prefix |
+| `-Dterminal-backend=` | `auto` (default) / `ghostty` | Terminal-test backend; see [TESTING.md](TESTING.md) |
+| `-Dghostty-vt-prefix=` | path | Override the libghostty-vt install prefix |
 
-// Creating a test step
-const test_step = b.step("test", "Run tests");
-test_step.dependOn(&exe.step);
+## Build steps
 
-// Custom build options
-const enable_tui = b.option(bool, "enable-tui", "Enable TUI support with ncurses (default: false)") orelse false;
-if (enable_tui) {
-    c_flags.append(b.allocator, "-DENABLE_TUI=1") catch @panic("OOM");
-}
-```
+| Command | What it does |
+| --- | --- |
+| `zig build` | Build and install the binary (the default step) |
+| `zig build run -- ARGS` | Build, then run with `ARGS` |
+| `zig build test` | CLI contract tests plus in-process unit tests |
+| `zig build unit-test` | Only the in-process unit tests |
+| `zig build terminal-test` | CLI contracts plus PTY/TUI scenarios when a backend is available |
+| `zig build tui-menu-lib` | Build the reusable TUI menu static library and install its headers |
+| `zig build fmt` / `fmt-check` | Format, or check formatting of, `build.zig`, `src`, and `test` |
+| `zig build check` | Baseline gate: `fmt-check` + tests (what CI runs) |
+| `zig build clean` | Remove `zig-out` and `.zig-cache` |
 
-## Understanding build.zig.zon
+## Adding a C file
 
-The `build.zig.zon` file manages dependencies and project metadata:
-
-```zig
-.{
-    .name = .myapp,
-    .version = "0.1.0",
-    .fingerprint = 0x8798022a387365d7,
-
-    // Dependencies
-    .dependencies = .{
-        .some_lib = .{
-            .url = "https://github.com/user/lib/archive/abc123.tar.gz",
-            .hash = "1220abc...",
-        },
-    },
-
-    // Paths to include in package
-    .paths = .{
-        "build.zig",
-        "build.zig.zon",
-        "src",
-        "LICENSE",
-        "README.md",
-    },
-}
-```
-
-## Common Build Tasks
-
-### Basic Commands
-
-```bash
-# Build the project
-zig build
-
-# Build and run
-zig build run
-
-# Run tests
-zig build test
-
-# Build with optimizations
-zig build -Doptimize=ReleaseSafe
-
-# Cross-compile
-zig build -Dtarget=x86_64-windows
-
-# Install to custom prefix
-zig build install --prefix ~/.local
-
-# Clean build
-rm -rf zig-cache zig-out
-```
-
-### Build Modes
-
-| Mode | Flag | Description |
-|------|------|-------------|
-| Debug | (default) | No optimizations, debug info |
-| ReleaseSafe | `-Doptimize=ReleaseSafe` | Optimized, safety checks |
-| ReleaseFast | `-Doptimize=ReleaseFast` | Optimized, no safety |
-| ReleaseSmall | `-Doptimize=ReleaseSmall` | Size-optimized |
-
-### Adding New C Files
-
-1. Add the file to `exe.addCSourceFiles()` in `build.zig`:
+1. Drop the file under `src/`.
+2. Add its path to the `base_sources` array in `build.zig` (or `tui_sources` if it is TUI-only):
 
    ```zig
-   exe.addCSourceFiles(.{
-       .files = &.{
-           // existing files...
-           "src/new_module.c",
-       },
-       .flags = &.{ "-std=c23", "-Wall" },
-   });
+   const base_sources = [_][]const u8{
+       // ... existing files ...
+       "src/features/deploy.c",
+   };
    ```
 
-2. Rebuild:
+3. Rebuild with `zig build`. Headers are found automatically because `src/` is on the include path.
 
-   ```bash
-   zig build
-   ```
+## Cross-compiling
 
-## Zig vs Make/CMake
+```bash
+# Windows binary from any host
+zig build -Dtarget=x86_64-windows -Doptimize=ReleaseSafe
 
-### Comparison Table
-
-| Feature | Zig | Make | CMake |
-|---------|-----|------|-------|
-| Language | Zig | Make syntax | CMake script |
-| Cross-compilation | Built-in | Manual setup | Toolchain files |
-| Dependency management | build.zig.zon | None | FetchContent/ExternalProject |
-| IDE support | Growing | Excellent | Excellent |
-| Learning curve | Moderate | Low | High |
-| Platform detection | Automatic | Manual | Automatic |
-| Parallel builds | Automatic | make -j | Automatic |
-| Cache management | Automatic | Manual | Automatic |
-
-### Migration Examples
-
-#### Makefile To build.zig
-
-```makefile
-# Makefile
-CC = gcc
-CFLAGS = -std=c23 -Wall -O2
-LDFLAGS = -lncurses
-
-myapp: main.o args.o
-    $(CC) $(LDFLAGS) -o $@ $^
-
-%.o: %.c
-    $(CC) $(CFLAGS) -c -o $@ $<
+# Apple Silicon macOS binary
+zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSafe
 ```
 
+The default CLI cross-compiles with no extra setup. A cross **TUI** build (`-Denable-tui=true`) also needs the curses library for the target; point at it with `-Dcurses-prefix=`.
+
+## Zig vs Make and CMake
+
+| Concern | Zig | Make | CMake |
+| --- | --- | --- | --- |
+| Build language | Zig | Make syntax | CMake script |
+| Cross-compilation | Built in | Manual toolchains | Toolchain files |
+| Dependencies | `build.zig.zon` | None | FetchContent / ExternalProject |
+| Platform detection | Automatic | Manual | Automatic |
+| Caching and parallelism | Automatic | `make -j`, manual cache | Automatic |
+| Learning curve | Moderate | Low | High |
+
+A Makefile rule like this:
+
+```makefile
+myapp: main.c args.c
+	gcc -std=c23 -Wall -O2 -o $@ $^ -lncursesw
+```
+
+becomes, in `build.zig`:
+
 ```zig
-// build.zig equivalent
 const exe = b.addExecutable(.{
     .name = "myapp",
     .root_module = b.createModule(.{
@@ -268,126 +184,35 @@ b.installArtifact(exe);
 
 ## Troubleshooting
 
-### Common Issues
+**`zig: command not found`** — install Zig 0.16.0. The simplest route is [zvm](https://github.com/tristanisham/zvm): `zvm install 0.16.0 && zvm use 0.16.0`.
 
-1. **"Unable to find zig"**
+**ncurses/PDCurses headers or library not found** — only happens with `-Denable-tui=true`. Install the dev package (`apt install libncurses-dev`, `brew install ncurses`, `dnf install ncurses-devel`), or point at a custom install with `-Dcurses-prefix=/path`.
 
-   ```bash
-   # Install Zig from https://ziglang.org/download/
-   # Or use the setup script:
-   curl -sSf https://ziglang.org/download/index.json | jq -r '.["0.16.0"]."x86_64-linux".tarball'
-   ```
+**libghostty-vt not found for terminal tests** — the PTY/TUI backend is optional. See [TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build test` and the CLI portion of `terminal-test` still run.
 
-2. **"C header not found"**
+**Stale build** — `zig build clean` removes `zig-out` and `.zig-cache`. (Equivalent: `rm -rf zig-out .zig-cache`.)
 
-   ```zig
-   // Add include paths in build.zig
-   exe.addIncludePath(b.path("include"));
-   exe.addSystemIncludePath("/usr/local/include");
-   ```
+**Need to see what the compiler is doing** — `zig build --verbose` shows commands; `zig build --verbose-cc` shows the C compiler invocations.
 
-3. **"Undefined symbol"**
+## A real custom build step
 
-   ```zig
-   // Ensure libraries are linked
-   exe.linkSystemLibrary("m");  // math library
-   exe.linkSystemLibrary("pthread");  // threading
-   ```
-
-4. **Cache issues**
-
-   ```bash
-   # Clear cache
-   rm -rf zig-cache zig-out
-   # Rebuild
-   zig build
-   ```
-
-### Debug Build Issues
-
-```bash
-# Verbose build output
-zig build --verbose
-
-# Show compile commands
-zig build --verbose-cc
-
-# Keep temporary files
-zig build --verbose-link
-```
-
-### Platform-Specific Issues
-
-#### Windows
-
-- Ensure Visual Studio Build Tools or MinGW is installed
-- Use `zig cc` instead of `gcc` for better compatibility
-
-#### macOS
-
-- May need to install Xcode Command Line Tools
-- Use `exe.linkFramework("CoreFoundation")` for system frameworks
-
-#### Linux
-
-- Install development packages for TUI builds: `apt install libncurses-dev`
-- Check pkg-config: `pkg-config --libs ncurses`
-- Use `zig build -Denable-tui=true` when you want to compile the optional TUI.
-
-## Advanced Topics
-
-### Custom Build Steps
+Build logic is ordinary Zig, so `build.zig` can compute inputs. This project injects the current git hash as a `#define`, falling back to `"unknown"` outside a checkout:
 
 ```zig
-// Generate version header
-const version_step = b.addSystemCommand(&.{
-    "git", "describe", "--tags", "--always",
-});
-const version_header = version_step.captureStdOut();
-exe.addCSourceFiles(.{
-    .files = &.{"src/version.c"},
-    .flags = &.{"-DVERSION=\"" ++ version_header ++ "\""},
-});
+const git_commit = blk: {
+    const res = std.process.run(b.allocator, b.graph.io, .{
+        .argv = &.{ "git", "rev-parse", "--short", "HEAD" },
+    }) catch break :blk "unknown";
+    // ... verify exit status ...
+    break :blk b.dupe(std.mem.trim(u8, res.stdout, "\r\n"));
+};
+// added to the compile flags as: -DAPP_GIT_COMMIT="<hash>"
 ```
 
-### Conditional Compilation
-
-```zig
-// Feature flags
-const enable_feature = b.option(bool, "feature", "Enable feature") orelse false;
-if (enable_feature) {
-    exe.defineCMacro("ENABLE_FEATURE", null);
-    exe.addCSourceFile(.{
-        .file = b.path("src/feature.c"),
-        .flags = &.{"-std=c23"},
-    });
-}
-```
-
-### Testing C Code with Zig
-
-```zig
-// Create test executable
-const test_exe = b.addExecutable(.{
-    .name = "test_runner",
-    .target = target,
-});
-test_exe.addCSourceFiles(.{
-    .files = &.{
-        "test/test_main.c",
-        "test/test_utils.c",
-    },
-    .flags = &.{"-std=c23"},
-});
-
-const test_cmd = b.addRunArtifact(test_exe);
-const test_step = b.step("test", "Run tests");
-test_step.dependOn(&test_cmd.step);
-```
+`myapp info` then reports that hash. Use the same pattern for any value you want baked into the binary at build time.
 
 ## Resources
 
-- [Zig Language Reference](https://ziglang.org/documentation/0.16.0/)
+- [Zig 0.16.0 Language Reference](https://ziglang.org/documentation/0.16.0/)
 - [Zig Build System Guide](https://ziglang.org/learn/build-system/)
-- [Zig Discord](https://discord.gg/zig) - Active community for questions
-- [This Project's build.zig](../build.zig) - Real example to study
+- [This project's build.zig](../build.zig) - the real script, the best reference

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -33,7 +33,7 @@ myapp --json info
 
 <!-- ![Diagnostics](doctor.gif) -->
 
-`doctor` reports environment status and exits non-zero on failure.
+`doctor` reports environment status. The current implementation is informational and always exits `0`; use `--json` and parse the checks if you need a hard gate.
 
 ```bash
 myapp doctor
@@ -54,10 +54,9 @@ myapp opencli
 
 <!-- ![Error handling](error-handling.gif) -->
 
-A missing command, an unknown command (exit 2), and an unknown option (exit 7).
+An unknown command (exit 2) and an unknown option (exit 7).
 
 ```bash
-myapp
 myapp frobnicate
 myapp --unknown-option
 ```

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,153 +1,93 @@
 # Demo Gallery
 
-This directory contains animated demonstrations of the CLI application's features.
+Animated demonstrations of the CLI. The `.gif` files are not checked in — build the project and run `./scripts/create-demo.sh` to produce them locally, then uncomment the image lines below.
 
-> **Note**: To generate the actual demo GIFs, run `./scripts/create-demo.sh` after building the project.
+## Demos
 
-## Available Demos
+### Basic usage
 
-### Basic Usage
-<!-- ![Basic Usage Demo](basic-usage.gif) -->
-*Demo showing basic command-line usage including help, version, and simple commands.*
+<!-- ![Basic usage](basic-usage.gif) -->
+
+Help, version, and the `hello` / `echo` commands.
 
 ```bash
-# Show help
 myapp --help
-
-# Show version
 myapp --version
-
-# Run commands
 myapp hello
 myapp hello "Demo User"
-myapp echo "Test message"
+myapp echo "This is a test message"
 ```
 
-### Progress Bar
-<!-- ![Progress Bar Demo](progress-bar.gif) -->
-*Demo showing the TUI progress bar during long-running operations.*
+### Human and JSON output
+
+<!-- ![Output formats](json-output.gif) -->
+
+The same command in human-readable and `--json` form.
 
 ```bash
-# Show progress for a 10-step operation
-myapp progress --steps 10 --delay 500
+myapp info
+myapp --json info
 ```
 
-### Interactive Mode
-<!-- ![Interactive Mode Demo](interactive.gif) -->
-*Demo showing the interactive TUI mode for menu-driven operations.*
+### Diagnostics
 
-```
-┌─────────────────────────────────────┐
-│        MyApp Interactive Mode       │
-├─────────────────────────────────────┤
-│                                     │
-│  1. Process File                    │
-│  2. View Status                     │
-│  3. Configure Settings              │
-│  4. Exit                            │
-│                                     │
-│  Select option: _                   │
-│                                     │
-└─────────────────────────────────────┘
-```
+<!-- ![Diagnostics](doctor.gif) -->
 
-### Configuration Management
-<!-- ![Configuration Demo](configuration.gif) -->
-*Demo showing configuration management through the CLI.*
+`doctor` reports environment status and exits non-zero on failure.
 
 ```bash
-# Show configuration
-myapp config show
-
-# Set values
-myapp config set output.format json
-
-# Get specific values
-myapp config get output.format
-
-# Reset to defaults
-myapp config reset
+myapp doctor
+myapp --json doctor
 ```
 
-### Error Handling
-<!-- ![Error Handling Demo](error-handling.gif) -->
-*Demo showing graceful error handling and helpful error messages.*
+### OpenCLI contract
+
+<!-- ![Contract](contract.gif) -->
+
+The machine-readable CLI contract the binary prints on demand.
 
 ```bash
-# Non-existent file
-myapp process /tmp/nonexistent.txt
-
-# Invalid data
-myapp validate invalid-data.txt
-
-# Invalid options
-myapp --invalid-option
+myapp opencli
 ```
 
-## Creating Demo GIFs
+### Error handling
 
-To generate the actual animated GIFs:
+<!-- ![Error handling](error-handling.gif) -->
 
-1. **Install dependencies**:
-
-   ```bash
-   # Install asciinema with your OS package manager
-
-   # Install agg (asciinema gif generator)
-   cargo install --git https://github.com/asciinema/agg
-   ```
-
-2. **Build the project**:
-
-   ```bash
-   zig build
-   ```
-
-3. **Run the demo script**:
-
-   ```bash
-   ./scripts/create-demo.sh
-   ```
-
-This will create all the demo GIFs in this directory.
-
-## Manual Demo Recording
-
-To record a custom demo:
+A missing command, an unknown command (exit 2), and an unknown option (exit 7).
 
 ```bash
-# Start recording
-asciinema rec docs/demos/custom-demo.cast
-
-# Perform your demo actions
-myapp [commands...]
-
-# Stop recording (Ctrl+D)
-
-# Convert to GIF
-agg docs/demos/custom-demo.cast docs/demos/custom-demo.gif
+myapp
+myapp frobnicate
+myapp --unknown-option
 ```
 
-## Embedding Demos
+## Recording the interactive menu
 
-To embed these demos in documentation:
+The TUI menu needs a real terminal and live input, so record it by hand rather than through the script:
+
+```bash
+zig build -Denable-tui=true run -- menu           # try it first
+asciinema rec docs/demos/recordings/menu.cast     # then record a session
+# drive the menu, press q to quit, then Ctrl-D to stop recording
+agg docs/demos/recordings/menu.cast docs/demos/menu.gif
+```
+
+## Generating the GIFs
+
+```bash
+# Dependencies:
+#   asciinema  - install with your OS package manager
+#   agg        - cargo install --git https://github.com/asciinema/agg
+
+zig build
+./scripts/create-demo.sh
+```
+
+The script records each non-interactive demo above and writes the GIFs into this directory.
+
+## Embedding
 
 ```markdown
-![Demo Name](docs/demos/demo-name.gif)
+![Demo name](docs/demos/demo-name.gif)
 ```
-
-Or with HTML for more control:
-
-```html
-<p align="center">
-  <img src="docs/demos/demo-name.gif" alt="Demo Name" width="600">
-</p>
-```
-
-## Demo Best Practices
-
-1. **Keep demos short** - Under 30 seconds
-2. **Use clear titles** - Explain what's being demonstrated
-3. **Show realistic usage** - Use practical examples
-4. **Include errors** - Show how the app handles mistakes
-5. **Use consistent styling** - Same terminal theme and size

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,6 +1,6 @@
 # Demo Gallery
 
-Animated demonstrations of the CLI. The `.gif` files are not checked in — build the project and run `./scripts/create-demo.sh` to produce them locally, then uncomment the image lines below.
+Animated demonstrations of the CLI. The `.gif` files are not checked in. Build the project and run `./scripts/create-demo.sh` to produce them locally, then uncomment the image lines below.
 
 ## Demos
 

--- a/examples/adding-a-command.md
+++ b/examples/adding-a-command.md
@@ -159,4 +159,4 @@ The command now:
 - returns a meaningful exit code on error (`APP_ERROR_MISSING_ARG`)
 - is covered by a contract test
 
-Repeat the same pattern for any command. Commands that open the TUI set `.requires_terminal = true` — see [custom-tui.md](custom-tui.md).
+Repeat the same pattern for any command. Commands that open the TUI set `.requires_terminal = true`. See [custom-tui.md](custom-tui.md).

--- a/examples/adding-a-command.md
+++ b/examples/adding-a-command.md
@@ -8,22 +8,24 @@ Create a command translation unit, for example `src/cli/commands_greet.c`. Every
 
 ```c
 app_error app_cmd_greet(const app_config_t *config, int argc, char **argv) {
-    (void)config;
-
     if (argc == 0) {
         fprintf(stderr, "Error: greet command requires at least one name\n");
         return APP_ERROR_MISSING_ARG;
     }
 
-    printf("Greetings to:\n");
+    app_output("Greetings to:", config, false);
     for (int i = 0; i < argc; i++) {
-        printf("  - %s\n", argv[i]);
+        app_output_format(config, false, "  - %s", argv[i]);
     }
-
-    printf("\nHave a great day!\n");
+    app_output("", config, false);
+    app_output("Have a great day!", config, false);
     return APP_SUCCESS;
 }
 ```
+
+Use `app_output` for plain strings and `app_output_format` for printf-style output (see
+`src/cli/commands_basic.c` for the real `hello` and `echo` handlers). Both honour
+`--json`, `--quiet`, and color flags; `fprintf(stderr, …)` is fine for the error path.
 
 Add the new file to the `base_sources` array in `build.zig` so it is compiled (see [ZIG_PRIMER.md](../docs/ZIG_PRIMER.md#adding-a-c-file)).
 

--- a/examples/adding-a-command.md
+++ b/examples/adding-a-command.md
@@ -1,11 +1,10 @@
 # Example: Adding a New Command
 
-This example shows how to add a new `greet` command that greets multiple people.
+This example adds a `greet` command that greets one or more people. The same five steps work for any command, because dispatch, help, and the OpenCLI contract are all driven by one command table.
 
-## 1. Add the Command Handler
+## 1. Add the command handler
 
-Create a small command translation unit, for example
-`src/cli/commands_greet.c`:
+Create a command translation unit, for example `src/cli/commands_greet.c`. Every handler has the same signature: it takes the resolved config and the command's arguments, and returns an `app_error`.
 
 ```c
 app_error app_cmd_greet(const app_config_t *config, int argc, char **argv) {
@@ -18,7 +17,7 @@ app_error app_cmd_greet(const app_config_t *config, int argc, char **argv) {
 
     printf("Greetings to:\n");
     for (int i = 0; i < argc; i++) {
-        printf("  👋 %s\n", argv[i]);
+        printf("  - %s\n", argv[i]);
     }
 
     printf("\nHave a great day!\n");
@@ -26,11 +25,11 @@ app_error app_cmd_greet(const app_config_t *config, int argc, char **argv) {
 }
 ```
 
-## 2. Register Command Metadata
+Add the new file to the `base_sources` array in `build.zig` so it is compiled (see [ZIG_PRIMER.md](../docs/ZIG_PRIMER.md#adding-a-c-file)).
 
-Add the handler forward declaration, arguments, examples, and command row in
-`src/cli/commands.c`. The command table feeds dispatch, help, and the OpenCLI
-contract:
+## 2. Register command metadata
+
+Add the forward declaration, argument table, examples, and a command row to `g_app_commands` in `src/cli/commands.c`. This one table feeds dispatch, help text, and `myapp opencli`.
 
 ```c
 app_error app_cmd_greet(const app_config_t *config, int argc, char **argv);
@@ -64,10 +63,13 @@ static const app_command_t g_app_commands[] = {
 
 ## 3. Update opencli.json
 
-Run the live contract command and update `opencli.json` with the new command.
-`zig build test` fails if the checked-in spec drifts from the binary output.
+The contract is checked in, and `zig build test` fails if it drifts from the binary. Regenerate it from the live command:
 
-Your command should appear in the `commands` array like this:
+```bash
+zig build run -- opencli > opencli.json
+```
+
+Your command should now appear in the `commands` array:
 
 ```json
 {
@@ -93,9 +95,11 @@ Your command should appear in the `commands` array like this:
 }
 ```
 
-## 4. Add Tests
+(`APP_ARG_ARITY_UNBOUNDED` serializes as JSON `null`.)
 
-In `test/cli_contract_cases.c`, add a test for your command:
+## 4. Add tests
+
+Add a case to `test/cli_contract_cases.c` that covers the happy path and the error path:
 
 ```c
 static bool test_greet_command(test_context_t *ctx) {
@@ -130,36 +134,29 @@ static bool test_greet_command(test_context_t *ctx) {
 }
 ```
 
-Then register it in the `tests` array:
+Register it in the `tests` array:
 
 ```c
 {"greet command handles names", test_greet_command},
 ```
 
-## 5. Build and Test
+See [TESTING.md](../docs/TESTING.md) for the difference between contract tests and unit tests.
+
+## 5. Build and test
 
 ```bash
-# Build
-zig build
-
-# Run tests
-zig build test
-
-# Confirm the live OpenCLI contract matches opencli.json
-./zig-out/bin/myapp opencli
-
-# Try your new command
+zig build                                  # build
+zig build test                             # run the suite (fails if opencli.json drifted)
 ./zig-out/bin/myapp greet Alice Bob Charlie
 ```
 
-## Result
+## What you get
 
-You've successfully added a new command that:
+The command now:
 
-- ✅ Accepts multiple arguments
-- ✅ Validates input
-- ✅ Has help documentation
-- ✅ Is tested
-- ✅ Follows the project structure
+- accepts multiple arguments and validates that at least one is present
+- appears in `--help` and in `myapp opencli`
+- returns a meaningful exit code on error (`APP_ERROR_MISSING_ARG`)
+- is covered by a contract test
 
-This pattern can be used to add any command to your CLI application!
+Repeat the same pattern for any command. Commands that open the TUI set `.requires_terminal = true` — see [custom-tui.md](custom-tui.md).

--- a/examples/advanced-usage.md
+++ b/examples/advanced-usage.md
@@ -1,6 +1,9 @@
 # Advanced Usage
 
-How to script and integrate the CLI. Every example here runs against the template's real commands (`hello`, `echo`, `info`, `doctor`, and `opencli`) plus the global flags. As you add your own commands ([adding a command](adding-a-command.md)), the same patterns apply.
+How to script and integrate the CLI. Every example here runs against the template's
+real commands (`hello`, `echo`, `info`, `doctor`, and `opencli`) plus the global flags.
+As you add your own commands ([adding a command](adding-a-command.md)), the same
+patterns apply.
 
 - [Output formats and streams](#output-formats-and-streams)
 - [Parsing output with jq](#parsing-output-with-jq)
@@ -12,7 +15,9 @@ How to script and integrate the CLI. Every example here runs against the templat
 
 ## Output formats and streams
 
-The CLI keeps a stable I/O contract: results go to **stdout**, errors and diagnostics go to **stderr**, and `--json` produces machine-readable output (always including a `format_version`) where a command supports it.
+The CLI keeps a stable I/O contract: results go to **stdout**, errors and diagnostics
+go to **stderr**, and `--json` produces machine-readable output (always including a
+`format_version`) where a command supports it.
 
 ```bash
 myapp info                       # human-readable

--- a/examples/advanced-usage.md
+++ b/examples/advanced-usage.md
@@ -68,31 +68,31 @@ myapp opencli | jq -r '.exitCodes[] | "\(.code) \(.description)"'
 Branch on them like any Unix tool:
 
 ```bash
-if myapp doctor > /dev/null 2>&1; then
-  echo "healthy"
-else
-  echo "doctor reported problems (exit $?)" >&2
-fi
-
 # Fail fast in a pipeline
 set -euo pipefail
 myapp --json info > build-info.json
 
 # Inspect a specific failure
 myapp frobnicate || echo "exit code: $?"   # unknown command -> 2
+myapp --unknown-option || echo "exit code: $?"   # unknown option -> 7
 ```
 
-## Health checks and smoke tests
+## Diagnostics
 
-`doctor` exists for exactly this: it reports environment status and exits non-zero on failure. `--deep` also exercises the TUI runtime when a terminal is available (and the TUI build is in use).
+`doctor` reports environment status to stdout, or as a JSON document with
+`--json`. `--deep` also exercises the TUI runtime when a terminal is available
+and the TUI build is in use.
 
 ```bash
-myapp doctor            # quick diagnostics
-myapp --json doctor     # machine-readable, for monitoring
+myapp doctor            # human-readable
+myapp --json doctor     # machine-readable
 myapp doctor --deep     # also smoke-test the TUI
 ```
 
-It makes a natural CI smoke test or container health check.
+The current implementation is **informational only** — it always exits `0`,
+even when checks report problems. To use it as a hard gate (CI smoke test,
+container health check, monitoring alert), parse the `--json` output and
+inspect the per-check statuses rather than relying on the exit code.
 
 ## Pipelines
 
@@ -134,10 +134,14 @@ The default build links only libc (no ncurses), so the image stays small. Add nc
 ```dockerfile
 FROM debian:stable-slim
 COPY zig-out/bin/myapp /usr/local/bin/myapp
-HEALTHCHECK CMD myapp doctor || exit 1
 ENTRYPOINT ["myapp"]
 CMD ["--help"]
 ```
+
+A `HEALTHCHECK` is intentionally omitted: the bundled `doctor` is
+informational (always exits 0), so it cannot act as a Docker health gate as
+written. Add your own check that parses `myapp --json doctor` once you have a
+field worth gating on.
 
 ```bash
 docker build -t myapp .
@@ -176,10 +180,10 @@ WantedBy=timers.target
 ```bash
 # Log machine-readable info hourly
 0 * * * * /usr/local/bin/myapp --json info >> /var/log/myapp-info.log
-
-# Nightly health check, mail on failure
-0 2 * * * /usr/local/bin/myapp doctor || echo "myapp doctor failed" | mail -s "myapp" you@example.com
 ```
+
+(`doctor` cannot drive a "mail on failure" cron line as written — it always
+exits 0. Parse `myapp --json doctor` with `jq -e` for a real gate.)
 
 ### CI contract check
 

--- a/examples/advanced-usage.md
+++ b/examples/advanced-usage.md
@@ -8,7 +8,7 @@ patterns apply.
 - [Output formats and streams](#output-formats-and-streams)
 - [Parsing output with jq](#parsing-output-with-jq)
 - [Exit codes in scripts](#exit-codes-in-scripts)
-- [Health checks and smoke tests](#health-checks-and-smoke-tests)
+- [Diagnostics](#diagnostics)
 - [Pipelines](#pipelines)
 - [Configuration and environment](#configuration-and-environment)
 - [Integration patterns](#integration-patterns)

--- a/examples/advanced-usage.md
+++ b/examples/advanced-usage.md
@@ -1,6 +1,6 @@
 # Advanced Usage
 
-How to script and integrate the CLI. Every example here runs against the template's real commands — `hello`, `echo`, `info`, `doctor`, and `opencli` — plus the global flags. As you add your own commands ([adding a command](adding-a-command.md)), the same patterns apply.
+How to script and integrate the CLI. Every example here runs against the template's real commands (`hello`, `echo`, `info`, `doctor`, and `opencli`) plus the global flags. As you add your own commands ([adding a command](adding-a-command.md)), the same patterns apply.
 
 - [Output formats and streams](#output-formats-and-streams)
 - [Parsing output with jq](#parsing-output-with-jq)
@@ -54,7 +54,7 @@ myapp --json info | jq -r '.format_version'
 
 ## Exit codes in scripts
 
-Commands return specific exit codes — `0` for success, non-zero for a categorized failure (for example `2` unknown command, `6` missing argument, `7` unknown option). The full list is in the contract:
+Commands return specific exit codes: `0` for success, non-zero for a categorized failure (for example `2` unknown command, `6` missing argument, `7` unknown option). The full list is in the contract:
 
 ```bash
 myapp opencli | jq -r '.exitCodes[] | "\(.code) \(.description)"'
@@ -111,7 +111,7 @@ myapp opencli | jq '.commands | length'
 
 Configuration resolves by precedence: **CLI args > environment > config file > defaults**.
 
-- **Config file:** `~/.config/myapp/config.json`, or an explicit path via `--config`. It is a flat JSON object of booleans — see [config.json](config.json).
+- **Config file:** `~/.config/myapp/config.json`, or an explicit path via `--config`. It is a flat JSON object of booleans (see [config.json](config.json)).
 - **Environment:** `APP_LOG_LEVEL` (`ERROR`, `WARNING`, `INFO`, `DEBUG`) and `NO_COLOR`.
 
 ```bash
@@ -124,7 +124,7 @@ myapp --quiet info                 # a CLI flag overrides file and environment
 
 ### Docker
 
-The default build links only libc — no ncurses — so the image stays small. Add ncurses only if you ship the TUI build (`-Denable-tui=true`).
+The default build links only libc (no ncurses), so the image stays small. Add ncurses only if you ship the TUI build (`-Denable-tui=true`).
 
 ```dockerfile
 FROM debian:stable-slim
@@ -178,7 +178,7 @@ WantedBy=timers.target
 
 ### CI contract check
 
-Assert the binary's contract still matches the checked-in spec — the same invariant `zig build test` enforces:
+Assert the binary's contract still matches the checked-in spec, the same invariant `zig build test` enforces:
 
 ```bash
 diff <(myapp opencli) opencli.json

--- a/examples/advanced-usage.md
+++ b/examples/advanced-usage.md
@@ -1,398 +1,192 @@
-# Advanced Usage Examples
+# Advanced Usage
 
-This guide demonstrates advanced usage patterns for the CLI application, including piping, scripting, and integration with other tools.
+How to script and integrate the CLI. Every example here runs against the template's real commands — `hello`, `echo`, `info`, `doctor`, and `opencli` — plus the global flags. As you add your own commands ([adding a command](adding-a-command.md)), the same patterns apply.
 
-## Table of Contents
+- [Output formats and streams](#output-formats-and-streams)
+- [Parsing output with jq](#parsing-output-with-jq)
+- [Exit codes in scripts](#exit-codes-in-scripts)
+- [Health checks and smoke tests](#health-checks-and-smoke-tests)
+- [Pipelines](#pipelines)
+- [Configuration and environment](#configuration-and-environment)
+- [Integration patterns](#integration-patterns)
 
-- [Input/Output Redirection](#inputoutput-redirection)
-- [Piping and Chaining](#piping-and-chaining)
-- [Scripting Examples](#scripting-examples)
-- [Integration Patterns](#integration-patterns)
-- [Performance Tips](#performance-tips)
-- [Error Handling](#error-handling)
+## Output formats and streams
 
-## Input/Output Redirection
-
-### Reading from Files
+The CLI keeps a stable I/O contract: results go to **stdout**, errors and diagnostics go to **stderr**, and `--json` produces machine-readable output (always including a `format_version`) where a command supports it.
 
 ```bash
-# Process input from a file
-myapp process < input.txt
+myapp info                       # human-readable
+myapp --json info                # machine-readable
+myapp --plain info               # no colors, good for logs
+NO_COLOR=1 myapp hello Alice     # same, via environment
 
-# Process multiple files
-cat file1.txt file2.txt | myapp process
-
-# Process with specific encoding
-iconv -f ISO-8859-1 -t UTF-8 input.txt | myapp process
+myapp info > info.txt            # capture stdout
+myapp doctor 2> diagnostics.log  # capture stderr only
+myapp info > out.txt 2>&1        # capture both
 ```
 
-### Writing to Files
+Use `--quiet`, `--verbose`, or `--debug` to dial verbosity up or down.
+
+## Parsing output with jq
+
+`myapp opencli` prints the whole CLI as JSON with a stable schema, which makes it ideal for discovery and for asserting behavior in scripts.
 
 ```bash
-# Save output to a file
-myapp generate --format json > output.json
+# Every command name
+myapp opencli | jq -r '.commands[].name'
 
-# Append to existing file
-myapp status >> log.txt
+# Public exit codes as a table
+myapp opencli | jq -r '.exitCodes[] | "\(.code)\t\(.description)"'
 
-# Split output streams
-myapp analyze 2>errors.log 1>results.txt
+# All global options
+myapp opencli | jq -r '.options[].name'
+
+# Version straight from the binary
+myapp opencli | jq -r '.info.version'
 ```
 
-### Silent Operation
+Command output works the same way:
 
 ```bash
-# Suppress all output
-myapp batch-process > /dev/null 2>&1
-
-# Show only errors
-myapp validate 1>/dev/null
-
-# Show only progress (if using stderr for progress)
-myapp convert large-file.dat 2>&1 1>/dev/null | grep -E "^\[.*%\]"
+myapp --json info | jq .                  # pretty-print
+myapp --json info | jq -r '.format_version'
 ```
 
-## Piping and Chaining
+## Exit codes in scripts
 
-### Basic Pipes
+Commands return specific exit codes — `0` for success, non-zero for a categorized failure (for example `2` unknown command, `6` missing argument, `7` unknown option). The full list is in the contract:
 
 ```bash
-# Filter and process
-grep "ERROR" log.txt | myapp analyze --type error
-
-# Chain multiple operations
-myapp list --format json | jq '.items[]' | myapp process --batch
-
-# Count results
-myapp search "pattern" | wc -l
+myapp opencli | jq -r '.exitCodes[] | "\(.code) \(.description)"'
 ```
 
-### Advanced Piping
+Branch on them like any Unix tool:
 
 ```bash
-# Parallel processing with xargs
-find . -name "*.dat" | xargs -P 4 -I {} myapp process {}
+if myapp doctor > /dev/null 2>&1; then
+  echo "healthy"
+else
+  echo "doctor reported problems (exit $?)" >&2
+fi
 
-# Process in batches
-ls *.csv | xargs -n 10 myapp import --batch
-
-# Stream processing
-tail -f app.log | myapp monitor --real-time
-```
-
-### Complex Pipelines
-
-```bash
-# Multi-stage processing pipeline
-cat raw-data.txt \
-  | myapp parse --format csv \
-  | awk '{print $2,$4}' \
-  | myapp analyze --columns 2 \
-  | tee results.txt \
-  | myapp visualize --output graph.png
-
-# Conditional processing
-myapp check --quiet && myapp process || echo "Check failed"
-
-# Loop with pipe
-for file in *.log; do
-  echo "Processing $file"
-  cat "$file" | myapp parse | myapp summarize >> summary.txt
-done
-```
-
-## Scripting Examples
-
-### Bash Integration
-
-```bash
-#!/bin/bash
-# process-daily.sh - Daily processing script
-
+# Fail fast in a pipeline
 set -euo pipefail
+myapp --json info > build-info.json
 
-# Configuration
-MYAPP_BIN="myapp"
-DATA_DIR="/var/data"
-OUTPUT_DIR="/var/output"
-LOG_FILE="/var/log/myapp-daily.log"
-
-# Function to process a single file
-process_file() {
-  local input_file="$1"
-  local output_file="$2"
-
-  echo "[$(date)] Processing $input_file" >> "$LOG_FILE"
-
-  if $MYAPP_BIN validate "$input_file"; then
-    $MYAPP_BIN process "$input_file" \
-      --output "$output_file" \
-      --format json \
-      2>> "$LOG_FILE"
-  else
-    echo "[$(date)] Validation failed for $input_file" >> "$LOG_FILE"
-    return 1
-  fi
-}
-
-# Main processing loop
-find "$DATA_DIR" -name "*.dat" -mtime -1 | while read -r file; do
-  basename=$(basename "$file" .dat)
-  output_file="$OUTPUT_DIR/${basename}_processed.json"
-
-  process_file "$file" "$output_file" || continue
-done
-
-# Generate summary
-$MYAPP_BIN summarize "$OUTPUT_DIR"/*.json > "$OUTPUT_DIR/daily-summary.txt"
+# Inspect a specific failure
+myapp frobnicate || echo "exit code: $?"   # unknown command -> 2
 ```
 
-### Makefile Integration
+## Health checks and smoke tests
 
-```makefile
-# Makefile - Build automation with myapp
+`doctor` exists for exactly this: it reports environment status and exits non-zero on failure. `--deep` also exercises the TUI runtime when a terminal is available (and the TUI build is in use).
 
-MYAPP := myapp
-DATA_DIR := data
-OUTPUT_DIR := output
-SOURCES := $(wildcard $(DATA_DIR)/*.txt)
-OUTPUTS := $(patsubst $(DATA_DIR)/%.txt,$(OUTPUT_DIR)/%.json,$(SOURCES))
-
-.PHONY: all clean validate process
-
-all: process
-
-# Create output directory
-$(OUTPUT_DIR):
-	mkdir -p $@
-
-# Validate all input files
-validate: $(SOURCES)
-	@echo "Validating input files..."
-	@for file in $^; do \
-		$(MYAPP) validate "$$file" || exit 1; \
-	done
-	@echo "All files valid."
-
-# Process files
-$(OUTPUT_DIR)/%.json: $(DATA_DIR)/%.txt | $(OUTPUT_DIR)
-	$(MYAPP) process $< --output $@ --format json
-
-process: validate $(OUTPUTS)
-	@echo "Processing complete. Generating summary..."
-	@$(MYAPP) summarize $(OUTPUT_DIR)/*.json > $(OUTPUT_DIR)/summary.txt
-
-clean:
-	rm -rf $(OUTPUT_DIR)
-
-# Watch for changes and reprocess
-watch:
-	while true; do \
-		make process; \
-		inotifywait -e modify $(DATA_DIR)/*.txt; \
-	done
+```bash
+myapp doctor            # quick diagnostics
+myapp --json doctor     # machine-readable, for monitoring
+myapp doctor --deep     # also smoke-test the TUI
 ```
 
-## Integration Patterns
+It makes a natural CI smoke test or container health check.
 
-### Docker Integration
+## Pipelines
+
+Real commands compose with standard tools.
+
+```bash
+# Greet a list of names, one invocation each
+printf 'Alice\nBob\nCharlie\n' | xargs -n1 myapp hello
+
+# Same, in parallel
+printf 'Alice\nBob\nCharlie\n' | parallel myapp hello
+
+# Feed command output into another stage
+myapp echo "build complete" | tr '[:lower:]' '[:upper:]'
+
+# Count the commands the binary exposes
+myapp opencli | jq '.commands | length'
+```
+
+## Configuration and environment
+
+Configuration resolves by precedence: **CLI args > environment > config file > defaults**.
+
+- **Config file:** `~/.config/myapp/config.json`, or an explicit path via `--config`. It is a flat JSON object of booleans — see [config.json](config.json).
+- **Environment:** `APP_LOG_LEVEL` (`ERROR`, `WARNING`, `INFO`, `DEBUG`) and `NO_COLOR`.
+
+```bash
+myapp --config ./myapp.json info   # explicit config file
+APP_LOG_LEVEL=DEBUG myapp doctor   # raise log verbosity for one run
+myapp --quiet info                 # a CLI flag overrides file and environment
+```
+
+## Integration patterns
+
+### Docker
+
+The default build links only libc — no ncurses — so the image stays small. Add ncurses only if you ship the TUI build (`-Denable-tui=true`).
 
 ```dockerfile
-# Dockerfile
-FROM alpine:latest
-
-RUN apk add --no-cache ncurses
-
-COPY myapp /usr/local/bin/
-COPY process.sh /usr/local/bin/
-
+FROM debian:stable-slim
+COPY zig-out/bin/myapp /usr/local/bin/myapp
+HEALTHCHECK CMD myapp doctor || exit 1
 ENTRYPOINT ["myapp"]
 CMD ["--help"]
 ```
 
 ```bash
-# Build and run in Docker
 docker build -t myapp .
-
-# Process files in container
-docker run -v $(pwd)/data:/data myapp process /data/input.txt
-
-# Interactive mode
-docker run -it myapp interactive
+docker run --rm myapp --json info
 ```
 
-### Systemd Service
+### systemd timer
+
+The template has no long-running daemon, so schedule periodic runs with a oneshot service plus a timer.
 
 ```ini
-# /etc/systemd/system/myapp-monitor.service
+# /etc/systemd/system/myapp-health.service
 [Unit]
-Description=MyApp Monitoring Service
-After=network.target
+Description=myapp health check
 
 [Service]
-Type=simple
-User=myapp
-ExecStart=/usr/local/bin/myapp monitor --daemon
-Restart=on-failure
-RestartSec=10
-StandardOutput=journal
-StandardError=journal
+Type=oneshot
+ExecStart=/usr/local/bin/myapp doctor
+```
+
+```ini
+# /etc/systemd/system/myapp-health.timer
+[Unit]
+Description=Run the myapp health check hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target
 ```
 
-### Cron Job
+### cron
 
 ```bash
-# Process files every hour
-0 * * * * /usr/local/bin/myapp process /var/data/*.new --output /var/processed/
+# Log machine-readable info hourly
+0 * * * * /usr/local/bin/myapp --json info >> /var/log/myapp-info.log
 
-# Daily summary at 2 AM
-0 2 * * * /usr/local/bin/myapp summarize --yesterday | mail -s "Daily Summary" admin@example.com
-
-# Cleanup old files weekly
-0 3 * * 0 find /var/processed -mtime +30 -name "*.json" | xargs /usr/local/bin/myapp archive
+# Nightly health check, mail on failure
+0 2 * * * /usr/local/bin/myapp doctor || echo "myapp doctor failed" | mail -s "myapp" you@example.com
 ```
 
-## Performance Tips
+### CI contract check
 
-### Parallel Processing
+Assert the binary's contract still matches the checked-in spec — the same invariant `zig build test` enforces:
 
 ```bash
-# GNU Parallel for maximum throughput
-find . -name "*.dat" | parallel -j 8 myapp process {} --output {.}.json
-
-# Process with progress bar
-find . -name "*.dat" | parallel --bar myapp process {} :::: -
-
-# Limit memory usage
-find . -name "*.dat" | parallel --memfree 1G myapp process {}
+diff <(myapp opencli) opencli.json
 ```
 
-### Batch Operations
+## See also
 
-```bash
-# Process in chunks to reduce overhead
-find . -name "*.dat" -print0 | xargs -0 -n 100 myapp process --batch
-
-# Use named pipes for streaming
-mkfifo /tmp/myapp-pipe
-myapp monitor --output /tmp/myapp-pipe &
-cat /tmp/myapp-pipe | myapp analyze --stream
-```
-
-### Resource Management
-
-```bash
-# Limit CPU usage
-nice -n 10 myapp process large-dataset.dat
-
-# Limit memory
-ulimit -v 1048576 && myapp process --low-memory
-
-# Monitor resource usage
-/usr/bin/time -v myapp process large-file.dat
-```
-
-## Error Handling
-
-### Robust Scripts
-
-```bash
-#!/bin/bash
-# robust-processor.sh - Error-handling example
-
-set -euo pipefail
-trap 'echo "Error on line $LINENO"' ERR
-
-# Function with error handling
-safe_process() {
-  local file="$1"
-  local max_retries=3
-  local retry_count=0
-
-  while [ $retry_count -lt $max_retries ]; do
-    if myapp process "$file" 2>/tmp/myapp-error.log; then
-      return 0
-    else
-      retry_count=$((retry_count + 1))
-      echo "Attempt $retry_count failed for $file"
-      sleep $((retry_count * 2))
-    fi
-  done
-
-  echo "Failed to process $file after $max_retries attempts"
-  cat /tmp/myapp-error.log
-  return 1
-}
-
-# Process with error recovery
-for file in *.dat; do
-  if ! safe_process "$file"; then
-    echo "$file" >> failed-files.txt
-  fi
-done
-
-# Report results
-if [ -f failed-files.txt ]; then
-  echo "Failed files:"
-  cat failed-files.txt
-  exit 1
-fi
-```
-
-### Validation Pipeline
-
-```bash
-# Multi-stage validation
-validate_and_process() {
-  local input="$1"
-
-  # Stage 1: Format validation
-  if ! myapp validate --format "$input"; then
-    echo "Format validation failed" >&2
-    return 1
-  fi
-
-  # Stage 2: Content validation
-  if ! myapp validate --content "$input"; then
-    echo "Content validation failed" >&2
-    return 2
-  fi
-
-  # Stage 3: Process with verification
-  local output=$(mktemp)
-  if myapp process "$input" --output "$output"; then
-    if myapp verify "$output"; then
-      mv "$output" "${input%.dat}.json"
-      return 0
-    else
-      echo "Output verification failed" >&2
-      rm -f "$output"
-      return 3
-    fi
-  else
-    echo "Processing failed" >&2
-    rm -f "$output"
-    return 4
-  fi
-}
-```
-
-## Best Practices
-
-1. **Always check exit codes** when scripting
-2. **Use proper quoting** for filenames with spaces
-3. **Handle signals gracefully** in long-running operations
-4. **Log operations** for debugging and auditing
-5. **Validate input** before processing
-6. **Use atomic operations** for file updates
-7. **Implement retry logic** for transient failures
-8. **Monitor resource usage** for large datasets
-
-## See Also
-
-- [Basic Usage](adding-a-command.md)
-- [Configuration Guide](config.json)
-- [API Documentation](../docs/README.md)
+- [Adding a Command](adding-a-command.md)
+- [Configuration example](config.json)
+- [Public Contracts](../docs/CONTRACTS.md)
+- [Documentation index](../docs/README.md)

--- a/examples/custom-tui.md
+++ b/examples/custom-tui.md
@@ -1,10 +1,16 @@
 # Example: Creating a Custom TUI Screen
 
-The terminal UI is opt-in: it only compiles with `-Denable-tui=true` (which defines `ENABLE_TUI`). `tui.h` gives you a window wrapper, dialogs, a progress bar, and one modal menu primitive, so command code never calls ncurses directly. Every screen follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return, on every path.
+The terminal UI is opt-in: it only compiles with `-Denable-tui=true` (which defines
+`ENABLE_TUI`). `tui.h` gives you a window wrapper, dialogs, a progress bar, and one
+modal menu primitive, so command code never calls ncurses directly. Every screen
+follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return,
+on every path.
 
 ## 1. A complete screen
 
-This handler opens a bordered window, draws a live value with a bar, and loops on keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is fine; the wrapper manages lifecycle and layout, not every cell.
+This handler opens a bordered window, draws a live value with a bar, and loops on
+keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is
+fine; the wrapper manages lifecycle and layout, not every cell.
 
 ```c
 #ifdef ENABLE_TUI
@@ -44,7 +50,8 @@ static app_error show_data_viewer(void) {
         mvwprintw(data_win->win, 2, 2, "Current Value: %d", data_value);
         tui_unset_color(data_win->win, TUI_COLOR_INFO);
 
-        int bar_width = (data_win->width - 4) * data_value / 100;
+        int inner = data_win->width > 4 ? data_win->width - 4 : 0;
+        int bar_width = inner * data_value / 100;
         mvwprintw(data_win->win, 4, 2, "[");
         tui_set_color(data_win->win, TUI_COLOR_SUCCESS);
         for (int i = 0; i < bar_width; i++) {
@@ -128,7 +135,10 @@ tui_progress_destroy(progress);
 
 ### Menu
 
-The menu is the one reusable primitive that is also shipped as a library (`tui-menu-lib`) and covered by the [TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config must outlive the call; the menu copies nothing.
+The menu is the one reusable primitive that is also shipped as a library
+(`tui-menu-lib`) and covered by the
+[TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config
+must outlive the call; the menu copies nothing.
 
 ```c
 enum { MENU_OPTION_ONE = 1, MENU_OPTION_TWO, MENU_EXIT };

--- a/examples/custom-tui.md
+++ b/examples/custom-tui.md
@@ -1,60 +1,49 @@
 # Example: Creating a Custom TUI Screen
 
-This example shows how to create a custom TUI screen using the ncurses wrapper.
+The terminal UI is opt-in: it only compiles with `-Denable-tui=true` (which defines `ENABLE_TUI`). `tui.h` gives you a window wrapper, dialogs, a progress bar, and one modal menu primitive, so command code never calls ncurses directly. Every screen follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return — on every path.
 
-## 1. Create Your TUI Function
+## 1. A complete screen
 
-Add a new function in `src/tui` and expose it through `tui.h` so command code
-does not call ncurses directly:
+This handler opens a bordered window, draws a live value with a bar, and loops on keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is fine — the wrapper manages lifecycle and layout, not every cell.
 
 ```c
 #ifdef ENABLE_TUI
 static app_error show_data_viewer(void) {
-    // Initialize TUI if not already done
     app_error err = tui_init();
     if (err != APP_SUCCESS) {
         return err;
     }
 
-    // Get terminal dimensions
     int max_y = tui_get_max_y();
     int max_x = tui_get_max_x();
 
-    // Create main window (leave space for borders)
     tui_window_t *main_win = tui_create_window(max_y - 2, max_x - 2, 1, 1);
     if (!main_win) {
         tui_cleanup();
         return APP_ERROR_MEMORY;
     }
-
     tui_draw_border(main_win);
     tui_set_window_title(main_win, "Data Viewer");
 
-    // Create a data display area
     tui_window_t *data_win = tui_create_window(max_y - 10, max_x - 10, 5, 5);
     if (!data_win) {
         tui_destroy_window(main_win);
         tui_cleanup();
         return APP_ERROR_MEMORY;
     }
-
     tui_draw_border(data_win);
     tui_set_window_title(data_win, "Live Data");
 
-    // Main loop
     bool running = true;
     int data_value = 0;
 
     while (running) {
-        // Clear data window content
         tui_clear_window(data_win);
 
-        // Display some data
         tui_set_color(data_win->win, TUI_COLOR_INFO);
         mvwprintw(data_win->win, 2, 2, "Current Value: %d", data_value);
         tui_unset_color(data_win->win, TUI_COLOR_INFO);
 
-        // Draw a simple bar graph
         int bar_width = (data_win->width - 4) * data_value / 100;
         mvwprintw(data_win->win, 4, 2, "[");
         tui_set_color(data_win->win, TUI_COLOR_SUCCESS);
@@ -64,52 +53,31 @@ static app_error show_data_viewer(void) {
         tui_unset_color(data_win->win, TUI_COLOR_SUCCESS);
         mvwprintw(data_win->win, 4, 3 + bar_width, "]");
 
-        // Instructions
-        tui_set_color(main_win->win, TUI_COLOR_INFO);
         mvwprintw(main_win->win, max_y - 4, 2,
                   "Press: [+] Increase  [-] Decrease  [r] Reset  [q] Quit");
-        tui_unset_color(main_win->win, TUI_COLOR_INFO);
 
-        // Refresh windows
         tui_refresh_window(data_win);
         tui_refresh_window(main_win);
 
-        // Handle input
-        int ch = tui_get_char();
-        switch (ch) {
-            case '+':
-            case '=':
-                if (data_value < 100) data_value += 5;
-                break;
-            case '-':
-            case '_':
-                if (data_value > 0) data_value -= 5;
-                break;
-            case 'r':
-            case 'R':
-                data_value = 0;
-                break;
-            case 'q':
-            case 'Q':
-            case 27:  // ESC
-                running = false;
-                break;
+        switch (tui_get_char()) {
+            case '+': case '=': if (data_value < 100) data_value += 5; break;
+            case '-': case '_': if (data_value > 0)   data_value -= 5; break;
+            case 'r': case 'R': data_value = 0; break;
+            case 'q': case 'Q': case 27 /* ESC */: running = false; break;
         }
     }
 
-    // Cleanup
     tui_destroy_window(data_win);
     tui_destroy_window(main_win);
     tui_cleanup();
-
     return APP_SUCCESS;
 }
 #endif
 ```
 
-## 2. Add Command Handler
+## 2. Wire it to a command
 
-Create a command handler and register it in `src/cli/commands.c`:
+Register a handler in `src/cli/commands.c` with `.requires_terminal = true`, and guard the TUI call so a non-TUI build still gives a clean message instead of failing to link:
 
 ```c
 app_error app_cmd_viewer(const app_config_t *config, int argc, char **argv) {
@@ -119,89 +87,61 @@ app_error app_cmd_viewer(const app_config_t *config, int argc, char **argv) {
 #ifdef ENABLE_TUI
     return show_data_viewer();
 #else
-    fprintf(stderr, "Error: TUI support not compiled in\n");
+    fprintf(stderr, "Error: TUI support not compiled in.\n");
     fprintf(stderr, "Rebuild with: zig build -Denable-tui=true\n");
     return APP_ERROR_CONFIG;
 #endif
 }
 ```
 
-Set `.requires_terminal = true` in the command table so help and
-`myapp opencli` expose the command as interactive policy.
+`.requires_terminal = true` makes help and `myapp opencli` mark the command as interactive. See [adding-a-command.md](adding-a-command.md) for the full registration steps.
 
-## 3. Using TUI Components
+## 3. Building blocks
 
-### Message Boxes
-
-```c
-tui_show_message("Success", "Operation completed successfully!");
-```
-
-### Confirmation Dialogs
+### Dialogs
 
 ```c
-if (tui_confirm("Delete File", "Are you sure you want to delete this file?")) {
-    // Perform deletion
+tui_show_message("Success", "Operation completed.");
+
+if (tui_confirm("Delete File", "Are you sure?")) {
+    // tui_confirm returns bool
 }
-```
 
-### Input Dialogs
-
-```c
 char username[256] = {0};
 if (tui_input_dialog("Login", "Enter username:", username, sizeof(username)) == APP_SUCCESS) {
-    printf("Welcome, %s!\n", username);
+    // username is filled in
 }
 ```
 
-### Progress Bars
+### Progress bar
 
 ```c
-tui_progress_t *progress = tui_progress_create("Processing Files", 100);
+tui_progress_t *progress = tui_progress_create("Processing", 100);
 for (int i = 0; i <= 100; i++) {
     char status[64];
-    snprintf(status, sizeof(status), "Processing file %d of 100", i);
+    snprintf(status, sizeof(status), "Item %d of 100", i);
     tui_progress_update(progress, i, status);
-    napms(50);  // Simulate work inside curses
+    napms(50);  // stand-in for real work
 }
 tui_progress_destroy(progress);
 ```
 
-### Menus
+### Menu
+
+The menu is the one reusable primitive that is also shipped as a library (`tui-menu-lib`) and covered by the [TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config must outlive the call — the menu copies nothing.
 
 ```c
-enum {
-    MENU_OPTION_ONE = 1,
-    MENU_OPTION_TWO,
-    MENU_EXIT,
-};
+enum { MENU_OPTION_ONE = 1, MENU_OPTION_TWO, MENU_EXIT };
 
 const tui_menu_item_t options[] = {
-    {
-        .label = "Option &1",
-        .description = "First option description",
-        .id = MENU_OPTION_ONE,
-    },
-    {
-        .label = "Option &2",
-        .description = "Second option description",
-        .id = MENU_OPTION_TWO,
-    },
-    {
-        .label = "&Disabled",
-        .description = "This option is disabled",
-        .id = 3,
-        .disabled = true,
-    },
-    {
-        .label = "E&xit",
-        .description = "Return to main menu",
-        .id = MENU_EXIT,
-    },
+    {.label = "Option &1", .description = "First option",  .id = MENU_OPTION_ONE},
+    {.label = "Option &2", .description = "Second option", .id = MENU_OPTION_TWO},
+    {.label = "&Disabled", .description = "Unavailable",   .id = 3, .disabled = true},
+    {.label = "E&xit",     .description = "Leave the menu", .id = MENU_EXIT},
 };
 
 tui_menu_result_t result = tui_show_menu(
-    window,
+    NULL,  // NULL => the menu owns its frame and handles resize
     &(tui_menu_config_t){
         .title = "Select Option",
         .items = options,
@@ -211,60 +151,45 @@ tui_menu_result_t result = tui_show_menu(
         .show_detail_pane = true,
     });
 
-if (result.status != TUI_MENU_OK) {
-    return;
-}
-
-switch (result.selected_id) {
-    case MENU_OPTION_ONE: /* Handle option 1 */ break;
-    case MENU_OPTION_TWO: /* Handle option 2 */ break;
-    case MENU_EXIT: /* Exit */ break;
+if (result.status == TUI_MENU_OK) {
+    switch (result.selected_id) {
+        case MENU_OPTION_ONE: /* ... */ break;
+        case MENU_OPTION_TWO: /* ... */ break;
+        case MENU_EXIT:       /* ... */ break;
+    }
 }
 ```
 
-## 4. Color Usage
+`&` in a label marks the mnemonic key (`&&` is a literal `&`). `result.status` is one of `TUI_MENU_OK`, `TUI_MENU_CANCELLED`, `TUI_MENU_INTERRUPTED`, `TUI_MENU_TOO_SMALL`, `TUI_MENU_INVALID_ARG`, or `TUI_MENU_NO_MEMORY`.
 
-The TUI wrapper provides predefined color pairs:
+## 4. Colors
 
-- `TUI_COLOR_DEFAULT` - Default terminal colors
-- `TUI_COLOR_HIGHLIGHT` - Highlighted text
-- `TUI_COLOR_ERROR` - Error messages (red)
-- `TUI_COLOR_SUCCESS` - Success messages (green)
-- `TUI_COLOR_WARNING` - Warnings (yellow)
-- `TUI_COLOR_INFO` - Information (cyan)
-- `TUI_COLOR_MENU_SELECTED` - Selected menu items
-- `TUI_COLOR_MENU_NORMAL` - Normal menu items
-- `TUI_COLOR_BORDER` - Window borders (blue)
-- `TUI_COLOR_TITLE` - Window titles (magenta)
-
-Use them like:
+Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors — the theme is defined in `src/utils/colors.c`:
 
 ```c
 tui_set_color(window->win, TUI_COLOR_ERROR);
-mvwprintw(window->win, y, x, "Error: %s", error_message);
+mvwprintw(window->win, y, x, "Error: %s", message);
 tui_unset_color(window->win, TUI_COLOR_ERROR);
 ```
 
-## 5. Best Practices
+Available pairs: `TUI_COLOR_DEFAULT`, `HIGHLIGHT`, `ERROR`, `SUCCESS`, `WARNING`, `INFO`, `MENU_SELECTED`, `MENU_NORMAL`, `BORDER`, `TITLE`, `ACCENT`, `DIM`.
 
-1. **Always check initialization**: TUI functions will fail if not initialized
-2. **Clean up properly**: Always call `tui_cleanup()` before exiting
-3. **Handle terminal resize**: Consider refreshing on `KEY_RESIZE`
-4. **Provide keyboard shortcuts**: Make UI keyboard-friendly
-5. **Show help**: Display available keys/commands
-6. **Test both builds**: Ensure `zig build` and `zig build -Denable-tui=true` work
+## 5. Practices
 
-## 6. Error Handling
+- **Pair every `tui_init()` with `tui_cleanup()`**, including on every error path, or the terminal is left in raw mode.
+- **Handle a failed init.** `tui_init()` returns an `app_error`; fall back to non-interactive output rather than aborting:
 
-Always handle TUI errors gracefully:
+  ```c
+  if (tui_init() != APP_SUCCESS) {
+      fprintf(stderr, "Terminal does not support the TUI; using plain output.\n");
+      return run_plain_version();
+  }
+  ```
 
-```c
-app_error err = tui_init();
-if (err != APP_SUCCESS) {
-    // Fall back to non-TUI interface
-    fprintf(stderr, "Failed to initialize TUI, falling back to CLI\n");
-    return handle_cli_version();
-}
-```
+- **Respect interrupts.** Check `tui_interrupted()` in long loops and exit cleanly.
+- **Test both builds.** Confirm `zig build` (no TUI) and `zig build -Denable-tui=true` both compile and behave. Drive TUI screens with the scenario harness in [TESTING.md](../docs/TESTING.md).
 
-This ensures your application remains functional even if the terminal doesn't support ncurses.
+## See also
+
+- [Public Contracts](../docs/CONTRACTS.md#tui-menu-contract) - the stable menu surface
+- [Architecture Overview](../docs/ARCHITECTURE.md) - where `tui/` sits in the codebase

--- a/examples/custom-tui.md
+++ b/examples/custom-tui.md
@@ -1,10 +1,10 @@
 # Example: Creating a Custom TUI Screen
 
-The terminal UI is opt-in: it only compiles with `-Denable-tui=true` (which defines `ENABLE_TUI`). `tui.h` gives you a window wrapper, dialogs, a progress bar, and one modal menu primitive, so command code never calls ncurses directly. Every screen follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return — on every path.
+The terminal UI is opt-in: it only compiles with `-Denable-tui=true` (which defines `ENABLE_TUI`). `tui.h` gives you a window wrapper, dialogs, a progress bar, and one modal menu primitive, so command code never calls ncurses directly. Every screen follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return, on every path.
 
 ## 1. A complete screen
 
-This handler opens a bordered window, draws a live value with a bar, and loops on keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is fine — the wrapper manages lifecycle and layout, not every cell.
+This handler opens a bordered window, draws a live value with a bar, and loops on keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is fine; the wrapper manages lifecycle and layout, not every cell.
 
 ```c
 #ifdef ENABLE_TUI
@@ -128,7 +128,7 @@ tui_progress_destroy(progress);
 
 ### Menu
 
-The menu is the one reusable primitive that is also shipped as a library (`tui-menu-lib`) and covered by the [TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config must outlive the call — the menu copies nothing.
+The menu is the one reusable primitive that is also shipped as a library (`tui-menu-lib`) and covered by the [TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config must outlive the call; the menu copies nothing.
 
 ```c
 enum { MENU_OPTION_ONE = 1, MENU_OPTION_TWO, MENU_EXIT };
@@ -164,7 +164,7 @@ if (result.status == TUI_MENU_OK) {
 
 ## 4. Colors
 
-Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors — the theme is defined in `src/utils/colors.c`:
+Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors. The theme is defined in `src/utils/colors.c`:
 
 ```c
 tui_set_color(window->win, TUI_COLOR_ERROR);

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-# create-demo.sh - Create animated demos of the TUI
+# create-demo.sh - Record animated demos of the CLI
 # Requires: asciinema, agg (asciinema gif generator)
+#
+# This records the non-interactive demos shown in docs/demos/README.md.
+# The gallery README is maintained by hand, not regenerated here. The TUI
+# `menu` is interactive, so record it manually (see docs/demos/README.md).
 
 set -euo pipefail
 
@@ -104,228 +108,79 @@ EOF
     echo -e "${GREEN}Created $DEMO_DIR/$name.gif${NC}"
 }
 
-# Demo 1: Basic Usage
+# Demo 1: Basic usage
 demo_basic_usage() {
     record_demo "basic-usage" "Basic Command Usage" '
-# Show help
 '$BINARY' --help
 sleep 3
-
-# Show version
 '$BINARY' --version
 sleep 2
-
-# Run hello command
 '$BINARY' hello
 sleep 2
-
-# Run hello with name
 '$BINARY' hello "Demo User"
 sleep 2
-
-# Run echo command
 '$BINARY' echo "This is a test message"
 sleep 2
 '
 }
 
-# Demo 2: TUI Progress Bar
-demo_progress_bar() {
-    record_demo "progress-bar" "TUI Progress Bar Demo" '
-# Create a test script that shows progress
-cat > /tmp/progress-demo.sh << '\''SCRIPT'\''
-#!/bin/bash
-echo "Starting long operation..."
-'$BINARY' progress --steps 10 --delay 500
-echo "Operation complete!"
-SCRIPT
-
-chmod +x /tmp/progress-demo.sh
-/tmp/progress-demo.sh
-rm -f /tmp/progress-demo.sh
-'
-}
-
-# Demo 3: Interactive Mode
-demo_interactive() {
-    record_demo "interactive" "Interactive TUI Mode" '
-# Note: This is a simulated demo since we cannot automate interactive input
-echo "Starting interactive mode..."
-echo "(Simulated demo - actual interactive mode requires user input)"
-sleep 1
-
-# Show what the interactive mode would look like
-cat << '\''DEMO'\''
-┌─────────────────────────────────────┐
-│        MyApp Interactive Mode       │
-├─────────────────────────────────────┤
-│                                     │
-│  1. Process File                    │
-│  2. View Status                     │
-│  3. Configure Settings              │
-│  4. Exit                            │
-│                                     │
-│  Select option: _                   │
-│                                     │
-└─────────────────────────────────────┘
-DEMO
+# Demo 2: Human and JSON output
+demo_json_output() {
+    record_demo "json-output" "Human and JSON Output" '
+'$BINARY' info
 sleep 3
-
-echo ""
-echo "User selects option 1..."
-sleep 2
-
-cat << '\''DEMO'\''
-┌─────────────────────────────────────┐
-│          Process File               │
-├─────────────────────────────────────┤
-│                                     │
-│  Enter filename: data.txt           │
-│                                     │
-│  [████████████████████░░░░] 75%     │
-│                                     │
-│  Processing... Please wait          │
-│                                     │
-└─────────────────────────────────────┘
-DEMO
+'$BINARY' --json info
 sleep 3
 '
 }
 
-# Demo 4: Configuration
-demo_config() {
-    record_demo "configuration" "Configuration Management" '
-# Show current configuration
-'$BINARY' config show
+# Demo 3: Diagnostics
+demo_doctor() {
+    record_demo "doctor" "Diagnostics" '
+'$BINARY' doctor
 sleep 3
-
-# Set a configuration value
-'$BINARY' config set output.format json
-sleep 2
-
-# Get a specific configuration value
-'$BINARY' config get output.format
-sleep 2
-
-# Reset configuration
-'$BINARY' config reset
-sleep 2
+'$BINARY' --json doctor
+sleep 3
 '
 }
 
-# Demo 5: Error Handling
+# Demo 4: OpenCLI contract
+demo_contract() {
+    record_demo "contract" "OpenCLI Contract" '
+'$BINARY' opencli | head -n 24
+sleep 4
+'
+}
+
+# Demo 5: Error handling
 demo_error_handling() {
-    record_demo "error-handling" "Error Handling Demo" '
-# Try to process a non-existent file
-'$BINARY' process /tmp/nonexistent.txt || true
+    record_demo "error-handling" "Error Handling" '
+'$BINARY' || true
+sleep 2
+'$BINARY' frobnicate || true
 sleep 3
-
-# Show validation error
-echo "Invalid data" > /tmp/invalid.txt
-'$BINARY' validate /tmp/invalid.txt || true
-rm -f /tmp/invalid.txt
-sleep 3
-
-# Show helpful error recovery
-'$BINARY' --invalid-option || true
+'$BINARY' --unknown-option || true
 sleep 2
 '
-}
-
-# Create README for demos
-create_demo_readme() {
-    cat > "$DEMO_DIR/README.md" << 'EOF'
-# Demo Gallery
-
-This directory contains animated demonstrations of the CLI application's features.
-
-## Available Demos
-
-### Basic Usage
-![Basic Usage Demo](basic-usage.gif)
-
-Demonstrates basic command-line usage including help, version, and simple commands.
-
-### Progress Bar
-![Progress Bar Demo](progress-bar.gif)
-
-Shows the TUI progress bar in action during long-running operations.
-
-### Interactive Mode
-![Interactive Mode Demo](interactive.gif)
-
-Demonstrates the interactive TUI mode for menu-driven operations.
-
-### Configuration
-![Configuration Demo](configuration.gif)
-
-Shows how to manage application configuration through the CLI.
-
-### Error Handling
-![Error Handling Demo](error-handling.gif)
-
-Demonstrates graceful error handling and helpful error messages.
-
-## Creating New Demos
-
-To create new demos, use the `scripts/create-demo.sh` script:
-
-```bash
-./scripts/create-demo.sh
-```
-
-### Requirements
-
-- asciinema: install with your OS package manager
-- agg: `cargo install --git https://github.com/asciinema/agg`
-
-### Adding a New Demo
-
-1. Add a new demo function in `create-demo.sh`
-2. Call `record_demo` with appropriate parameters
-3. Add the demo to the main execution flow
-4. Update this README with the new demo
-
-## Embedding Demos
-
-To embed these demos in documentation:
-
-```markdown
-![Demo Name](docs/demos/demo-name.gif)
-```
-
-Or with HTML for more control:
-
-```html
-<p align="center">
-  <img src="docs/demos/demo-name.gif" alt="Demo Name" width="600">
-</p>
-```
-EOF
-
-    echo -e "${GREEN}Created $DEMO_DIR/README.md${NC}"
 }
 
 # Main execution
 main() {
-    echo -e "${GREEN}Creating TUI demos...${NC}"
+    echo -e "${GREEN}Creating CLI demos...${NC}"
 
     check_dependencies
     build_project
     setup_demo_dir
 
-    # Create all demos
     demo_basic_usage
-    demo_progress_bar
-    demo_interactive
-    demo_config
+    demo_json_output
+    demo_doctor
+    demo_contract
     demo_error_handling
 
-    # Create README
-    create_demo_readme
-
-    echo -e "${GREEN}All demos created successfully!${NC}"
-    echo -e "View demos in: ${BLUE}$DEMO_DIR/${NC}"
+    echo -e "${GREEN}All demos created.${NC}"
+    echo -e "View them in: ${BLUE}$DEMO_DIR/${NC}"
+    echo -e "The gallery is documented by hand in ${BLUE}$DEMO_DIR/README.md${NC}."
 }
 
 # Run main function

--- a/scripts/create-demo.sh
+++ b/scripts/create-demo.sh
@@ -155,8 +155,6 @@ sleep 4
 # Demo 5: Error handling
 demo_error_handling() {
     record_demo "error-handling" "Error Handling" '
-'$BINARY' || true
-sleep 2
 '$BINARY' frobnicate || true
 sleep 3
 '$BINARY' --unknown-option || true

--- a/test/README.md
+++ b/test/README.md
@@ -1,40 +1,25 @@
 # Test Suite
 
-This template has two layers of tests:
+Three test layers cover unit logic, CLI contracts, and interactive terminal flows.
 
-- `cli_contract_runner.c` keeps fast C23 smoke and CLI contract tests close to
-  the build graph.
-- The C Ghostty VT runner covers PTY-backed TUI flows when libghostty-vt is available.
+| Layer | How it runs | What it asserts | Lives in |
+| --- | --- | --- | --- |
+| Unit tests | In-process, linked against the real sources | Logic inside `config`, `error`, `tui_menu_model`, and other modules | `unit_*.c` |
+| CLI contract tests | The built binary as a subprocess | Exit codes, JSON fields, durable output, `myapp opencli` matching `opencli.json` | `cli_contract_*.c` |
+| PTY/TUI scenarios | The binary in a real PTY via libghostty-vt | Rendered screen snapshots, input and resize handling | `terminal_vt_*.c` |
 
-Run the default CLI contract suite:
-
-```bash
-zig build test
-```
-
-Run the terminal scenarios against the built binary:
+## Running them
 
 ```bash
-zig build terminal-test
+zig build unit-test       # just the in-process unit tests
+zig build test            # unit tests + CLI contract tests
+zig build terminal-test   # the above + PTY/TUI scenarios when available
 ```
 
-Run the same scenarios against a TUI-enabled build:
+`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the
+Ghostty VT backend when libghostty-vt is available through `pkg-config` on POSIX hosts.
+The Nix dev shell wires this up automatically. Without libghostty-vt the CLI portion
+still runs; pass `-Dterminal-backend=ghostty` to require the PTY backend, or
+`-Dghostty-vt-prefix=/path` to override the install prefix.
 
-```bash
-zig build -Denable-tui=true terminal-test
-```
-
-The default terminal-test backend is `auto`: it uses the C Ghostty VT runner
-when `libghostty-vt` is available through `pkg-config` on POSIX hosts. In the
-Nix dev shell, nixpkgs `libghostty-vt` is exported through `pkg-config`
-automatically, so `zig build -Dterminal-backend=ghostty terminal-test` works
-without extra flags. CLI contracts always run through `cli_contract_runner.c`,
-so hosts without libghostty-vt still exercise non-interactive behavior without
-a fallback scripting runtime.
-
-The Ghostty VT runner is split across `terminal_vt_*.c` files. It runs TUI
-checks in a pseudo-terminal, feeds output through libghostty-vt, snapshots the
-screen with Ghostty's formatter API, and drives deterministic input plus resize
-actions. For the Ghostty backend, install a libghostty-vt build with the
-development Terminal and Formatter APIs and make it visible through `pkg-config` or
-`-Dghostty-vt-prefix=/path/to/ghostty`.
+See [docs/TESTING.md](../docs/TESTING.md) for the full guide, including how to write each layer.


### PR DESCRIPTION
Rewrite every documentation file in the repository for accuracy against the actual code, progressive disclosure, and emoji-free presentation. Sixteen markdown files plus the demo-recording script that generates one of them (net diff: +958 / -2166 — the rewrites are tighter).

**Accuracy fixes against the real code**

About a dozen invented function names in `ARCHITECTURE.md` (`parse_args`, `init_tui`, `execute_command`, …) replaced with the real `app_*` / `tui_*` API. `ZIG_PRIMER.md` and `CONTRIBUTING.md` updated from an outdated Zig build API (`exe.addCSourceFiles`, `exe.defineCMacro`) to the real `b.createModule` / `exe.root_module.…`. False compiler-hardening claims (PIE/RELRO/stack-canary/FORTIFY) removed from `ARCHITECTURE.md` and `SECURITY.md` and replaced with what is actually wired in (`app_secret_zero`, `mlock`, CI `clang-tidy` / `cppcheck` / Gitleaks / Scorecard / SBOM). `TESTING.md` gained the previously undocumented in-process unit-test layer. Windows config path corrected to `%USERPROFILE%\AppData\Local\<name>\config.json`.

**Fictional commands replaced in examples and demos**

`examples/advanced-usage.md` and `docs/demos/README.md` demonstrated about eighteen commands that do not exist (`process`, `analyze`, `validate`, `summarize`, `convert`, …). Both rewritten to use only the real commands (`hello`, `echo`, `info`, `doctor`, `opencli`) and the stable `opencli` JSON schema for `jq` examples. `scripts/create-demo.sh` was recording the same fictional commands and overwriting the gallery README with that fiction; updated to record real commands and to stop regenerating the README so the hand-maintained gallery is the source of truth.

**Template and meta-file corrections**

`TEMPLATE_README.md` had an `app_output` argument-order bug (text first per the real signature) — fixed. `.template/README.md` removed a non-existent `camelCase` transform and fixed the schema example to match `template-vars.json`. `TEMPLATE_SUPPORT.md` dropped a false `sammyjoyce` → username replacement claim. `SECURITY.md` replaced a placeholder email and the fictional "1.x.x supported" table with GitHub Private Vulnerability Reporting and a pre-1.0 statement. `CODE_OF_CONDUCT.md` filled the unfilled `[INSERT CONTACT METHOD]` placeholder (Covenant text otherwise preserved). `CHANGELOG.md` dropped a fabricated `[1.0.0]` entry in favor of the real `[0.1.0]` and fixed link refs from `yourrepo` (which the replacer does not touch) to `yourproject` (which it does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and demo-recording script only; no runtime, auth, or build logic changes—risk is doc drift or misleading examples if anything was missed.
> 
> **Overview**
> This PR **rewrites documentation and demo tooling** across the repo (no application source changes): shorter, emoji-free guides with progressive disclosure, aligned to the real CLI, build, tests, and template cleanup flow.
> 
> **Accuracy against the codebase:** Architecture and contributing docs now name real `app_*` / `tui_*` entry points and the command-table lifecycle. Zig build docs match `build.zig` (`b.createModule`, `exe.root_module.addCSourceFiles`, `base_sources` / `tui_sources`). Security and architecture text drop claims about default PIE/RELRO/stack canaries/FORTIFY and describe what is actually present (warnings, `app_secret_zero`, CI static analysis and supply-chain checks). Testing docs add the **unit-test** layer (`zig build unit-test`) alongside CLI contracts and Ghostty PTY scenarios. Template/generated README fixes include **`app_output(text, config, …)`** argument order and Windows config under `%USERPROFILE%\AppData\Local\…`.
> 
> **Examples and demos:** `advanced-usage.md` and the demo gallery stop documenting fictional commands (`process`, `validate`, etc.) and use only shipped commands plus `opencli`/`jq` patterns. `scripts/create-demo.sh` records those real flows and **no longer overwrites** `docs/demos/README.md`, so the hand-maintained gallery stays authoritative.
> 
> **Meta / template:** Changelog trimmed to **`[0.1.0]`** with `yourproject` link placeholders; CoC enforcement contact filled in; security policy points at **GitHub private vulnerability reporting**; template maintainer docs fix `template-vars.json` shape (`sources`), transforms, and support placeholder tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3bdfe866587ae28c9bc9ded7529c069d4fc5ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->