### PR TITLE
feat(template): round 3 — CLI/TUI congruency & integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   unreadable one — instead of a blanket I/O error (11).
 - The interactive TUI now responds to `Esc` promptly (ESCDELAY tuned to 25 ms)
   rather than pausing up to a second on every Esc affordance.
+- The interactive TUI honours the same color policy as the CLI: `NO_COLOR`,
+  `FORCE_COLOR`, `CLICOLOR`/`CLICOLOR_FORCE`, and the `--no-color`/`--plain`
+  flags now disable or force TUI color, where it previously consulted only the
+  terminal's capability. Both surfaces resolve color through one `app_use_colors`
+  helper.
+- `myapp menu` and the bare-TTY launch now reject conflicting JSON output with a
+  single shared message and exit code, instead of two slightly different
+  wordings on the two entry points.
 
 ### Added
 
@@ -31,6 +39,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   contract.
 - The TUI Commands browser now lists each command's example invocations
   alongside its summary.
+- The TUI Commands browser now also shows each command's arguments and options,
+  carried through the shared action seam so the detail view mirrors the usage
+  `--help` renders.
 
 ### Fixed
 
@@ -42,6 +53,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `FORCE_COLOR=0` now disables color instead of (as before) enabling it.
 - The TUI Commands browser hides commands marked hidden from `--help`, so it no
   longer lists the internal `menu` command.
+- The plain-text `--help` ENVIRONMENT section now lists the same variables as
+  the styled help and the OpenCLI contract (previously only three), all rendered
+  from one shared table so the documentation cannot drift between build modes.
 
 ## [0.1.0]
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -115,6 +115,10 @@ zig-out/include/c23-cli-template/tui/tui_progress.h
 **Supported:**
 
 - the `tui_init()` / `tui_cleanup()` lifecycle from `tui.h`
+- `tui_set_color_enabled()` to set the color policy before `tui_init()` — the
+  generated app passes `app_use_colors(config)` so the TUI honours the same
+  `NO_COLOR` / `FORCE_COLOR` / `CLICOLOR(_FORCE)` / `--no-color` / `--plain`
+  inputs as the CLI; left unset, the TUI falls back to terminal capability alone
 - `tui_show_menu()` from `tui_menu.h`
 - `tui_menu_config_t`, `tui_menu_item_t`, and `tui_menu_result_t`
 - the pointer-lifetime rules documented in `tui_menu.h`

--- a/opencli.json
+++ b/opencli.json
@@ -316,6 +316,7 @@
         "name": "environment",
         "value": {
           "APP_LOG_LEVEL": "Set logging verbosity: ERROR, WARNING, INFO, DEBUG (default: ERROR)",
+          "APP_CONFIG_PATH": "Override the default config file lookup path",
           "NO_COLOR": "Disable colored output when set",
           "FORCE_COLOR": "Force colored output on; set 0 (or false) to force off",
           "CLICOLOR_FORCE": "Set to a non-zero value to force colored output on",

--- a/src/cli/commands.c
+++ b/src/cli/commands.c
@@ -226,6 +226,15 @@ const app_command_t *app_command_find(const char *name) {
   return NULL;
 }
 
+bool app_command_is_visible(const app_command_t *command) {
+  // Single definition of "appears in human-facing listings" shared by root
+  // --help (plain and styled) and the TUI Commands browser, so those surfaces
+  // can never disagree on which commands a person sees. Hidden commands stay
+  // dispatchable and remain in the OpenCLI contract (the machine surface lists
+  // every command); only human discovery filters on this.
+  return command && !command->hidden_from_help;
+}
+
 // Levenshtein edit distance between a and b. Bounded to short inputs (a real
 // typo is short): anything longer is treated as far away so the suggestion gate
 // rejects it. Command names are tiny, so the row buffers are small.

--- a/src/cli/commands.h
+++ b/src/cli/commands.h
@@ -104,6 +104,12 @@ const app_global_value_option_t *app_global_value_option_find(const char *arg);
 // Look up a command by name. Returns NULL when no command matches.
 const app_command_t *app_command_find(const char *name);
 
+// True when a command should appear in human-facing listings: root --help
+// (plain and styled) and the TUI Commands browser. Hidden commands stay
+// dispatchable and remain in the OpenCLI contract; only human discovery
+// surfaces filter on this, so they all agree on what a person sees.
+bool app_command_is_visible(const app_command_t *command);
+
 // Suggest the closest visible command name to an unknown token (bounded edit
 // distance), or NULL when nothing is close enough. Hidden commands are never
 // suggested, so a typo near an internal command yields no misleading hint.

--- a/src/cli/commands_menu.c
+++ b/src/cli/commands_menu.c
@@ -7,13 +7,29 @@
 #include "../core/error.h"
 #include "../core/types.h"
 #include "../io/output.h"
+#include "../utils/colors.h"
 #ifdef ENABLE_TUI
 #include "../tui/tui.h"
 #endif
 #include "commands.h"
 
 app_error app_run_tui(const app_config_t *config) {
+  // Single TUI launch precondition shared by `myapp menu` and the bare-TTY
+  // launch in main(): the interactive TUI cannot coexist with machine JSON
+  // output. Reject it once, identically, on both entry points (this was
+  // duplicated with divergent wording in main.c and app_cmd_menu).
+  if (app_config_is_json_output(config)) {
+    app_output(
+        "JSON output is incompatible with the interactive TUI; remove "
+        "--json (or unset json_output) to launch it.",
+        config, true);
+    return APP_ERROR_INVALID_ARG;
+  }
 #ifdef ENABLE_TUI
+  // Mirror the CLI's resolved color policy in the TUI so NO_COLOR / FORCE_COLOR
+  // / CLICOLOR(_FORCE) / --no-color / --plain behave identically on both
+  // surfaces. The TUI otherwise consulted only terminal capability.
+  tui_set_color_enabled(app_use_colors(config));
   const app_error tui_err = tui_run_app();
   // Signal-driven exits already use conventional shell statuses. Keep them
   // quiet instead of printing a misleading TUI failure diagnostic.
@@ -50,12 +66,7 @@ app_error app_cmd_menu(const app_config_t *config, int argc,
   (void)argc;
   (void)argv;
 
-  if (app_config_is_json_output(config)) {
-    app_output(
-        "The menu command is interactive; remove --json to launch the TUI.",
-        config, true);
-    return APP_ERROR_INVALID_ARG;
-  }
-
+  // The --json precondition lives in app_run_tui() now, so `menu` and the
+  // bare-TTY launch reject it identically.
   return app_run_tui(config);
 }

--- a/src/cli/help.c
+++ b/src/cli/help.c
@@ -44,6 +44,7 @@ void app_print_command_help_ex(const char *program_name,
 
 #include "../utils/colors.h"
 #include "../utils/logging.h"
+#include "opencli_contract.h"
 #include "option_meta.h"
 
 static const char *program_or_default(const char *program_name) {
@@ -59,7 +60,7 @@ static void print_commands_block(void) {
   const app_command_t *commands = app_commands(&count);
   printf("Commands:\n");
   for (size_t i = 0; i < count; i++) {
-    if (commands[i].hidden_from_help) {
+    if (!app_command_is_visible(&commands[i])) {
       continue;
     }
     printf("  %-16s%s\n", commands[i].name,
@@ -152,7 +153,7 @@ void app_print_verbose_usage_ex(const char *program_name,
   size_t cmd_count = 0;
   const app_command_t *commands = app_commands(&cmd_count);
   for (size_t i = 0; i < cmd_count; i++) {
-    if (commands[i].hidden_from_help) {
+    if (!app_command_is_visible(&commands[i])) {
       continue;
     }
     printf("  %-18s%s\n", commands[i].name,
@@ -167,10 +168,16 @@ void app_print_verbose_usage_ex(const char *program_name,
   printf("\n");
 
   printf("%sENVIRONMENT%s\n", bold, reset);
-  printf(
-      "  APP_LOG_LEVEL       Set logging level: ERROR, WARNING, INFO, DEBUG\n");
-  printf("  APP_CONFIG_PATH     Override the default config file lookup.\n");
-  printf("  NO_COLOR            Disable colored output when set.\n\n");
+  // Render the same canonical environment table the OpenCLI contract publishes,
+  // so this plain help and the machine contract document identical variables.
+  size_t env_count = 0;
+  const app_opencli_metadata_field_t *env_docs =
+      app_opencli_environment_docs(&env_count);
+  for (size_t i = 0; i < env_count; i++) {
+    printf("  %-20s%s\n", env_docs[i].name,
+           env_docs[i].description ? env_docs[i].description : "");
+  }
+  printf("\n");
 
   printf("%sEXIT CODES%s\n", bold, reset);
   size_t error_count = 0;

--- a/src/cli/opencli_contract.c
+++ b/src/cli/opencli_contract.c
@@ -21,6 +21,8 @@ static const app_opencli_metadata_field_t environment_fields[] = {
     {.name = "APP_LOG_LEVEL",
      .description =
          "Set logging verbosity: ERROR, WARNING, INFO, DEBUG (default: ERROR)"},
+    {.name = "APP_CONFIG_PATH",
+     .description = "Override the default config file lookup path"},
     {.name = "NO_COLOR", .description = "Disable colored output when set"},
     {.name = "FORCE_COLOR",
      .description = "Force colored output on; set 0 (or false) to force off"},
@@ -100,4 +102,15 @@ static const app_opencli_contract_t g_opencli_contract = {
 
 const app_opencli_contract_t *app_opencli_contract(void) {
   return &g_opencli_contract;
+}
+
+const app_opencli_metadata_field_t *app_opencli_environment_docs(
+    size_t *count) {
+  // The same table the OpenCLI `metadata.environment` group publishes. The
+  // human help renderers (plain and styled) iterate this so the documented
+  // environment stays congruent with the machine contract from one source.
+  if (count) {
+    *count = sizeof(environment_fields) / sizeof(environment_fields[0]);
+  }
+  return environment_fields;
 }

--- a/src/cli/opencli_contract.h
+++ b/src/cli/opencli_contract.h
@@ -57,3 +57,9 @@ typedef struct {
 } app_opencli_contract_t;
 
 const app_opencli_contract_t *app_opencli_contract(void);
+
+// The canonical environment-variable documentation, also published as the
+// OpenCLI `metadata.environment` group. Root --help (plain and styled) renders
+// the same rows so the documented environment never drifts from the machine
+// contract. count receives the entry count.
+const app_opencli_metadata_field_t *app_opencli_environment_docs(size_t *count);

--- a/src/cli/style/cli_help_render.c
+++ b/src/cli/style/cli_help_render.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "../../core/error.h"
+#include "../opencli_contract.h"
 #include "../option_meta.h"
 #include "cli_layout.h"
 
@@ -150,7 +151,7 @@ static void help_render_commands(app_cli_render_ctx_t *ctx) {
   help_row_t rows[APP_HELP_MAX_ROWS];
   size_t n = 0;
   for (size_t i = 0; i < count && n < APP_HELP_MAX_ROWS; i++) {
-    if (commands[i].hidden_from_help) {
+    if (!app_command_is_visible(&commands[i])) {
       continue;
     }
     help_row_set(&rows[n++], commands[i].name,
@@ -221,20 +222,19 @@ static void help_render_verbose(app_cli_render_ctx_t *ctx) {
   help_render_options(ctx, true);
 
   app_cli_section_title(ctx, "ENVIRONMENT");
-  static const char *const env_lines[] = {
-      "  APP_LOG_LEVEL       Logging level: ERROR, WARNING, INFO, DEBUG.",
-      "  APP_CONFIG_PATH     Override the default config file lookup.",
-      "  NO_COLOR            Disable colored output when set.",
-      "  FORCE_COLOR         Force color on; set 0 to force off.",
-      "  CLICOLOR_FORCE      Set non-zero to force color on.",
-      "  CLICOLOR            Set 0 to disable colored output.",
-      "  APP_CLI_THEME       CLI theme: auto (detect), dark, or light.",
-      "  APP_CLI_COLOR       Color profile: auto, never, 16, 256, truecolor.",
-      "  APP_CLI_OSC11       Set 0 to disable terminal background detection.",
-      "  APP_CLI_ACCENT      Override accent (#rrggbb or palette idx).",
-  };
-  help_render_plain_block(ctx, env_lines,
-                          sizeof(env_lines) / sizeof(env_lines[0]));
+  // Render the same canonical environment table the OpenCLI contract publishes
+  // (app_opencli_environment_docs), so this styled help, the plain help, and
+  // the machine contract all document one identical set of variables.
+  size_t env_count = 0;
+  const app_opencli_metadata_field_t *env_docs =
+      app_opencli_environment_docs(&env_count);
+  for (size_t i = 0; i < env_count; i++) {
+    char line[160];
+    snprintf(line, sizeof(line), "  %-20s%s", env_docs[i].name,
+             env_docs[i].description ? env_docs[i].description : "");
+    app_cli_write_token(ctx, APP_CLI_COLOR_TOKEN_DESCRIPTION, line);
+    app_cli_newline(ctx);
+  }
   app_cli_newline(ctx);
 
   app_cli_section_title(ctx, "CONFIGURATION");

--- a/src/main.c
+++ b/src/main.c
@@ -297,19 +297,11 @@ int main(int argc, char *argv[]) {
   if (argc == 1) {
     // A bare invocation launches the TUI on an interactive terminal. JSON
     // output (set via config or env, since argc == 1 means no flags) targets
-    // machine consumers and conflicts with the interactive TUI, so reject it
-    // with the same guidance app_cmd_menu gives. Falling through to the
-    // headless path here would instead emit "expects a JSON request object on
-    // stdin", which misdescribes the real problem.
+    // machine consumers and conflicts with the interactive TUI. app_run_tui()
+    // owns that precondition now and rejects it with the same message `menu`
+    // gives, so both entry points stay byte-identical; routing to the headless
+    // path here instead would misdescribe the problem as missing stdin input.
     if (app_terminal_is_interactive()) {
-      if (app_config_is_json_output(config)) {
-        app_output(
-            "JSON output is enabled on an interactive terminal; "
-            "unset json_output to launch the TUI",
-            config, true);
-        app_config_destroy(config);
-        return APP_ERROR_INVALID_ARG;
-      }
       err = app_run_tui(config);
     } else {
       err = app_run_headless_json(config, start_ms);

--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -25,6 +25,14 @@
 
 static bool tui_initialized = false;
 static bool tui_default_colors = false;
+// Color policy the app resolves from config/env via app_use_colors(): -1 unset
+// (fall back to terminal capability alone), 0 forced off, 1 allowed. Set by
+// tui_set_color_enabled() before tui_init().
+static int tui_color_policy = -1;
+// Whether color was actually activated this session (policy allowed AND the
+// terminal supports it AND start_color() succeeded). Gates tui_set_color() so a
+// policy-disabled run never applies uninitialized color pairs.
+static bool tui_colors_active = false;
 static volatile sig_atomic_t tui_interrupted_signal = 0;
 static int tui_saved_cursor_state = 0;
 static tui_window_t *tui_background_win = NULL;
@@ -246,10 +254,18 @@ app_error tui_init(void) {
 
   tui_saved_cursor_state = curs_set(0);
 
-  if (has_colors()) {
+  // Honor the app-resolved color policy (app_use_colors) so the TUI suppresses
+  // or forces color for exactly the same NO_COLOR / FORCE_COLOR / CLICOLOR(_
+  // FORCE) / --no-color / --plain inputs the CLI obeys. tui_color_policy == 0
+  // means a hard disable; -1 (unset) and 1 both allow color subject to terminal
+  // capability. When disabled we skip start_color() entirely and leave
+  // tui_colors_active false, so tui_set_color() becomes a no-op and the whole
+  // UI renders in the terminal's default monochrome.
+  if (tui_color_policy != 0 && has_colors()) {
     if (start_color() != ERR) {
       tui_default_colors = use_default_colors() != ERR;
       (void)tui_init_colors();
+      tui_colors_active = true;
     }
   }
 
@@ -266,6 +282,7 @@ fail:
   endwin();
   app_terminal_discard_pending_input();
   tui_default_colors = false;
+  tui_colors_active = false;
   tui_interrupted_signal = 0;
   return err;
 }
@@ -284,6 +301,7 @@ void tui_cleanup(void) {
 
   tui_initialized = false;
   tui_default_colors = false;
+  tui_colors_active = false;
   tui_clear_background_window();
   tui_interrupted_signal = 0;
   LOG_DEBUG("TUI cleaned up");
@@ -383,17 +401,29 @@ app_error tui_init_colors(void) {
 }
 
 void tui_set_color(WINDOW *win, tui_color_pair_t color) {
-  if (win && has_colors() && color > TUI_COLOR_DEFAULT &&
+  // Guard on tui_colors_active, not has_colors(): when the color policy
+  // disabled color we never called start_color()/init_pair(), so applying a
+  // COLOR_PAIR would reference an uninitialized pair. Skipping keeps the UI
+  // monochrome.
+  if (win && tui_colors_active && color > TUI_COLOR_DEFAULT &&
       color < TUI_COLOR_MAX) {
     wattron(win, COLOR_PAIR(color) | (color == TUI_COLOR_DIM ? A_DIM : 0));
   }
 }
 
 void tui_unset_color(WINDOW *win, tui_color_pair_t color) {
-  if (win && has_colors() && color > TUI_COLOR_DEFAULT &&
+  if (win && tui_colors_active && color > TUI_COLOR_DEFAULT &&
       color < TUI_COLOR_MAX) {
     wattroff(win, COLOR_PAIR(color) | (color == TUI_COLOR_DIM ? A_DIM : 0));
   }
+}
+
+void tui_set_color_enabled(bool enabled) {
+  tui_color_policy = enabled ? 1 : 0;
+}
+
+bool tui_colors_enabled(void) {
+  return tui_colors_active;
 }
 
 tui_window_t *tui_create_window(int height, int width, int y, int x) {

--- a/src/tui/tui.h
+++ b/src/tui/tui.h
@@ -59,6 +59,18 @@ APP_NODISCARD app_error tui_init_colors(void);
 void tui_set_color(WINDOW *win, tui_color_pair_t color);
 void tui_unset_color(WINDOW *win, tui_color_pair_t color);
 
+// Set the TUI color policy before tui_init(), mirroring the CLI. The generated
+// app passes app_use_colors(config) so NO_COLOR / FORCE_COLOR /
+// CLICOLOR(_FORCE) / --no-color / --plain disable or force TUI color exactly as
+// they do CLI output. When never called, the TUI falls back to terminal
+// capability detection alone, preserving standalone behavior for foreign
+// library consumers.
+void tui_set_color_enabled(bool enabled);
+
+// Whether color was actually activated by the most recent tui_init() (policy
+// allowed it, the terminal supports color, and start_color() succeeded).
+bool tui_colors_enabled(void);
+
 // Window helpers
 APP_NODISCARD tui_window_t *tui_create_window(int height, int width, int y,
                                               int x);

--- a/src/tui/tui_app.c
+++ b/src/tui/tui_app.c
@@ -53,7 +53,8 @@ static void app_show_system_info(void) {
            "Terminal Size: %dx%d\n"
            "Colors Supported: %s",
            build->name, build->version, build->git_commit, build->build_date,
-           tui_get_max_x(), tui_get_max_y(), has_colors() ? "yes" : "no");
+           tui_get_max_x(), tui_get_max_y(),
+           tui_colors_enabled() ? "yes" : "no");
   tui_show_message("System Information", info);
 }
 
@@ -250,7 +251,7 @@ static void app_detail_append(char *dst, size_t cap, size_t *used,
 static void app_show_command_detail(const app_action_item_t *action) {
   const bool interactive =
       (action->capabilities & APP_ACTION_CAP_INTERACTIVE_TERMINAL) != 0;
-  char detail[512];
+  char detail[1024];
   const int header =
       snprintf(detail, sizeof(detail),
                "Command: %s\n\n"
@@ -264,8 +265,39 @@ static void app_show_command_detail(const app_action_item_t *action) {
     used = sizeof(detail) - 1;
   }
 
-  // Surface the same ready-to-run examples the CLI `--help` prints, so the
-  // Commands browser is a real reference rather than just a name + summary.
+  // Mirror the CLI `--help` layout (options, then arguments, then examples) so
+  // the Commands browser is a real command reference, not just a name and
+  // summary. All three blocks read the borrowed metadata the shared action seam
+  // carries from the same command table `--help` renders.
+  if (action->options && action->option_count > 0) {
+    app_detail_append(detail, sizeof(detail), &used, "\n\nOptions:");
+    for (size_t i = 0; i < action->option_count; i++) {
+      if (!action->options[i].name) {
+        continue;
+      }
+      char line[192];
+      snprintf(
+          line, sizeof(line), "\n  %-16s%s", action->options[i].name,
+          action->options[i].description ? action->options[i].description : "");
+      app_detail_append(detail, sizeof(detail), &used, line);
+    }
+  }
+
+  if (action->arguments && action->argument_count > 0) {
+    app_detail_append(detail, sizeof(detail), &used, "\n\nArguments:");
+    for (size_t i = 0; i < action->argument_count; i++) {
+      const app_command_arg_t *arg = &action->arguments[i];
+      if (!arg->name) {
+        continue;
+      }
+      char line[192];
+      snprintf(line, sizeof(line), "\n  %-16s%s%s", arg->name,
+               arg->required ? "(required) " : "",
+               arg->description ? arg->description : "");
+      app_detail_append(detail, sizeof(detail), &used, line);
+    }
+  }
+
   if (action->examples && action->example_count > 0) {
     app_detail_append(detail, sizeof(detail), &used, "\n\nExamples:");
     for (size_t i = 0; i < action->example_count; i++) {

--- a/src/ui/action_item.c
+++ b/src/ui/action_item.c
@@ -12,7 +12,7 @@ size_t app_actions_from_commands(app_action_item_t *out, size_t out_count) {
   size_t written = 0;
   for (size_t i = 0; i < command_count; i++) {
     const app_command_t *command = &commands[i];
-    if (command->hidden_from_help) {
+    if (!app_command_is_visible(command)) {
       continue;
     }
     if (out && written < out_count) {
@@ -30,7 +30,11 @@ size_t app_actions_from_commands(app_action_item_t *out, size_t out_count) {
                               .command_name = command->name,
                               .capabilities = capabilities,
                               .examples = command->examples,
-                              .example_count = command->example_count};
+                              .example_count = command->example_count,
+                              .arguments = command->arguments,
+                              .argument_count = command->argument_count,
+                              .options = command->options,
+                              .option_count = command->option_count};
     }
     written++;
   }

--- a/src/ui/action_item.h
+++ b/src/ui/action_item.h
@@ -8,6 +8,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+// The seam borrows argument/option metadata straight from the CLI command
+// table, so it needs those struct types. action_item.c already depends on the
+// command table to project it; pulling the types here lets a TUI detail view
+// present the same usage the CLI `--help` renders without copying any data.
+#include "../cli/commands.h"
+
 typedef enum {
   APP_ACTION_COMMAND = 0,
   APP_ACTION_CALLBACK,
@@ -34,6 +40,15 @@ typedef struct {
   // no examples. The pointers are owned by the static command table.
   const char *const *examples;
   size_t example_count;
+  // Borrowed argument and option metadata from the source command, so a TUI
+  // detail view can present the same usage (arguments and command options) the
+  // CLI `--help` renders. NULL/0 when the command declares none. Like the
+  // examples above, these point into the static command table and are never
+  // freed by the action.
+  const app_command_arg_t *arguments;
+  size_t argument_count;
+  const app_command_option_t *options;
+  size_t option_count;
 } app_action_item_t;
 
 // Project the CLI command table into action descriptors. Commands flagged

--- a/test/cli_contract_cases.c
+++ b/test/cli_contract_cases.c
@@ -39,13 +39,20 @@ static bool test_installed_binary_starts(test_context_t *ctx) {
 static bool test_help_is_human_readable(test_context_t *ctx) {
   const char *args[] = {"--help"};
   command_result_t result = cc_run_cli(ctx, args, ARRAY_LEN(args), NULL, 0);
-  const bool ok = cc_expect_exit(&result, 0) &&
-                  cc_expect_stdout_contains(&result, "USAGE") &&
-                  cc_expect_stdout_contains(&result, "COMMANDS") &&
-                  cc_expect_stdout_contains(&result, "doctor") &&
-                  cc_expect_stdout_contains(
-                      &result, "Enable debug output (DEBUG level logs)") &&
-                  cc_expect_stdout_contains(&result, "(env: APP_LOG_LEVEL)");
+  const bool ok =
+      cc_expect_exit(&result, 0) &&
+      cc_expect_stdout_contains(&result, "USAGE") &&
+      cc_expect_stdout_contains(&result, "COMMANDS") &&
+      cc_expect_stdout_contains(&result, "doctor") &&
+      cc_expect_stdout_contains(&result,
+                                "Enable debug output (DEBUG level logs)") &&
+      cc_expect_stdout_contains(&result, "(env: APP_LOG_LEVEL)") &&
+      // ENVIRONMENT is rendered from the single canonical table the
+      // OpenCLI contract publishes, so the color env vars and
+      // APP_CONFIG_PATH appear here just as they do in opencli.json.
+      cc_expect_stdout_contains(&result, "FORCE_COLOR") &&
+      cc_expect_stdout_contains(&result, "NO_COLOR") &&
+      cc_expect_stdout_contains(&result, "APP_CONFIG_PATH");
   if (ok && result.out && strstr(result.out, "  menu") != NULL) {
     fprintf(stderr, "root help must not list the interactive menu command\n");
     fprintf(stderr, "stdout:\n%s\n", result.out);

--- a/test/terminal_vt_scenarios.c
+++ b/test/terminal_vt_scenarios.c
@@ -353,7 +353,8 @@ int run_tui_bare_invocation_json(test_stats_t *stats, const char *binary,
     failed = test_fail(stats, name, "failed to start PTY session");
   }
   if (!failed &&
-      !vt_expect_text(&session, "unset json_output to launch the TUI",
+      !vt_expect_text(&session,
+                      "JSON output is incompatible with the interactive TUI",
                       PTY_TIMEOUT_MS, &snapshot)) {
     failed = test_fail(
         stats, name,

--- a/test/unit_shared_primitives_tests.c
+++ b/test/unit_shared_primitives_tests.c
@@ -25,9 +25,29 @@ static const char *const stub_hello_examples[] = {
     "app hello Alice",
 };
 
+// Argument and option metadata the seam must carry through to a TUI detail view
+// exactly as the CLI command table declares it (borrowed, not copied).
+static const app_command_arg_t stub_hello_args[] = {
+    {.name = "name",
+     .required = false,
+     .arity_minimum = 0,
+     .arity_maximum = 1,
+     .description = "Who to greet"},
+};
+
+static const app_command_option_t stub_hello_options[] = {
+    {.id = APP_COMMAND_OPTION_UNKNOWN,
+     .name = "--loud",
+     .description = "Greet emphatically"},
+};
+
 static const app_command_t stub_commands[] = {
     {.name = "hello",
      .summary = "Print a greeting",
+     .options = stub_hello_options,
+     .option_count = 1,
+     .arguments = stub_hello_args,
+     .argument_count = 1,
      .examples = stub_hello_examples,
      .example_count = 2,
      .hidden_from_help = false},
@@ -43,6 +63,13 @@ const app_command_t *app_commands(size_t *count) {
     *count = sizeof(stub_commands) / sizeof(stub_commands[0]);
   }
   return stub_commands;
+}
+
+// app_actions_from_commands() now filters through app_command_is_visible()
+// (commands.c). The unit binary stubs the command table instead of linking
+// commands.c, so provide the predicate here with the production semantics.
+bool app_command_is_visible(const app_command_t *command) {
+  return command && !command->hidden_from_help;
 }
 
 static bool test_app_info_feature_table(void) {
@@ -233,6 +260,27 @@ static bool test_actions_from_commands_excludes_hidden(void) {
   return saw_hello && hello_has_examples && !saw_menu;
 }
 
+static bool test_actions_from_commands_carries_usage_metadata(void) {
+  // The seam must borrow the command's arguments and options so a TUI detail
+  // view can render the same usage `--help` shows, pointing at the very same
+  // table entries (zero-copy) rather than duplicating them.
+  app_action_item_t actions[16];
+  const size_t count = app_actions_from_commands(actions, 16);
+  for (size_t i = 0; i < count; i++) {
+    if (!actions[i].command_name ||
+        strcmp(actions[i].command_name, "hello") != 0) {
+      continue;
+    }
+    return actions[i].argument_count == 1 && actions[i].arguments != NULL &&
+           actions[i].arguments == stub_hello_args &&
+           strcmp(actions[i].arguments[0].name, "name") == 0 &&
+           actions[i].option_count == 1 && actions[i].options != NULL &&
+           actions[i].options == stub_hello_options &&
+           strcmp(actions[i].options[0].name, "--loud") == 0;
+  }
+  return false;
+}
+
 static bool test_diagnostics_collects_core_checks(void) {
   app_config_t *config = NULL;
   if (app_config_create(&config) != APP_SUCCESS) {
@@ -267,6 +315,8 @@ void run_shared_primitives_unit_tests(unit_stats_t *stats) {
               "tui_menu_adapter maps action descriptors");
   unit_record(stats, test_actions_from_commands_excludes_hidden(),
               "action projection skips hidden commands and carries examples");
+  unit_record(stats, test_actions_from_commands_carries_usage_metadata(),
+              "action projection carries command arguments and options");
   unit_record(stats, test_diagnostics_collects_core_checks(),
               "diagnostics collector returns core checks");
 }


### PR DESCRIPTION
## Round 3 — CLI ↔ TUI congruency & integration

Third improvement pass on the template. The focus this round is **cohesion, not features**: route both front-ends through shared seams so the CLI and the TUI cannot drift in behavior, wording, or visibility. Every change is additive and contract-safe.

### What changed

1. **TUI color now honours the CLI color policy.** A `tui_color_policy` / `tui_colors_active` state machine in `tui.c`, set via the new additive `tui_set_color_enabled()` seam from `commands_menu.c` (passing `app_use_colors(config)`), makes `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR`/`CLICOLOR_FORCE`, and `--no-color`/`--plain` disable or force TUI color exactly as they do CLI output. Previously the TUI consulted only the terminal's capability. `tui_init()`'s signature is deliberately **unchanged**, so the `tui-menu-lib` foreign-link contract and config.h-free installed headers still hold.
2. **The TUI Commands browser shows arguments and options.** The shared action seam (`action_item`) now carries borrowed `arguments`/`options` pointers from the same command table `--help` reads, and the detail view renders them in the `--help` order (options → arguments → examples). The browser is now a real command reference rather than a name + summary.
3. **One environment-doc source of truth.** `app_opencli_environment_docs()` feeds plain help, styled help, **and** `opencli.json` from a single table. The plain `--help` ENVIRONMENT section went from 3 variables to the full 10, and `APP_CONFIG_PATH` was added (`opencli.json` regenerated; the drift test passes).
4. **Unified the TUI-launch precondition.** The `--json` rejection now lives solely in `app_run_tui` (one message, one exit code), removed from both `main.c` and `app_cmd_menu`, so the two entry points no longer emit slightly different wordings.
5. **One visibility predicate.** `app_command_is_visible()` backs all four human-facing listings (plain and styled `--help`, the verbose loop, the TUI browser). `commands_opencli.c` is intentionally left unfiltered so the machine contract still lists hidden commands such as `menu`.

### Review

Ran a 5-dimension adversarial review over the diff before opening this PR (color state machine, seam lifetime/bounds, precondition dispatch, env-doc/contract safety, visibility + whole-diff regression sweep) with a refute pass on any blocker. Result: **0 blockers, 0 nits, 1 warning** — a missing `arg->name` NULL guard in the Arguments render loop, which is fixed in this branch (it now matches the Options loop's defensive style).

### Verification

- `zig build test` — 25/25 (incl. OpenCLI drift test)
- `zig build unit-test` — 85/85 (+1 new seam-metadata test)
- `zig build terminal-test` — 11/11 VT/PTY scenarios
- `-Denable-cli-style=false` (plain), `-Denable-tui=false` (headless), and `tui-menu-lib` all build
- `zig fmt`, `clang-format`, `markdownlint` all clean

`CHANGELOG.md` and `docs/CONTRACTS.md` updated (the latter documents the new `tui_set_color_enabled()` supported seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract and UX alignment with tests and docs; no auth, data, or breaking API changes beyond consistent error text for JSON+TUI conflicts.
> 
> **Overview**
> This PR routes the **CLI and interactive TUI through shared seams** so behavior, wording, and human-facing listings stay aligned.
> 
> **TUI color** now follows the same policy as CLI output: `tui_set_color_enabled()` (called from `app_run_tui` with `app_use_colors(config)`) gates `start_color()` and pair usage via `tui_colors_active`, so `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR`/`CLICOLOR_FORCE`, and `--no-color`/`--plain` affect the TUI the way they already affect the CLI.
> 
> **TUI launch with JSON** is rejected in one place (`app_run_tui`) with a single message and exit code for both `myapp menu` and bare-TTY launch (replacing divergent checks in `main` and `app_cmd_menu`).
> 
> **Human command visibility** uses `app_command_is_visible()` everywhere root help and the TUI Commands browser list commands (hidden commands stay dispatchable and in OpenCLI).
> 
> **Environment documentation** comes from `app_opencli_environment_docs()` for plain help, styled help, and `opencli.json` (including `APP_CONFIG_PATH`); the plain `--help` ENVIRONMENT section grows from three variables to the full canonical set.
> 
> The **Commands browser detail view** shows options, arguments, and examples in `--help` order via borrowed metadata on the shared `app_action_item` seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b17b627c6c7a452297e8bedc54a5260289a004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->