### PR TITLE
feat(build): Support non-Nix template workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,7 @@
     },
     "ghcr.io/devcontainers/features/zig:1": {
       "version": "0.16.0"
-    },
-    "ghcr.io/devcontainers/features/nix:1": {}
+    }
   },
 
   // Configure tool-specific properties
@@ -35,7 +34,7 @@
         "editor.rulers": [80, 120],
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true,
-        "C_Cpp.default.cStandard": "c11",
+        "C_Cpp.default.cStandard": "c23",
         "C_Cpp.default.cppStandard": "c++17",
         "C_Cpp.clang_format_style": "file",
         "C_Cpp.formatting": "clangFormat"
@@ -83,7 +82,7 @@
   "remoteUser": "vscode",
 
   // Additional features
-  "updateContentCommand": "sudo apt-get update && sudo apt-get install -y build-essential clang clang-format lldb gdb cmake ninja-build valgrind codelldb lldb-mi pkg-config libncurses-dev",
+  "updateContentCommand": "sudo apt-get update && sudo apt-get install -y build-essential clang clang-format clang-tidy cppcheck lldb gdb cmake ninja-build valgrind codelldb lldb-mi pkg-config libncurses-dev just shellcheck",
 
   // Workspace settings
   "workspaceFolder": "/workspace",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,35 +9,19 @@ echo "Zig version: $(zig version)"
 echo "Clang version: $(clang --version | head -n1)"
 echo "CMake version: $(cmake --version | head -n1)"
 
-# Always verify the TUI build itself, then add PTY coverage when Ghostty VT is
-# available. libghostty-vt is a Ghostty flake output, not a nixpkgs package, so
-# mirror CI's explicit flake build instead of relying on devcontainer Nix attrs.
+# Keep the default container path Nix-free: Zig + platform packages are enough
+# for the baseline CLI and TUI build. PTY-backed terminal scenarios run only
+# when libghostty-vt is already installed and discoverable by pkg-config.
+echo "🔨 Building default CLI..."
+zig build
+
+echo "🧪 Running baseline tests..."
+zig build test
+
 echo "🔨 Building TUI-enabled project..."
 zig build -Denable-tui=true
 
-if ! pkg-config --exists libghostty-vt && command -v nix >/dev/null 2>&1; then
-  ghostty_ref="github:ghostty-org/ghostty/2e5ad917eb4e325a3dbb161c3f41208a8cd35e44"
-  echo "🔨 Building libghostty-vt from $ghostty_ref..."
-  if ghostty_vt_dev=$(nix build --accept-flake-config --no-link --print-out-paths "$ghostty_ref#libghostty-vt.dev"); then
-    export PKG_CONFIG_PATH="$ghostty_vt_dev/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-    profile_line="export PKG_CONFIG_PATH=$ghostty_vt_dev/share/pkgconfig\${PKG_CONFIG_PATH:+:\$PKG_CONFIG_PATH}"
-    grep -qxF "$profile_line" "$HOME/.profile" 2>/dev/null || printf '%s\n' "$profile_line" >>"$HOME/.profile"
-  else
-    echo "⚠️  Could not build libghostty-vt; continuing with CLI-only setup."
-  fi
-fi
-
-if pkg-config --exists libghostty-vt; then
-  echo "Ghostty VT version: $(pkg-config --modversion libghostty-vt)"
-  echo "🧪 Running Ghostty VT terminal tests..."
-  zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
-else
-  echo "⚠️  Ghostty VT not detected; skipping PTY terminal tests during setup."
-  echo "   Run nix build github:ghostty-org/ghostty/<rev>#libghostty-vt.dev and"
-  echo "   add its share/pkgconfig directory to PKG_CONFIG_PATH if you need"
-  echo "   'zig build -Denable-tui=true terminal-test' inside the container."
-  echo "🧪 Running CLI contract tests..."
-  zig build test
-fi
+echo "🧪 Running terminal-test in auto mode..."
+zig build -Denable-tui=true terminal-test
 
 echo "✨ Development environment setup complete!"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,11 +10,8 @@ echo "Clang version: $(clang --version | head -n1)"
 echo "CMake version: $(cmake --version | head -n1)"
 
 # Keep the default container path Nix-free: Zig + platform packages are enough
-# for the baseline CLI and TUI build. PTY-backed terminal scenarios run only
+# for the TUI build and baseline tests. PTY-backed terminal scenarios run only
 # when libghostty-vt is already installed and discoverable by pkg-config.
-echo "🔨 Building default CLI..."
-zig build
-
 echo "🧪 Running terminal-test in auto mode..."
 zig build -Denable-tui=true terminal-test
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -15,9 +15,6 @@ echo "CMake version: $(cmake --version | head -n1)"
 echo "🔨 Building default CLI..."
 zig build
 
-echo "🧪 Running baseline tests..."
-zig build test
-
 echo "🔨 Building TUI-enabled project..."
 zig build -Denable-tui=true
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -15,9 +15,6 @@ echo "CMake version: $(cmake --version | head -n1)"
 echo "🔨 Building default CLI..."
 zig build
 
-echo "🔨 Building TUI-enabled project..."
-zig build -Denable-tui=true
-
 echo "🧪 Running terminal-test in auto mode..."
 zig build -Denable-tui=true terminal-test
 

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,7 @@
-watch_file flake.nix
-watch_file flake.lock
-use flake path:.
+if has nix; then
+  watch_file flake.nix
+  watch_file flake.lock
+  use flake path:.
+else
+  log_status "nix not found; skipping optional Nix dev shell"
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,12 +167,6 @@ jobs:
           fi
 
           "./zig-out/bin/$BINARY_NAME$BINARY_EXT" --json info | grep '"tui":true'
-
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            # PTY/TUI coverage is Linux-only in CI for now; macOS and Windows
-            # still build the TUI binary and run the JSON smoke check above.
-            zig build -Denable-tui=true terminal-test
-          fi
         timeout-minutes: 15
         shell: bash
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,9 @@ jobs:
             zig-out/bin/${{ steps.extract_binary_name.outputs.binary_name }}.exe
           retention-days: 7
 
+  # Optional required-PTY gate for maintainers. This runs through flake.lock via
+  # `nix develop`; if you make it branch-protected, update the flake pin
+  # intentionally so Ghostty VT API drift is reviewed.
   ghostty-vt-nix:
     name: PTY/TUI terminal tests with Nix
     if: ${{ vars.CI_ENABLE_NIX_GHOSTTY == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,10 +56,6 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
 
-      - name: Install Nix (Linux)
-        if: runner.os == 'Linux'
-        uses: cachix/install-nix-action@v31
-
       - name: Get Zig version
         id: zig-version
         run: |
@@ -90,21 +86,10 @@ jobs:
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then
             sudo apt-get update
-            sudo apt-get install -y libncurses-dev
+            sudo apt-get install -y pkg-config libncurses-dev
           elif [ "${{ runner.os }}" = "macOS" ]; then
-            brew install ncurses
+            brew install pkg-config ncurses
           fi
-        shell: bash
-
-      - name: Build libghostty-vt (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          ghostty_ref="github:ghostty-org/ghostty/2e5ad917eb4e325a3dbb161c3f41208a8cd35e44"
-          nix build --accept-flake-config --no-link "$ghostty_ref#libghostty-vt.out"
-          ghostty_vt_dev="$(nix build --accept-flake-config --no-link --print-out-paths "$ghostty_ref#libghostty-vt.dev")"
-          echo "GHOSTTY_VT_DEV=$ghostty_vt_dev" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$ghostty_vt_dev/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
-        timeout-minutes: 15
         shell: bash
 
       - name: Install pdcurses (Windows)
@@ -186,7 +171,7 @@ jobs:
           if [ "${{ runner.os }}" = "Linux" ]; then
             # PTY/TUI coverage is Linux-only in CI for now; macOS and Windows
             # still build the TUI binary and run the JSON smoke check above.
-            zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
+            zig build -Denable-tui=true terminal-test
           fi
         timeout-minutes: 15
         shell: bash
@@ -204,6 +189,27 @@ jobs:
             zig-out/bin/${{ steps.extract_binary_name.outputs.binary_name }}
             zig-out/bin/${{ steps.extract_binary_name.outputs.binary_name }}.exe
           retention-days: 7
+
+  ghostty-vt-nix:
+    name: PTY/TUI terminal tests with Nix
+    if: ${{ vars.CI_ENABLE_NIX_GHOSTTY == 'true' }}
+    runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Run required Ghostty VT terminal tests
+        run: |
+          nix --accept-flake-config develop --command \
+            zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
+        timeout-minutes: 20
+        shell: bash
 
   lint:
     name: Lint and Format

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,9 +184,10 @@ jobs:
             zig-out/bin/${{ steps.extract_binary_name.outputs.binary_name }}.exe
           retention-days: 7
 
-  # Optional required-PTY gate for maintainers. This runs through flake.lock via
-  # `nix develop`; if you make it branch-protected, update the flake pin
-  # intentionally so Ghostty VT API drift is reviewed.
+  # Optional required-PTY gate for maintainers. This uses pkgs.libghostty-vt
+  # from the repository flake, not the old direct Ghostty flake build. If you
+  # make it branch-protected, update flake.lock intentionally so nixpkgs package
+  # lineage and Ghostty VT API drift are reviewed.
   ghostty-vt-nix:
     name: PTY/TUI terminal tests with Nix
     if: ${{ vars.CI_ENABLE_NIX_GHOSTTY == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ zig-pkg/
 
 # OS files
 .DS_Store
+._*
 Thumbs.db
 
 # Editor files

--- a/.template/TEMPLATE_README.md
+++ b/.template/TEMPLATE_README.md
@@ -16,17 +16,27 @@ A ready-to-use C23 TUI + CLI starter.
 
 ## Requirements
 
-- Zig 0.16.0.
-- A system C toolchain for libc and optional platform libraries.
-- ncurses development headers (Linux/macOS) or PDCurses (Windows) when building with `-Denable-tui=true`.
-- Optional `libghostty-vt` development files for PTY-backed TUI scenario tests.
+Default CLI builds need only:
+
+- Zig 0.16.0 (the version pinned by this template).
+- A system C toolchain for libc.
+
+Optional TUI builds (`-Denable-tui=true`) also need curses development files:
+
+- Ubuntu/Debian: `sudo apt-get install pkg-config libncurses-dev`
+- macOS: `brew install pkg-config ncurses`
+- Fedora: `sudo dnf install pkg-config ncurses-devel`
+- Windows: `vcpkg install pdcurses:x64-windows`
+
+Optional PTY-backed TUI scenarios need `libghostty-vt` development files discoverable through `pkg-config`, or the Nix dev shell.
 
 ## Build
 
 ```bash
 zig build                          # debug
 zig build -Doptimize=ReleaseSafe   # optimized
-zig build -Denable-tui=true        # with the ncurses TUI
+zig build -Denable-tui=true        # with the ncurses/PDCurses TUI
+zig build -Denable-tui=true -Dcurses-prefix="$(brew --prefix ncurses)"  # macOS/Homebrew TUI
 zig build tui-menu-lib             # the reusable TUI menu static library
 ```
 
@@ -55,11 +65,15 @@ zig build -Denable-tui=true run -- menu
 
 ```bash
 zig build test            # unit tests + CLI contract tests
-zig build terminal-test   # the above, plus PTY/TUI scenarios when available
+zig build terminal-test   # unit + CLI tests; PTY/TUI skipped unless TUI + backend are available
+zig build -Denable-tui=true terminal-test  # TUI build; PTY scenarios run if libghostty-vt is found
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test  # require Ghostty VT
+zig build -Dterminal-backend=none terminal-test  # never run PTY/TUI scenarios
 zig build check           # fmt-check + tests (the CI gate)
 ```
 
-`zig build test` verifies that `myapp opencli` still matches `opencli.json`. PTY-backed TUI tests need `libghostty-vt`; they skip cleanly when it is absent, or pass `-Dterminal-backend=ghostty` to require them.
+`zig build test` verifies that `myapp opencli` still matches `opencli.json`. PTY-backed TUI tests need `libghostty-vt`.
+Auto mode skips them cleanly when it is absent, `-Dterminal-backend=ghostty` requires them, and `-Dterminal-backend=none` disables them explicitly.
 
 ## Project layout
 
@@ -97,7 +111,9 @@ Then update `src/cli/commands.c` (metadata and dispatch), regenerate `opencli.js
 
 ## Customize the TUI
 
-The TUI helpers live under `src/tui/`: `tui.c` owns the ncurses lifecycle, windows, and dialogs; `tui_menu.c` / `tui_menu_model.c` own the reusable modal menu; `tui_progress.c` owns progress rendering; `tui_app.c` wires the `menu` command's showcase. Keep raw curses calls inside this layer so command handlers stay testable without a terminal. See `examples/custom-tui.md`.
+The TUI helpers live under `src/tui/`: `tui.c` owns the ncurses lifecycle, windows, and dialogs; `tui_menu.c` / `tui_menu_model.c` own the reusable modal menu.
+`tui_progress.c` owns progress rendering; `tui_app.c` wires the `menu` command's showcase.
+Keep raw curses calls inside this layer so command handlers stay testable without a terminal. See `examples/custom-tui.md`.
 
 ## Configuration
 

--- a/.template/TEMPLATE_USAGE.md
+++ b/.template/TEMPLATE_USAGE.md
@@ -115,11 +115,14 @@ zig build
 zig build test
 zig build terminal-test
 zig build -Denable-tui=true terminal-test
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test  # require Ghostty VT when available
+zig build -Dterminal-backend=none terminal-test                       # force non-PTY mode
 zig build check
 ```
 
-For the TUI, `zig build -Denable-tui=true terminal-test` drives the menu through a pseudo-terminal when `libghostty-vt` is available.
+For the TUI, `zig build -Denable-tui=true terminal-test` builds the TUI and drives the menu through a pseudo-terminal only when `libghostty-vt` is available.
 Use `-Dterminal-backend=ghostty` to require that backend instead of skipping PTY-backed TUI coverage on machines without Ghostty VT.
+Use `nix develop` as a convenience path if you want the repository-provided Nix shell.
 
 Also run the menu command in a real terminal before shipping major UI changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ cd c23-cli-template
 git checkout -b your-change
 
 # Build and test
-zig build check                                # fmt-check + tests (the CI gate)
-zig build -Denable-tui=true terminal-test      # if you touched the TUI
+zig build check                                           # fmt-check + tests (the CI gate)
+zig build -Denable-tui=true terminal-test                 # if you touched the TUI
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test  # require PTY/TUI coverage
 
 # Format, commit, push
 zig build fmt
@@ -22,7 +23,7 @@ git commit -m "feat(scope): one-line summary"
 git push origin your-change
 ```
 
-Open a PR against `main`. CI runs `zig build check` on Linux, macOS, and Windows, plus `clang-tidy` and `cppcheck`.
+Open a PR against `main`. CI runs `zig build check` on Linux, macOS, and Windows, plus `clang-tidy` and `cppcheck`, without requiring Nix by default.
 
 ## Reporting issues
 
@@ -54,18 +55,18 @@ Only needed for `-Denable-tui=true` builds. (The default build links only libc.)
 
 | Platform | Install |
 | --- | --- |
-| macOS | `brew install ncurses` |
-| Ubuntu / Debian | `sudo apt-get install libncurses-dev clang-format clang-tidy` |
-| Fedora / RHEL | `sudo dnf install ncurses-devel clang-tools-extra` |
+| macOS | `brew install pkg-config ncurses` |
+| Ubuntu / Debian | `sudo apt-get install pkg-config libncurses-dev clang-format clang-tidy` |
+| Fedora / RHEL | `sudo dnf install pkg-config ncurses-devel clang-tools-extra` |
 | Windows | `vcpkg install pdcurses:x64-windows` |
 
-### Alternative: Nix or devcontainer
+### Optional: Nix or devcontainer
 
 ```bash
-nix develop                # Zig, C toolchain, libghostty-vt, markdownlint
+nix develop                # convenience shell with Zig, C tooling, curses, Ghostty VT, markdownlint
 ```
 
-The repository also ships a devcontainer (open in VS Code, choose **Reopen in Container**) with the same dependencies pre-installed.
+The repository also ships a default devcontainer (open in VS Code, choose **Reopen in Container**) that uses Zig and normal Linux packages, not Nix.
 
 ## Build and test
 
@@ -76,7 +77,8 @@ zig build                                # debug build
 zig build -Doptimize=ReleaseSafe         # optimized
 zig build run -- hello Alice             # build + run with arguments
 zig build test                           # unit tests + CLI contract tests
-zig build terminal-test                  # the above + PTY/TUI scenarios when available
+zig build terminal-test                  # unit + CLI tests; PTY/TUI skipped unless TUI + backend are available
+zig build -Denable-tui=true terminal-test # TUI build; PTY scenarios run if libghostty-vt is found
 zig build check                          # fmt-check + tests (the CI gate)
 zig build fmt                            # apply formatting
 zig build clean                          # remove zig-out + .zig-cache
@@ -112,7 +114,8 @@ Append the path to `base_sources` in `build.zig` (TUI-only files belong in `tui_
 
 4. Keep PRs focused. Update documentation when behavior changes (commands, flags, exit codes, the OpenCLI contract).
 
-Local pre-commit hooks (install with `pre-commit install`) run clang-format, markdownlint, and the conventional-commit validator. CI runs `zig build check` on three platforms plus `clang-tidy` and `cppcheck`.
+Local pre-commit hooks (install with `pre-commit install`) run clang-format, markdownlint, and the conventional-commit validator.
+CI runs `zig build check` on three platforms plus `clang-tidy` and `cppcheck`; optional Ghostty VT coverage can be enabled with `CI_ENABLE_NIX_GHOSTTY=true`.
 
 ## Coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ Append the path to `base_sources` in `build.zig` (TUI-only files belong in `tui_
 
 Local pre-commit hooks (install with `pre-commit install`) run clang-format, markdownlint, and the conventional-commit validator.
 CI runs `zig build check` on three platforms plus `clang-tidy` and `cppcheck`; optional Ghostty VT coverage can be enabled with `CI_ENABLE_NIX_GHOSTTY=true`.
+That optional job uses the nixpkgs `libghostty-vt` package pinned by `flake.lock`, so review lockfile bumps if you make it branch-protected.
 
 ## Coding standards
 

--- a/README.md
+++ b/README.md
@@ -140,21 +140,27 @@ For TUI screens, see [examples/custom-tui.md](examples/custom-tui.md).
 
 ### Prerequisites
 
-- **Zig 0.16.0** (current stable release) - Install via [zvm](https://github.com/tristanisham/zvm)
-- **C compiler** - For system libraries
-- **NCurses** - Optional; required only for `-Denable-tui=true`
-  - Ubuntu/Debian: `sudo apt-get install libncurses-dev`
-  - macOS: `brew install ncurses`
-  - Fedora: `sudo dnf install ncurses-devel`
-- **[libghostty-vt](https://libghostty.tip.ghostty.org/index.html) tip/development API** - Optional outside Nix; enables the C Ghostty VT backend for PTY-backed terminal tests
+Default CLI builds need only:
+
+- **Zig 0.16.0** - the version pinned by this template; install via [zvm](https://github.com/tristanisham/zvm) or your package manager
+- **A system C toolchain** - for libc and platform libraries
+
+Optional TUI builds (`-Denable-tui=true`) also need curses development files:
+
+- Ubuntu/Debian: `sudo apt-get install pkg-config libncurses-dev`
+- macOS: `brew install pkg-config ncurses`
+- Fedora: `sudo dnf install pkg-config ncurses-devel`
+- Windows: `vcpkg install pdcurses:x64-windows`
+
+Optional PTY-backed TUI scenarios need [libghostty-vt](https://libghostty.tip.ghostty.org/index.html) development files discoverable through `pkg-config`, or the Nix dev shell.
 
 ### Development environment
 
 This template provides several tools to enhance your development experience:
 
-- **Devcontainer Support** - Pre-configured development environment with all dependencies
-- **Nix Dev Shell** - Includes Zig, C tooling, nixpkgs `libghostty-vt` for terminal tests, and markdown lint tooling
-- **CI Quality Checks** - Automated build, test, lint, security, and release checks
+- **Devcontainer Support** - Pre-configured non-Nix development environment with Zig and platform packages
+- **Optional Nix Dev Shell** - Convenience shell with Zig, C tooling, curses, Ghostty VT, and markdown lint tooling
+- **CI Quality Checks** - Automated build, test, lint, security, and release checks without requiring Nix by default
 
 ### Commands
 
@@ -163,13 +169,16 @@ This template provides several tools to enhance your development experience:
 zig build                                  # Debug build
 zig build -Doptimize=ReleaseSafe           # Release build
 zig build -Denable-tui=true                # Build with the ncurses/PDCurses TUI
+zig build -Denable-tui=true -Dcurses-prefix="$(brew --prefix ncurses)"  # macOS/Homebrew TUI
 zig build tui-menu-lib                     # Build the reusable TUI menu static library
 
 # Test
 zig build unit-test                        # In-process unit tests
 zig build test                             # Unit tests + CLI contract tests
-zig build terminal-test                    # The above + PTY/TUI scenarios when available
-zig build -Denable-tui=true terminal-test  # Run PTY/TUI scenarios against the TUI build
+zig build terminal-test                    # Unit + CLI tests; PTY/TUI skipped unless TUI + backend are available
+zig build -Denable-tui=true terminal-test  # TUI build; PTY scenarios run if libghostty-vt is found
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test  # Require Ghostty VT
+zig build -Dterminal-backend=none terminal-test  # Never run PTY/TUI scenarios
 zig build check                            # fmt-check + tests (the CI gate)
 
 # Format

--- a/build.zig
+++ b/build.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const TerminalTestBackend = enum {
     auto,
+    none,
     ghostty,
 };
 
@@ -42,25 +43,35 @@ fn ghosttyLibraryExists(b: *std.Build, lib_dir: []const u8) bool {
         pathExists(b, b.fmt("{s}/libghostty-vt.a", .{lib_dir}));
 }
 
+fn ghosttyLibraryExistsUnderPrefix(b: *std.Build, prefix: []const u8) bool {
+    return ghosttyLibraryExists(b, b.fmt("{s}/lib", .{prefix})) or
+        ghosttyLibraryExists(b, b.fmt("{s}/lib64", .{prefix}));
+}
+
 fn hasGhosttyTerminalApi(b: *std.Build, prefix: ?[]const u8) bool {
     if (prefix) |pref| {
-        return pathExists(b, b.fmt("{s}/include/ghostty/vt/terminal.h", .{pref})) and
+        return pathExists(b, b.fmt("{s}/include/ghostty/vt.h", .{pref})) and
+            pathExists(b, b.fmt("{s}/include/ghostty/vt/terminal.h", .{pref})) and
             pathExists(b, b.fmt("{s}/include/ghostty/vt/formatter.h", .{pref})) and
-            ghosttyLibraryExists(b, b.fmt("{s}/lib", .{pref}));
+            ghosttyLibraryExistsUnderPrefix(b, pref);
     }
 
-    return commandSucceeds(b, &.{
-        "sh",
-        "-c",
-        "pkg-config --exists libghostty-vt && " ++
-            "inc=$(pkg-config --variable=includedir libghostty-vt) && " ++
-            "lib=$(pkg-config --variable=libdir libghostty-vt) && " ++
-            "test -f \"$inc/ghostty/vt/terminal.h\" && " ++
-            "test -f \"$inc/ghostty/vt/formatter.h\" && " ++
-            "{ test -f \"$lib/libghostty-vt.so\" || " ++
-            "test -f \"$lib/libghostty-vt.dylib\" || " ++
-            "test -f \"$lib/libghostty-vt.a\"; }",
-    });
+    if (!commandSucceeds(b, &.{ "pkg-config", "--exists", "libghostty-vt" })) return false;
+    const include_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=includedir", "libghostty-vt" }) orelse return false;
+    const lib_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" }) orelse return false;
+
+    return pathExists(b, b.fmt("{s}/ghostty/vt.h", .{include_dir})) and
+        pathExists(b, b.fmt("{s}/ghostty/vt/terminal.h", .{include_dir})) and
+        pathExists(b, b.fmt("{s}/ghostty/vt/formatter.h", .{include_dir})) and
+        ghosttyLibraryExists(b, lib_dir);
+}
+
+fn addMessageCommand(b: *std.Build, target: std.Build.ResolvedTarget, message: []const u8) *std.Build.Step.Run {
+    if (target.result.os.tag == .windows) {
+        return b.addSystemCommand(&.{ "cmd", "/C", "echo", message });
+    }
+
+    return b.addSystemCommand(&.{ "printf", "%s\n", message });
 }
 
 fn prependRunEnvPath(run: *std.Build.Step.Run, key: []const u8, dir: []const u8) void {
@@ -126,7 +137,7 @@ pub fn build(b: *std.Build) void {
 
     const enable_tui = b.option(bool, "enable-tui", "Enable TUI support with ncurses/PDCurses (default: false)") orelse false;
     const curses_prefix = b.option([]const u8, "curses-prefix", "Override ncurses/PDCurses prefix (e.g. /usr/local/opt/ncurses)");
-    const terminal_backend = b.option(TerminalTestBackend, "terminal-backend", "Terminal test backend: auto or ghostty") orelse .auto;
+    const terminal_backend = b.option(TerminalTestBackend, "terminal-backend", "Terminal test backend: auto, none, or ghostty") orelse .auto;
     const ghostty_vt_prefix = b.option([]const u8, "ghostty-vt-prefix", "Override libghostty-vt install prefix for Ghostty-backed terminal tests");
 
     const exe = b.addExecutable(.{
@@ -335,15 +346,25 @@ pub fn build(b: *std.Build) void {
     unit_step.dependOn(&unit_cmd.step);
     test_step.dependOn(&unit_cmd.step);
 
-    if (terminal_backend == .ghostty and target.result.os.tag == .windows) {
+    const is_windows = target.result.os.tag == .windows;
+    if (terminal_backend == .ghostty and is_windows) {
         std.log.err("-Dterminal-backend=ghostty is not supported on Windows", .{});
         std.process.exit(1);
     }
-    const have_ghostty_vt = hasGhosttyTerminalApi(b, ghostty_vt_prefix);
+    if (terminal_backend == .ghostty and !enable_tui) {
+        std.log.err(
+            "-Dterminal-backend=ghostty requires -Denable-tui=true because the PTY scenarios exercise the TUI.",
+            .{},
+        );
+        std.process.exit(1);
+    }
+
+    const should_probe_ghostty = enable_tui and !is_windows and terminal_backend != .none;
+    const have_ghostty_vt = should_probe_ghostty and hasGhosttyTerminalApi(b, ghostty_vt_prefix);
     if (terminal_backend == .ghostty and !have_ghostty_vt) {
         std.log.err(
-            "-Dterminal-backend=ghostty needs libghostty-vt with the terminal/formatter API.\n" ++
-                "  Install libghostty-vt and ensure pkg-config can find it, or pass -Dghostty-vt-prefix=/path.",
+            "-Dterminal-backend=ghostty requires libghostty-vt with the terminal/formatter API.\n" ++
+                "  Install it so pkg-config can find libghostty-vt.pc, or pass -Dghostty-vt-prefix=/path.",
             .{},
         );
         std.process.exit(1);
@@ -352,8 +373,14 @@ pub fn build(b: *std.Build) void {
         commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" })
     else
         null;
-    const use_ghostty_terminal_tests = target.result.os.tag != .windows and
-        (terminal_backend == .ghostty or (terminal_backend == .auto and have_ghostty_vt));
+    const ghostty_prefix_lib_dir = if (ghostty_vt_prefix) |pref|
+        if (ghosttyLibraryExists(b, b.fmt("{s}/lib", .{pref})))
+            b.fmt("{s}/lib", .{pref})
+        else
+            b.fmt("{s}/lib64", .{pref})
+    else
+        null;
+    const use_ghostty_terminal_tests = enable_tui and !is_windows and have_ghostty_vt and terminal_backend != .none;
 
     const terminal_test_step = b.step("terminal-test", "Run CLI contracts and optional PTY/TUI terminal scenarios");
     terminal_test_step.dependOn(test_step);
@@ -381,9 +408,10 @@ pub fn build(b: *std.Build) void {
         });
 
         if (ghostty_vt_prefix) |pref| {
+            const lib_dir = ghostty_prefix_lib_dir.?;
             vt_test_mod.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{pref}) });
-            vt_test_mod.addLibraryPath(.{ .cwd_relative = b.fmt("{s}/lib", .{pref}) });
-            vt_test_mod.addRPath(.{ .cwd_relative = b.fmt("{s}/lib", .{pref}) });
+            vt_test_mod.addLibraryPath(.{ .cwd_relative = lib_dir });
+            vt_test_mod.addRPath(.{ .cwd_relative = lib_dir });
             vt_test_mod.linkSystemLibrary("ghostty-vt", .{ .use_pkg_config = .no });
         } else {
             if (ghostty_pkg_lib_dir) |lib_dir| {
@@ -404,8 +432,8 @@ pub fn build(b: *std.Build) void {
             "--tui-enabled",
             "auto",
         });
-        if (ghostty_vt_prefix) |pref| {
-            const lib_path = b.fmt("{s}/lib", .{pref});
+        if (ghostty_vt_prefix != null) {
+            const lib_path = ghostty_prefix_lib_dir.?;
             prependRunEnvPath(vt_test_cmd, "LD_LIBRARY_PATH", lib_path);
             prependRunEnvPath(vt_test_cmd, "DYLD_FALLBACK_LIBRARY_PATH", lib_path);
         } else if (ghostty_pkg_lib_dir) |lib_dir| {
@@ -414,6 +442,17 @@ pub fn build(b: *std.Build) void {
         }
         vt_test_cmd.step.dependOn(b.getInstallStep());
         terminal_test_step.dependOn(&vt_test_cmd.step);
+    } else {
+        const skip_reason = if (terminal_backend == .none)
+            "Skipping PTY/TUI terminal scenarios: disabled by -Dterminal-backend=none."
+        else if (!enable_tui)
+            "Skipping PTY/TUI terminal scenarios: pass -Denable-tui=true to build the TUI."
+        else if (is_windows)
+            "Skipping PTY/TUI terminal scenarios: Ghostty VT backend is POSIX-only."
+        else
+            "Skipping PTY/TUI terminal scenarios: libghostty-vt was not found; use -Dterminal-backend=ghostty to require it.";
+        const skip_cmd = addMessageCommand(b, target, skip_reason);
+        terminal_test_step.dependOn(&skip_cmd.step);
     }
 
     // Clean command – cross-platform

--- a/build.zig
+++ b/build.zig
@@ -82,22 +82,23 @@ fn ghosttyLibraryExistsUnderPrefix(b: *std.Build, prefix: []const u8) bool {
         ghosttyLibraryExists(b, b.fmt("{s}/lib64", .{prefix}));
 }
 
-fn hasGhosttyTerminalApi(b: *std.Build, prefix: ?[]const u8) bool {
-    if (prefix) |pref| {
-        return pathExists(b, b.fmt("{s}/include/ghostty/vt.h", .{pref})) and
-            pathExists(b, b.fmt("{s}/include/ghostty/vt/terminal.h", .{pref})) and
-            pathExists(b, b.fmt("{s}/include/ghostty/vt/formatter.h", .{pref})) and
-            ghosttyLibraryExistsUnderPrefix(b, pref);
-    }
+fn hasGhosttyPrefixTerminalApi(b: *std.Build, prefix: []const u8) bool {
+    return pathExists(b, b.fmt("{s}/include/ghostty/vt.h", .{prefix})) and
+        pathExists(b, b.fmt("{s}/include/ghostty/vt/terminal.h", .{prefix})) and
+        pathExists(b, b.fmt("{s}/include/ghostty/vt/formatter.h", .{prefix})) and
+        ghosttyLibraryExistsUnderPrefix(b, prefix);
+}
 
-    if (!commandSucceeds(b, &.{ "pkg-config", "--exists", "libghostty-vt" })) return false;
-    const include_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=includedir", "libghostty-vt" }) orelse return false;
-    const lib_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" }) orelse return false;
+fn ghosttyPkgConfigLibDir(b: *std.Build) ?[]const u8 {
+    if (!commandSucceeds(b, &.{ "pkg-config", "--exists", "libghostty-vt" })) return null;
+    const include_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=includedir", "libghostty-vt" }) orelse return null;
+    const lib_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" }) orelse return null;
 
-    return pathExists(b, b.fmt("{s}/ghostty/vt.h", .{include_dir})) and
+    const found = pathExists(b, b.fmt("{s}/ghostty/vt.h", .{include_dir})) and
         pathExists(b, b.fmt("{s}/ghostty/vt/terminal.h", .{include_dir})) and
         pathExists(b, b.fmt("{s}/ghostty/vt/formatter.h", .{include_dir})) and
         ghosttyLibraryExists(b, lib_dir);
+    return if (found) lib_dir else null;
 }
 
 fn addMessageCommand(b: *std.Build, message: []const u8) *std.Build.Step.Run {
@@ -381,16 +382,19 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&unit_cmd.step);
 
     const should_probe_ghostty = enable_tui and target.result.os.tag != .windows and terminal_backend != .none;
-    const have_ghostty_vt = should_probe_ghostty and hasGhosttyTerminalApi(b, ghostty_vt_prefix);
+    const ghostty_pkg_lib_dir = if (should_probe_ghostty and ghostty_vt_prefix == null)
+        ghosttyPkgConfigLibDir(b)
+    else
+        null;
+    const have_ghostty_vt = should_probe_ghostty and if (ghostty_vt_prefix) |pref|
+        hasGhosttyPrefixTerminalApi(b, pref)
+    else
+        ghostty_pkg_lib_dir != null;
     const terminal_test_plan = resolveTerminalTestPlan(enable_tui, terminal_backend, target, have_ghostty_vt);
     if (terminal_test_plan == .fail) {
         std.log.err("{s}", .{terminal_test_plan.fail});
         std.process.exit(1);
     }
-    const ghostty_pkg_lib_dir = if (have_ghostty_vt and ghostty_vt_prefix == null)
-        commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" })
-    else
-        null;
     const ghostty_prefix_lib_dir = if (ghostty_vt_prefix) |pref|
         if (ghosttyLibraryExists(b, b.fmt("{s}/lib", .{pref})))
             b.fmt("{s}/lib", .{pref})

--- a/build.zig
+++ b/build.zig
@@ -66,8 +66,8 @@ fn hasGhosttyTerminalApi(b: *std.Build, prefix: ?[]const u8) bool {
         ghosttyLibraryExists(b, lib_dir);
 }
 
-fn addMessageCommand(b: *std.Build, target: std.Build.ResolvedTarget, message: []const u8) *std.Build.Step.Run {
-    if (target.result.os.tag == .windows) {
+fn addMessageCommand(b: *std.Build, message: []const u8) *std.Build.Step.Run {
+    if (b.graph.host.result.os.tag == .windows) {
         return b.addSystemCommand(&.{ "cmd", "/C", "echo", message });
     }
 
@@ -451,7 +451,7 @@ pub fn build(b: *std.Build) void {
             "Skipping PTY/TUI terminal scenarios: Ghostty VT backend is POSIX-only."
         else
             "Skipping PTY/TUI terminal scenarios: libghostty-vt was not found; use -Dterminal-backend=ghostty to require it.";
-        const skip_cmd = addMessageCommand(b, target, skip_reason);
+        const skip_cmd = addMessageCommand(b, skip_reason);
         terminal_test_step.dependOn(&skip_cmd.step);
     }
 

--- a/build.zig
+++ b/build.zig
@@ -6,13 +6,18 @@ const TerminalTestBackend = enum {
     ghostty,
 };
 
+const GhosttyTerminalApi = struct {
+    pkg_lib_dir: ?[]const u8 = null,
+    prefix_lib_dir: ?[]const u8 = null,
+};
+
 const TerminalTestPlan = union(enum) {
-    run_ghostty,
+    run_ghostty: GhosttyTerminalApi,
     skip: []const u8,
     fail: []const u8,
 };
 
-fn resolveTerminalTestPlan(enable_tui: bool, terminal_backend: TerminalTestBackend, target: std.Build.ResolvedTarget, have_ghostty_vt: bool) TerminalTestPlan {
+fn resolveTerminalTestPlan(b: *std.Build, enable_tui: bool, terminal_backend: TerminalTestBackend, target: std.Build.ResolvedTarget, ghostty_vt_prefix: ?[]const u8) TerminalTestPlan {
     const target_is_windows = target.result.os.tag == .windows;
 
     if (terminal_backend == .ghostty and target_is_windows) {
@@ -20,9 +25,6 @@ fn resolveTerminalTestPlan(enable_tui: bool, terminal_backend: TerminalTestBacke
     }
     if (terminal_backend == .ghostty and !enable_tui) {
         return .{ .fail = "-Dterminal-backend=ghostty requires -Denable-tui=true because the PTY scenarios exercise the TUI." };
-    }
-    if (terminal_backend == .ghostty and !have_ghostty_vt) {
-        return .{ .fail = "-Dterminal-backend=ghostty requires libghostty-vt with the terminal/formatter API.\n  Install it so pkg-config can find libghostty-vt.pc, or pass -Dghostty-vt-prefix=/path." };
     }
     if (terminal_backend == .none) {
         return .{ .skip = "Skipping PTY/TUI terminal scenarios: disabled by -Dterminal-backend=none." };
@@ -33,11 +35,19 @@ fn resolveTerminalTestPlan(enable_tui: bool, terminal_backend: TerminalTestBacke
     if (target_is_windows) {
         return .{ .skip = "Skipping PTY/TUI terminal scenarios: Ghostty VT backend is POSIX-only." };
     }
-    if (!have_ghostty_vt) {
+
+    const ghostty_api = if (ghostty_vt_prefix) |pref|
+        ghosttyPrefixTerminalApi(b, pref)
+    else
+        ghosttyPkgConfigTerminalApi(b);
+    if (ghostty_api == null and terminal_backend == .ghostty) {
+        return .{ .fail = "-Dterminal-backend=ghostty requires libghostty-vt with the terminal/formatter API.\n  Install it so pkg-config can find libghostty-vt.pc, or pass -Dghostty-vt-prefix=/path." };
+    }
+    if (ghostty_api == null) {
         return .{ .skip = "Skipping PTY/TUI terminal scenarios: libghostty-vt was not found; use -Dterminal-backend=ghostty to require it." };
     }
 
-    return .run_ghostty;
+    return .{ .run_ghostty = ghostty_api.? };
 }
 
 fn commandSucceeds(b: *std.Build, argv: []const []const u8) bool {
@@ -77,28 +87,39 @@ fn ghosttyLibraryExists(b: *std.Build, lib_dir: []const u8) bool {
         pathExists(b, b.fmt("{s}/libghostty-vt.a", .{lib_dir}));
 }
 
-fn ghosttyLibraryExistsUnderPrefix(b: *std.Build, prefix: []const u8) bool {
-    return ghosttyLibraryExists(b, b.fmt("{s}/lib", .{prefix})) or
-        ghosttyLibraryExists(b, b.fmt("{s}/lib64", .{prefix}));
+fn ghosttyApiPresent(b: *std.Build, include_dir: []const u8, lib_dir: []const u8) bool {
+    return pathExists(b, b.fmt("{s}/ghostty/vt.h", .{include_dir})) and
+        pathExists(b, b.fmt("{s}/ghostty/vt/terminal.h", .{include_dir})) and
+        pathExists(b, b.fmt("{s}/ghostty/vt/formatter.h", .{include_dir})) and
+        ghosttyLibraryExists(b, lib_dir);
 }
 
-fn hasGhosttyPrefixTerminalApi(b: *std.Build, prefix: []const u8) bool {
-    return pathExists(b, b.fmt("{s}/include/ghostty/vt.h", .{prefix})) and
-        pathExists(b, b.fmt("{s}/include/ghostty/vt/terminal.h", .{prefix})) and
-        pathExists(b, b.fmt("{s}/include/ghostty/vt/formatter.h", .{prefix})) and
-        ghosttyLibraryExistsUnderPrefix(b, prefix);
+fn ghosttyPrefixLibDir(b: *std.Build, prefix: []const u8) ?[]const u8 {
+    const lib_dir = b.fmt("{s}/lib", .{prefix});
+    if (ghosttyLibraryExists(b, lib_dir)) return lib_dir;
+
+    const lib64_dir = b.fmt("{s}/lib64", .{prefix});
+    return if (ghosttyLibraryExists(b, lib64_dir)) lib64_dir else null;
 }
 
-fn ghosttyPkgConfigLibDir(b: *std.Build) ?[]const u8 {
+fn ghosttyPrefixTerminalApi(b: *std.Build, prefix: []const u8) ?GhosttyTerminalApi {
+    const include_dir = b.fmt("{s}/include", .{prefix});
+    const lib_dir = ghosttyPrefixLibDir(b, prefix) orelse return null;
+    return if (ghosttyApiPresent(b, include_dir, lib_dir))
+        .{ .prefix_lib_dir = lib_dir }
+    else
+        null;
+}
+
+fn ghosttyPkgConfigTerminalApi(b: *std.Build) ?GhosttyTerminalApi {
     if (!commandSucceeds(b, &.{ "pkg-config", "--exists", "libghostty-vt" })) return null;
     const include_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=includedir", "libghostty-vt" }) orelse return null;
     const lib_dir = commandOutputTrimmed(b, &.{ "pkg-config", "--variable=libdir", "libghostty-vt" }) orelse return null;
 
-    const found = pathExists(b, b.fmt("{s}/ghostty/vt.h", .{include_dir})) and
-        pathExists(b, b.fmt("{s}/ghostty/vt/terminal.h", .{include_dir})) and
-        pathExists(b, b.fmt("{s}/ghostty/vt/formatter.h", .{include_dir})) and
-        ghosttyLibraryExists(b, lib_dir);
-    return if (found) lib_dir else null;
+    return if (ghosttyApiPresent(b, include_dir, lib_dir))
+        .{ .pkg_lib_dir = lib_dir }
+    else
+        null;
 }
 
 fn addMessageCommand(b: *std.Build, message: []const u8) *std.Build.Step.Run {
@@ -381,30 +402,15 @@ pub fn build(b: *std.Build) void {
     unit_step.dependOn(&unit_cmd.step);
     test_step.dependOn(&unit_cmd.step);
 
-    const should_probe_ghostty = enable_tui and target.result.os.tag != .windows and terminal_backend != .none;
-    const ghostty_pkg_lib_dir = if (should_probe_ghostty and ghostty_vt_prefix == null)
-        ghosttyPkgConfigLibDir(b)
-    else
-        null;
-    const have_ghostty_vt = should_probe_ghostty and if (ghostty_vt_prefix) |pref|
-        hasGhosttyPrefixTerminalApi(b, pref)
-    else
-        ghostty_pkg_lib_dir != null;
-    const terminal_test_plan = resolveTerminalTestPlan(enable_tui, terminal_backend, target, have_ghostty_vt);
+    const terminal_test_plan = resolveTerminalTestPlan(b, enable_tui, terminal_backend, target, ghostty_vt_prefix);
     if (terminal_test_plan == .fail) {
         std.log.err("{s}", .{terminal_test_plan.fail});
         std.process.exit(1);
     }
-    const ghostty_prefix_lib_dir = if (ghostty_vt_prefix) |pref|
-        if (ghosttyLibraryExists(b, b.fmt("{s}/lib", .{pref})))
-            b.fmt("{s}/lib", .{pref})
-        else
-            b.fmt("{s}/lib64", .{pref})
-    else
-        null;
     const terminal_test_step = b.step("terminal-test", "Run CLI contracts and optional PTY/TUI terminal scenarios");
     terminal_test_step.dependOn(test_step);
     if (terminal_test_plan == .run_ghostty) {
+        const ghostty_api = terminal_test_plan.run_ghostty;
         const vt_test_mod = b.createModule(.{
             .root_source_file = null,
             .target = target,
@@ -428,13 +434,13 @@ pub fn build(b: *std.Build) void {
         });
 
         if (ghostty_vt_prefix) |pref| {
-            const lib_dir = ghostty_prefix_lib_dir.?;
+            const lib_dir = ghostty_api.prefix_lib_dir.?;
             vt_test_mod.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{pref}) });
             vt_test_mod.addLibraryPath(.{ .cwd_relative = lib_dir });
             vt_test_mod.addRPath(.{ .cwd_relative = lib_dir });
             vt_test_mod.linkSystemLibrary("ghostty-vt", .{ .use_pkg_config = .no });
         } else {
-            if (ghostty_pkg_lib_dir) |lib_dir| {
+            if (ghostty_api.pkg_lib_dir) |lib_dir| {
                 vt_test_mod.addRPath(.{ .cwd_relative = lib_dir });
             }
             vt_test_mod.linkSystemLibrary("libghostty-vt", .{});
@@ -452,11 +458,10 @@ pub fn build(b: *std.Build) void {
             "--tui-enabled",
             "auto",
         });
-        if (ghostty_vt_prefix != null) {
-            const lib_path = ghostty_prefix_lib_dir.?;
-            prependRunEnvPath(vt_test_cmd, "LD_LIBRARY_PATH", lib_path);
-            prependRunEnvPath(vt_test_cmd, "DYLD_FALLBACK_LIBRARY_PATH", lib_path);
-        } else if (ghostty_pkg_lib_dir) |lib_dir| {
+        if (ghostty_api.prefix_lib_dir) |lib_dir| {
+            prependRunEnvPath(vt_test_cmd, "LD_LIBRARY_PATH", lib_dir);
+            prependRunEnvPath(vt_test_cmd, "DYLD_FALLBACK_LIBRARY_PATH", lib_dir);
+        } else if (ghostty_api.pkg_lib_dir) |lib_dir| {
             prependRunEnvPath(vt_test_cmd, "LD_LIBRARY_PATH", lib_dir);
             prependRunEnvPath(vt_test_cmd, "DYLD_FALLBACK_LIBRARY_PATH", lib_dir);
         }

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,40 @@ const TerminalTestBackend = enum {
     ghostty,
 };
 
+const TerminalTestPlan = union(enum) {
+    run_ghostty,
+    skip: []const u8,
+    fail: []const u8,
+};
+
+fn resolveTerminalTestPlan(enable_tui: bool, terminal_backend: TerminalTestBackend, target: std.Build.ResolvedTarget, have_ghostty_vt: bool) TerminalTestPlan {
+    const target_is_windows = target.result.os.tag == .windows;
+
+    if (terminal_backend == .ghostty and target_is_windows) {
+        return .{ .fail = "-Dterminal-backend=ghostty is not supported on Windows" };
+    }
+    if (terminal_backend == .ghostty and !enable_tui) {
+        return .{ .fail = "-Dterminal-backend=ghostty requires -Denable-tui=true because the PTY scenarios exercise the TUI." };
+    }
+    if (terminal_backend == .ghostty and !have_ghostty_vt) {
+        return .{ .fail = "-Dterminal-backend=ghostty requires libghostty-vt with the terminal/formatter API.\n  Install it so pkg-config can find libghostty-vt.pc, or pass -Dghostty-vt-prefix=/path." };
+    }
+    if (terminal_backend == .none) {
+        return .{ .skip = "Skipping PTY/TUI terminal scenarios: disabled by -Dterminal-backend=none." };
+    }
+    if (!enable_tui) {
+        return .{ .skip = "Skipping PTY/TUI terminal scenarios: pass -Denable-tui=true to build the TUI." };
+    }
+    if (target_is_windows) {
+        return .{ .skip = "Skipping PTY/TUI terminal scenarios: Ghostty VT backend is POSIX-only." };
+    }
+    if (!have_ghostty_vt) {
+        return .{ .skip = "Skipping PTY/TUI terminal scenarios: libghostty-vt was not found; use -Dterminal-backend=ghostty to require it." };
+    }
+
+    return .run_ghostty;
+}
+
 fn commandSucceeds(b: *std.Build, argv: []const []const u8) bool {
     const child_res = std.process.run(b.allocator, b.graph.io, .{ .argv = argv }) catch return false;
     defer b.allocator.free(child_res.stdout);
@@ -346,27 +380,11 @@ pub fn build(b: *std.Build) void {
     unit_step.dependOn(&unit_cmd.step);
     test_step.dependOn(&unit_cmd.step);
 
-    const is_windows = target.result.os.tag == .windows;
-    if (terminal_backend == .ghostty and is_windows) {
-        std.log.err("-Dterminal-backend=ghostty is not supported on Windows", .{});
-        std.process.exit(1);
-    }
-    if (terminal_backend == .ghostty and !enable_tui) {
-        std.log.err(
-            "-Dterminal-backend=ghostty requires -Denable-tui=true because the PTY scenarios exercise the TUI.",
-            .{},
-        );
-        std.process.exit(1);
-    }
-
-    const should_probe_ghostty = enable_tui and !is_windows and terminal_backend != .none;
+    const should_probe_ghostty = enable_tui and target.result.os.tag != .windows and terminal_backend != .none;
     const have_ghostty_vt = should_probe_ghostty and hasGhosttyTerminalApi(b, ghostty_vt_prefix);
-    if (terminal_backend == .ghostty and !have_ghostty_vt) {
-        std.log.err(
-            "-Dterminal-backend=ghostty requires libghostty-vt with the terminal/formatter API.\n" ++
-                "  Install it so pkg-config can find libghostty-vt.pc, or pass -Dghostty-vt-prefix=/path.",
-            .{},
-        );
+    const terminal_test_plan = resolveTerminalTestPlan(enable_tui, terminal_backend, target, have_ghostty_vt);
+    if (terminal_test_plan == .fail) {
+        std.log.err("{s}", .{terminal_test_plan.fail});
         std.process.exit(1);
     }
     const ghostty_pkg_lib_dir = if (have_ghostty_vt and ghostty_vt_prefix == null)
@@ -380,11 +398,9 @@ pub fn build(b: *std.Build) void {
             b.fmt("{s}/lib64", .{pref})
     else
         null;
-    const use_ghostty_terminal_tests = enable_tui and !is_windows and have_ghostty_vt and terminal_backend != .none;
-
     const terminal_test_step = b.step("terminal-test", "Run CLI contracts and optional PTY/TUI terminal scenarios");
     terminal_test_step.dependOn(test_step);
-    if (use_ghostty_terminal_tests) {
+    if (terminal_test_plan == .run_ghostty) {
         const vt_test_mod = b.createModule(.{
             .root_source_file = null,
             .target = target,
@@ -442,16 +458,8 @@ pub fn build(b: *std.Build) void {
         }
         vt_test_cmd.step.dependOn(b.getInstallStep());
         terminal_test_step.dependOn(&vt_test_cmd.step);
-    } else {
-        const skip_reason = if (terminal_backend == .none)
-            "Skipping PTY/TUI terminal scenarios: disabled by -Dterminal-backend=none."
-        else if (!enable_tui)
-            "Skipping PTY/TUI terminal scenarios: pass -Denable-tui=true to build the TUI."
-        else if (is_windows)
-            "Skipping PTY/TUI terminal scenarios: Ghostty VT backend is POSIX-only."
-        else
-            "Skipping PTY/TUI terminal scenarios: libghostty-vt was not found; use -Dterminal-backend=ghostty to require it.";
-        const skip_cmd = addMessageCommand(b, skip_reason);
+    } else if (terminal_test_plan == .skip) {
+        const skip_cmd = addMessageCommand(b, terminal_test_plan.skip);
         terminal_test_step.dependOn(&skip_cmd.step);
     }
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,13 +22,16 @@ zig build check           # fmt-check + tests (the gate CI runs)
 PTY/TUI scenarios only run when the TUI is built and a terminal backend is present:
 
 ```bash
-zig build -Denable-tui=true terminal-test
+zig build -Denable-tui=true terminal-test                         # auto-run PTY scenarios when libghostty-vt is found
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test  # require Ghostty VT
+zig build -Dterminal-backend=none terminal-test                   # never run PTY/TUI scenarios
 ```
 
 ## The Ghostty VT backend
 
-`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the
-Ghostty VT backend when `pkg-config` finds libghostty-vt and its headers expose the
+`zig build terminal-test` defaults to `-Dterminal-backend=auto`. In auto mode it runs
+unit and CLI contract tests everywhere, then runs Ghostty VT-backed PTY/TUI scenarios
+only when `-Denable-tui=true` is set and `pkg-config` finds libghostty-vt with the
 Terminal and Formatter APIs. The backend is a C runner (`test/terminal_vt_*.c`) that
 runs the app in a real PTY, feeds output through
 [`libghostty-vt`](https://libghostty.tip.ghostty.org/index.html), snapshots the virtual
@@ -36,14 +39,16 @@ terminal with Ghostty's formatter API, and drives deterministic input and resize
 sequences.
 
 Use `-Dterminal-backend=ghostty` to *require* it on POSIX hosts (the build fails if
-libghostty-vt is missing). Without the backend, `zig build terminal-test` still runs the
-unit and CLI contract suites and skips PTY/TUI coverage.
+TUI support or libghostty-vt is missing). Use `-Dterminal-backend=none` to skip PTY/TUI
+coverage explicitly. Without the backend, auto mode still runs the unit and CLI contract
+suites and prints a skip reason.
 
-The Nix dev shell wires Zig, the C toolchain, and nixpkgs `libghostty-vt` into `PATH` and `pkg-config`:
+The Nix dev shell is a convenience path that wires Zig, the C toolchain, curses, and
+`libghostty-vt` into `PATH` and `pkg-config`:
 
 ```bash
 nix develop
-zig build -Denable-tui=true terminal-test
+zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
 ```
 
 Outside Nix, install a libghostty-vt build that exposes the development
@@ -93,12 +98,15 @@ Prefer small step tables (`expect`, `send`, `resize`, `wait`) over long branch l
 
 ## What CI runs
 
-CI runs `zig build check` on Linux, macOS, and Windows, so the unit and CLI contract
-suites are enforced on every platform. Linux additionally builds libghostty-vt from the
-Ghostty flake and runs `zig build -Denable-tui=true -Dterminal-backend=ghostty
-terminal-test`, making PTY-backed TUI coverage a required gate there. macOS and Windows
-build the TUI binary and run the `--json info` smoke check, but do not run PTY
-scenarios by default.
+CI runs `zig build check` on Linux, macOS, and Windows without Nix, so the unit and CLI
+contract suites are enforced on every platform. CI also builds the TUI with platform
+package managers and runs a `--json info` smoke check. Linux runs `zig build
+-Denable-tui=true terminal-test` in auto mode, so PTY/TUI coverage runs automatically if
+libghostty-vt is available and otherwise reports a skip.
+
+Maintainers who want required Ghostty VT coverage can set `CI_ENABLE_NIX_GHOSTTY=true`
+to enable the separate Nix-backed job. That job is intentionally not part of the default
+release gate.
 
 ## Choosing a richer tool
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,7 +15,7 @@ The first two run everywhere with no extra dependencies. The third needs libghos
 ```bash
 zig build unit-test       # just the in-process unit tests
 zig build test            # unit tests + CLI contract tests
-zig build terminal-test   # the above, plus PTY/TUI scenarios when available
+zig build terminal-test   # unit + CLI tests; PTY/TUI skipped unless TUI + backend are available
 zig build check           # fmt-check + tests (the gate CI runs)
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -100,9 +100,7 @@ Prefer small step tables (`expect`, `send`, `resize`, `wait`) over long branch l
 
 CI runs `zig build check` on Linux, macOS, and Windows without Nix, so the unit and CLI
 contract suites are enforced on every platform. CI also builds the TUI with platform
-package managers and runs a `--json info` smoke check. Linux runs `zig build
--Denable-tui=true terminal-test` in auto mode, so PTY/TUI coverage runs automatically if
-libghostty-vt is available and otherwise reports a skip.
+package managers and runs a `--json info` smoke check.
 
 Maintainers who want required Ghostty VT coverage can set `CI_ENABLE_NIX_GHOSTTY=true`
 to enable the separate Nix-backed job. That job is intentionally not part of the default

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -103,8 +103,10 @@ contract suites are enforced on every platform. CI also builds the TUI with plat
 package managers and runs a `--json info` smoke check.
 
 Maintainers who want required Ghostty VT coverage can set `CI_ENABLE_NIX_GHOSTTY=true`
-to enable the separate Nix-backed job. That job is intentionally not part of the default
-release gate.
+to enable the separate Nix-backed job. That job uses `nix develop`, so its Ghostty VT
+coverage comes from the nixpkgs `libghostty-vt` package pinned by this repository's
+`flake.lock`, not the older direct Ghostty source flake build. It is intentionally not
+part of the default release gate.
 
 ## Choosing a richer tool
 

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -112,7 +112,7 @@ Pass these as `-D<name>=<value>` on any `zig build` command.
 | `-Dapp-name=` | string (default `myapp`) | Application and binary name |
 | `-Dversion=` | string (default `0.1.0`) | Version baked into the binary |
 | `-Dcurses-prefix=` | path | Override the ncurses/PDCurses install prefix |
-| `-Dterminal-backend=` | `auto` (default) / `ghostty` | Terminal-test backend; see [TESTING.md](TESTING.md) |
+| `-Dterminal-backend=` | `auto` (default) / `none` / `ghostty` | PTY/TUI terminal-test backend selection; see [TESTING.md](TESTING.md) |
 | `-Dghostty-vt-prefix=` | path | Override the libghostty-vt install prefix |
 
 ## Build steps
@@ -123,7 +123,7 @@ Pass these as `-D<name>=<value>` on any `zig build` command.
 | `zig build run -- ARGS` | Build, then run with `ARGS` |
 | `zig build test` | CLI contract tests plus in-process unit tests |
 | `zig build unit-test` | Only the in-process unit tests |
-| `zig build terminal-test` | CLI contracts plus PTY/TUI scenarios when a backend is available |
+| `zig build terminal-test` | Unit and CLI tests plus PTY/TUI scenarios when TUI + backend are available |
 | `zig build tui-menu-lib` | Build the reusable TUI menu static library and install its headers |
 | `zig build fmt` / `fmt-check` | Format, or check formatting of, `build.zig`, `src`, and `test` |
 | `zig build check` | Baseline gate: `fmt-check` + tests (what CI runs) |
@@ -203,8 +203,10 @@ install ncurses`, `dnf install ncurses-devel`), or point at a custom install wit
 `-Dcurses-prefix=/path`.
 
 **libghostty-vt not found for terminal tests.** The PTY/TUI backend is optional. See
-[TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, `zig build
-test` and the CLI portion of `terminal-test` still run.
+[TESTING.md](TESTING.md), or pass `-Dghostty-vt-prefix=/path`. Without it, auto mode
+still runs `zig build test` and prints a PTY/TUI skip reason. Use
+`-Dterminal-backend=ghostty` to require the backend, or `-Dterminal-backend=none` to
+skip it explicitly.
 
 **Stale build.** `zig build clean` removes `zig-out` and `.zig-cache`. (Equivalent: `rm -rf zig-out .zig-cache`.)
 

--- a/justfile
+++ b/justfile
@@ -5,21 +5,21 @@ set positional-arguments
 
 # --- Build ---
 
-# Build the project (TUI enabled by default)
+# Build the default CLI
 build:
-    zig build -Denable-tui=true
-
-# Build without TUI support
-build-no-tui:
     zig build
 
-# Build with release optimization (TUI enabled by default)
-release:
-    zig build -Doptimize=ReleaseSafe -Denable-tui=true
+# Build with TUI support
+build-tui:
+    zig build -Denable-tui=true
 
-# Build with release optimization without TUI
-release-no-tui:
+# Build with release optimization
+release:
     zig build -Doptimize=ReleaseSafe
+
+# Build with release optimization and TUI support
+release-tui:
+    zig build -Doptimize=ReleaseSafe -Denable-tui=true
 
 # Build the reusable TUI menu static library
 tui-menu-lib:
@@ -27,13 +27,13 @@ tui-menu-lib:
 
 # --- Run ---
 
-# Run the application (TUI enabled by default)
+# Run the application
 run *args:
-    zig build -Denable-tui=true run -- {{ args }}
-
-# Run the application without TUI
-run-no-tui *args:
     zig build run -- {{ args }}
+
+# Run the application with TUI support
+run-tui *args:
+    zig build -Denable-tui=true run -- {{ args }}
 
 # --- Test ---
 
@@ -48,6 +48,14 @@ terminal-test:
 # Run terminal scenarios with TUI explicitly enabled
 tui-test:
     zig build -Denable-tui=true terminal-test
+
+# Require Ghostty VT-backed TUI scenarios
+tui-test-ghostty:
+    zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
+
+# Require Ghostty VT-backed TUI scenarios inside the Nix shell
+nix-test-ghostty:
+    nix develop --command zig build -Denable-tui=true -Dterminal-backend=ghostty terminal-test
 
 # Run tests with different optimization levels
 test-debug:

--- a/test/README.md
+++ b/test/README.md
@@ -13,13 +13,15 @@ Three test layers cover unit logic, CLI contracts, and interactive terminal flow
 ```bash
 zig build unit-test       # just the in-process unit tests
 zig build test            # unit tests + CLI contract tests
-zig build terminal-test   # the above + PTY/TUI scenarios when available
+zig build terminal-test   # unit + CLI tests; PTY/TUI skipped unless TUI + backend are available
 ```
 
-`zig build terminal-test` defaults to `-Dterminal-backend=auto`, which selects the
-Ghostty VT backend when libghostty-vt is available through `pkg-config` on POSIX hosts.
-The Nix dev shell wires this up automatically. Without libghostty-vt the CLI portion
-still runs; pass `-Dterminal-backend=ghostty` to require the PTY backend, or
-`-Dghostty-vt-prefix=/path` to override the install prefix.
+`zig build terminal-test` defaults to `-Dterminal-backend=auto`. It always runs the unit
+and CLI contract suites, then runs PTY/TUI scenarios only when `-Denable-tui=true` is set
+and libghostty-vt is available through `pkg-config` on POSIX hosts. Without libghostty-vt
+auto mode prints a skip reason; pass `-Dterminal-backend=ghostty` to require the PTY
+backend, `-Dterminal-backend=none` to disable it explicitly, or `-Dghostty-vt-prefix=/path`
+to override the install prefix. The Nix dev shell is an optional convenience path for
+Ghostty VT coverage.
 
 See [docs/TESTING.md](../docs/TESTING.md) for the full guide, including how to write each layer.


### PR DESCRIPTION
Make the template's default local, devcontainer, and CI paths work with Zig plus normal platform package managers instead of requiring Nix. Nix remains available as an optional convenience path for maintainers who want required Ghostty VT coverage.

**Terminal test modes**

`build.zig` now supports explicit `auto`, `none`, and `ghostty` terminal-test modes. The build resolves those modes through a small terminal-test plan so `build()` only wires the selected run, skip, or fail behavior.

**Non-Nix development paths**

The default devcontainer and CI matrix no longer install Nix or build Ghostty from a flake. They use apt, Homebrew, or vcpkg for standard TUI dependencies, with a separate opt-in Nix job gated by `CI_ENABLE_NIX_GHOSTTY=true`.

**Optional PTY/TUI coverage**

The default CI gate builds the TUI and runs a JSON smoke check without pretending Ghostty VT is covered. Required PTY/TUI scenarios live in the opt-in Nix job, while local `terminal-test` auto mode still prints clear skip reasons when the backend is unavailable.

**Documentation**

The README, generated template README, testing docs, Zig primer, contributing guide, and justfile now document the baseline non-Nix workflow, optional TUI dependencies, and required Ghostty VT path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly template DX, docs, and CI gating; runtime app code is untouched, with the main behavioral shift being optional rather than default PTY coverage in CI.
> 
> **Overview**
> Makes **Zig + platform packages** the default path for local work, devcontainers, and CI, with **Nix optional** for maintainers who want required Ghostty VT PTY tests.
> 
> **`build.zig`** adds `-Dterminal-backend=auto|none|ghostty` and a **terminal-test plan** that runs Ghostty PTY scenarios, prints an explicit skip reason, or fails the build when `ghostty` is required but missing. Detection now uses structured `pkg-config`/prefix checks (including `lib64` and `ghostty/vt.h`) instead of a shell one-liner.
> 
> **CI** drops Nix and the direct Ghostty flake build from the main matrix; Linux/macOS/Windows still run `zig build check`, TUI builds, and a JSON smoke check. A separate job **`ghostty-vt-nix`** runs `nix develop` + required terminal tests only when `CI_ENABLE_NIX_GHOSTTY=true`.
> 
> **Devcontainer** removes the Nix feature; post-create runs `zig build -Denable-tui=true terminal-test` in auto mode. **`.envrc`** loads the flake only when `nix` is on PATH.
> 
> Docs, **justfile** (CLI-first defaults + `tui-test-ghostty` / `nix-test-ghostty`), and template READMEs are aligned with the new baseline and optional PTY workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea44d1a94b8cdbf33a0e9b52b193535025a56bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->