### PR TITLE
fix(dev): Repair Nix shell menu workflow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,8 @@ if has nix; then
   watch_file flake.lock
   # Use the Git flake source so Nix reads tracked files instead of copying
   # transient .git internals such as fsmonitor--daemon.ipc sockets.
+  # Git flake sources include tracked files; use git add -N for new files the
+  # dev shell must see before their first real commit.
   use flake "git+file://${PWD}"
 else
   log_status "nix not found; skipping optional Nix dev shell"

--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,9 @@
 if has nix; then
   watch_file flake.nix
   watch_file flake.lock
-  use flake path:.
+  # Use the Git flake source so Nix reads tracked files instead of copying
+  # transient .git internals such as fsmonitor--daemon.ipc sockets.
+  use flake "git+file://${PWD}"
 else
   log_status "nix not found; skipping optional Nix dev shell"
 fi

--- a/justfile
+++ b/justfile
@@ -29,7 +29,6 @@ tui-menu-lib:
 
 # Run the application. Automatically enable TUI support for TUI commands.
 run *args:
-    set -- {{ args }}; \
     if [ "${1:-}" = "menu" ]; then \
         zig build -Denable-tui=true run -- "$@"; \
     else \

--- a/justfile
+++ b/justfile
@@ -27,9 +27,14 @@ tui-menu-lib:
 
 # --- Run ---
 
-# Run the application
+# Run the application. Automatically enable TUI support for TUI commands.
 run *args:
-    zig build run -- {{ args }}
+    set -- {{ args }}; \
+    if [ "${1:-}" = "menu" ]; then \
+        zig build -Denable-tui=true run -- "$@"; \
+    else \
+        zig build run -- "$@"; \
+    fi
 
 # Run the application with TUI support
 run-tui *args:

--- a/justfile
+++ b/justfile
@@ -27,17 +27,17 @@ tui-menu-lib:
 
 # --- Run ---
 
-# Run the application. Automatically enable TUI support for TUI commands.
+# Run the application. Delegate menu to the TUI-enabled recipe.
 run *args:
     if [ "${1:-}" = "menu" ]; then \
-        zig build -Denable-tui=true run -- "$@"; \
+        just run-tui "$@"; \
     else \
         zig build run -- "$@"; \
     fi
 
 # Run the application with TUI support
 run-tui *args:
-    zig build -Denable-tui=true run -- {{ args }}
+    zig build -Denable-tui=true run -- "$@"
 
 # --- Test ---
 


### PR DESCRIPTION
Fix the local Nix-backed development shell path after the non-Nix workflow changes.

**Direnv Flake Source**

Direnv now loads the repository as a Git flake source so Nix reads tracked files instead of copying transient `.git` internals like `fsmonitor--daemon.ipc` sockets. The `.envrc` also calls out the tradeoff: new files must be tracked, or added with `git add -N`, before the dev shell can see them.

**Menu Shortcut**

`just run menu` now delegates to `just run-tui`, so the convenience command uses the same TUI-enabled recipe instead of duplicating Zig flags in the generic run path.