### PR TITLE
refactor(template): rename project to Curspan

### DIFF
--- a/.github/template.yml
+++ b/.github/template.yml
@@ -1,5 +1,5 @@
 # GitHub template repository configuration
-name: C23 CLI Template - Modern C23 with Zig Build System
+name: Curspan - Modern C23 with Zig Build System
 description: Modern C23 CLI application starter with Zig build system, NCurses TUI support, and comprehensive project structure
 topics:
   - cli

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -438,8 +438,9 @@ jobs:
   validate-template:
     name: Validate Template
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
-    # Skip validation for the template repository itself
-    if: github.repository != 'sammyjoyce/curspan'
+    # Skip validation for the template repository itself (name-independent;
+    # generated repos have is_template == false)
+    if: ${{ !github.event.repository.is_template }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -439,7 +439,7 @@ jobs:
     name: Validate Template
     runs-on: ${{ vars.CI_LINUX_RUNNER || 'ubuntu-latest' }}
     # Skip validation for the template repository itself
-    if: github.repository != 'sammyjoyce/c23-cli-template'
+    if: github.repository != 'sammyjoyce/curspan'
 
     steps:
       - name: Check out repository

--- a/.template/TEMPLATE_SUPPORT.md
+++ b/.template/TEMPLATE_SUPPORT.md
@@ -2,7 +2,7 @@
 
 This page is for problems with the **template itself**, not with a project you generated from it.
 
-- **Search existing issues:** [c23-cli-template/issues](https://github.com/sammyjoyce/c23-cli-template/issues)
+- **Search existing issues:** [curspan/issues](https://github.com/sammyjoyce/curspan/issues)
 - **Open a new issue:** use the provided issue templates.
 - **Problems in your generated project:** use that repository's own issue tracker.
 

--- a/.template/TEMPLATE_USAGE.md
+++ b/.template/TEMPLATE_USAGE.md
@@ -1,6 +1,6 @@
 # Template Usage Guide
 
-This guide covers creating a project from `sammyjoyce/c23-cli-template` and cleaning up the template-specific files.
+This guide covers creating a project from `sammyjoyce/curspan` and cleaning up the template-specific files.
 
 ## Create A Repository
 
@@ -15,7 +15,7 @@ This guide covers creating a project from `sammyjoyce/c23-cli-template` and clea
 
 ```bash
 gh repo create my-cli \
-  --template sammyjoyce/c23-cli-template \
+  --template sammyjoyce/curspan \
   --public \
   --clone
 cd my-cli

--- a/.template/setup.sh
+++ b/.template/setup.sh
@@ -142,7 +142,7 @@ get_prompt() {
 
 if (( non_interactive == 0 )); then
     require_command gum
-    gum style --border normal --padding "1 2" --border-foreground 212 "C23 TUI + CLI Template Setup"
+    gum style --border normal --padding "1 2" --border-foreground 212 "Curspan Setup"
 
     export PROJECT_NAME
     PROJECT_NAME=$(gum input --value "${PROJECT_NAME:-$(get_default PROJECT_NAME)}" --placeholder "$(get_prompt PROJECT_NAME)")

--- a/.template/template-vars.json
+++ b/.template/template-vars.json
@@ -80,7 +80,9 @@
     "*.txt",
     "LICENSE*",
     "Makefile",
-    "CMakeLists.txt"
+    "CMakeLists.txt",
+    "justfile",
+    "Justfile"
   ],
   "exclude_patterns": [
     ".git/*",

--- a/.template/template-vars.json
+++ b/.template/template-vars.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "PROJECT_NAME": {
-      "placeholders": ["C23 TUI + CLI Starter"],
+      "placeholders": ["Curspan"],
       "description": "Human-readable project name shown in documentation, metadata, and headings.",
       "sources": ["repository_name"],
       "validation": "^[A-Za-z][A-Za-z0-9 _-]*$"
@@ -101,19 +101,19 @@
       "Copyright (c) 2026": "Copyright (c) ${CURRENT_YEAR}"
     },
     "build.zig": {
-      "include/c23-cli-template/": "include/${PROJECT_NAME_KEBAB}/"
+      "include/curspan/": "include/${PROJECT_NAME_KEBAB}/"
     },
     "build.zig.zon": {
       ".myapp": ".${PROJECT_NAME_SNAKE}"
     },
     "docs/CONTRACTS.md": {
-      "include/c23-cli-template/": "include/${PROJECT_NAME_KEBAB}/"
+      "include/curspan/": "include/${PROJECT_NAME_KEBAB}/"
     },
     "flake.nix": {
-      "name = \"c23-cli-template\";": "name = \"${PROJECT_NAME_KEBAB}\";"
+      "name = \"curspan\";": "name = \"${PROJECT_NAME_KEBAB}\";"
     },
     "opencli.json": {
-      "C23 TUI + CLI Starter": "${PROJECT_NAME}",
+      "Curspan": "${PROJECT_NAME}",
       "A ready-to-use C23 starter for command-line tools and ncurses terminal UIs.": "${PROJECT_DESCRIPTION}",
       "Your Name": "${AUTHOR_NAME}",
       "https://github.com/yourusername/yourproject": "${PROJECT_URL}",

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# C23 TUI + CLI Starter Template - Zig + ncurses
+# Curspan — a C23 TUI + CLI framework (Zig + ncurses)
 
-[![GitHub Release](https://img.shields.io/github/v/release/sammyjoyce/c23-cli-template?style=for-the-badge)](https://github.com/sammyjoyce/c23-cli-template)
-[![License](https://img.shields.io/github/license/sammyjoyce/c23-cli-template?style=for-the-badge)](https://github.com/sammyjoyce/c23-cli-template/blob/main/LICENSE)
-[![CI Status](https://img.shields.io/github/actions/workflow/status/sammyjoyce/c23-cli-template/ci.yaml?style=for-the-badge&label=CI)](https://github.com/sammyjoyce/c23-cli-template/actions/workflows/ci.yaml)
+[![GitHub Release](https://img.shields.io/github/v/release/sammyjoyce/curspan?style=for-the-badge)](https://github.com/sammyjoyce/curspan)
+[![License](https://img.shields.io/github/license/sammyjoyce/curspan?style=for-the-badge)](https://github.com/sammyjoyce/curspan/blob/main/LICENSE)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/sammyjoyce/curspan/ci.yaml?style=for-the-badge&label=CI)](https://github.com/sammyjoyce/curspan/actions/workflows/ci.yaml)
 [![Zig](https://img.shields.io/badge/Zig-0.16.0-F7A41D?style=for-the-badge&logo=zig)](https://ziglang.org/)
-[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/c23-cli-template?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/c23-cli-template)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/curspan?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/curspan)
 
 A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this
 template**, run the cleanup script, and you have a cross-compiling C project with
 argument parsing, a default ncurses TUI, end-to-end tests, and a GitHub
 Actions CI/CD scaffold.
 
-[Use this template](https://github.com/sammyjoyce/c23-cli-template/generate) • [Read the setup guide](.template/TEMPLATE_USAGE.md) • [Report a template issue](https://github.com/sammyjoyce/c23-cli-template/issues)
+[Use this template](https://github.com/sammyjoyce/curspan/generate) • [Read the setup guide](.template/TEMPLATE_USAGE.md) • [Report a template issue](https://github.com/sammyjoyce/curspan/issues)
 
 ---
 
@@ -31,7 +31,7 @@ Actions CI/CD scaffold.
 
 #### Option 1: GitHub UI
 
-1. Click ["Use this template"](https://github.com/sammyjoyce/c23-cli-template/generate)
+1. Click ["Use this template"](https://github.com/sammyjoyce/curspan/generate)
 2. Name your repository
 3. Click "Create repository"
 
@@ -39,7 +39,7 @@ Actions CI/CD scaffold.
 
 ```bash
 gh repo create my-cli \
-  --template sammyjoyce/c23-cli-template \
+  --template sammyjoyce/curspan \
   --public \
   --clone
 ```
@@ -285,7 +285,7 @@ Start with [**Using This Template**](.template/TEMPLATE_USAGE.md) for the full s
 
 For problems with the template itself:
 
-- Check [existing issues](https://github.com/sammyjoyce/c23-cli-template/issues)
+- Check [existing issues](https://github.com/sammyjoyce/curspan/issues)
 - Create a new issue
 - Read [template support](.template/TEMPLATE_SUPPORT.md)
 
@@ -307,4 +307,4 @@ When you use this template, you can choose any license for your project.
 
 **Ready to build your CLI app?**
 
-[![Use this template](https://img.shields.io/badge/Use%20this-template-success?style=for-the-badge&logo=github)](https://github.com/sammyjoyce/c23-cli-template/generate)
+[![Use this template](https://img.shields.io/badge/Use%20this-template-success?style=for-the-badge&logo=github)](https://github.com/sammyjoyce/curspan/generate)

--- a/build.zig
+++ b/build.zig
@@ -244,7 +244,7 @@ pub fn build(b: *std.Build) void {
 
     const version_str = b.option([]const u8, "version", "Application version string") orelse "0.1.0";
     const app_name = b.option([]const u8, "app-name", "Application and binary name") orelse "myapp";
-    const app_title = b.option([]const u8, "app-title", "Human-readable application title") orelse "C23 TUI + CLI Starter";
+    const app_title = b.option([]const u8, "app-title", "Human-readable application title") orelse "Curspan";
     const app_description = b.option([]const u8, "app-description", "Application description") orelse "A ready-to-use C23 starter for command-line tools and ncurses terminal UIs.";
     const binary_name = app_name;
 
@@ -576,11 +576,11 @@ pub fn build(b: *std.Build) void {
 
     const install_tui_menu_lib = b.addInstallArtifact(tui_menu_lib, .{});
     const install_tui_headers = [_]*std.Build.Step.InstallFile{
-        b.addInstallFile(b.path("src/core/error.h"), "include/c23-cli-template/core/error.h"),
-        b.addInstallFile(b.path("src/core/types.h"), "include/c23-cli-template/core/types.h"),
-        b.addInstallFile(b.path("src/tui/tui.h"), "include/c23-cli-template/tui/tui.h"),
-        b.addInstallFile(b.path("src/tui/tui_menu.h"), "include/c23-cli-template/tui/tui_menu.h"),
-        b.addInstallFile(b.path("src/tui/tui_progress.h"), "include/c23-cli-template/tui/tui_progress.h"),
+        b.addInstallFile(b.path("src/core/error.h"), "include/curspan/core/error.h"),
+        b.addInstallFile(b.path("src/core/types.h"), "include/curspan/core/types.h"),
+        b.addInstallFile(b.path("src/tui/tui.h"), "include/curspan/tui/tui.h"),
+        b.addInstallFile(b.path("src/tui/tui_menu.h"), "include/curspan/tui/tui_menu.h"),
+        b.addInstallFile(b.path("src/tui/tui_progress.h"), "include/curspan/tui/tui_progress.h"),
     };
 
     // pkg-config manifest so a consumer can `pkg-config --cflags --libs

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -105,11 +105,11 @@ failure.
 ```text
 zig-out/lib/libtui-menu.a
 zig-out/lib/pkgconfig/tui-menu.pc
-zig-out/include/c23-cli-template/core/error.h
-zig-out/include/c23-cli-template/core/types.h
-zig-out/include/c23-cli-template/tui/tui.h
-zig-out/include/c23-cli-template/tui/tui_menu.h
-zig-out/include/c23-cli-template/tui/tui_progress.h
+zig-out/include/curspan/core/error.h
+zig-out/include/curspan/core/types.h
+zig-out/include/curspan/tui/tui.h
+zig-out/include/curspan/tui/tui_menu.h
+zig-out/include/curspan/tui/tui_progress.h
 ```
 
 **Supported:**

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
         in
         {
           default = pkgs.mkShell {
-            name = "c23-cli-template";
+            name = "curspan";
 
             packages = projectTooling;
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Justfile for C23 CLI Template
+# Justfile for Curspan
 # Quick reference: https://just.systems/man/en/
 
 set positional-arguments

--- a/opencli.json
+++ b/opencli.json
@@ -1,7 +1,7 @@
 {
   "opencli": "0.1",
   "info": {
-    "title": "C23 TUI + CLI Starter",
+    "title": "Curspan",
     "description": "A ready-to-use C23 starter for command-line tools and ncurses terminal UIs.",
     "version": "0.1.0",
     "contact": {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -62,9 +62,10 @@ typedef struct {
 #endif
 
 #ifndef APP_DESCRIPTION
-#define APP_DESCRIPTION                                                     \
-  "A ready-to-use C23 starter for command-line tools and ncurses terminal " \
-  "UIs."
+// clang-format off
+#define APP_DESCRIPTION \
+  "A ready-to-use C23 starter for command-line tools and ncurses terminal UIs."
+// clang-format on
 #endif
 
 // Build date - should be provided by build system

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -58,7 +58,7 @@ typedef struct {
 
 // Human-readable application title and description
 #ifndef APP_TITLE
-#define APP_TITLE "C23 TUI + CLI Starter"
+#define APP_TITLE "Curspan"
 #endif
 
 #ifndef APP_DESCRIPTION

--- a/test/unit_config_tests.c
+++ b/test/unit_config_tests.c
@@ -431,7 +431,7 @@ static bool test_config_load_reports_not_found(void) {
     return false;
   }
   const app_error err =
-      app_config_load_file(config, "/nonexistent/curspan-xyz.json");
+      app_config_load_file(config, "/nonexistent/myapp-xyz.json");
   app_config_destroy(config);
   return err == APP_ERROR_NOT_FOUND;
 }

--- a/test/unit_config_tests.c
+++ b/test/unit_config_tests.c
@@ -431,7 +431,7 @@ static bool test_config_load_reports_not_found(void) {
     return false;
   }
   const app_error err =
-      app_config_load_file(config, "/nonexistent/c23-cli-template-xyz.json");
+      app_config_load_file(config, "/nonexistent/curspan-xyz.json");
   app_config_destroy(config);
   return err == APP_ERROR_NOT_FOUND;
 }


### PR DESCRIPTION
Renames the project/repo identity from **c23-cli-template** / "C23 TUI + CLI Starter" to **Curspan** (curses + span) — a name that reads as a TUI/CLI framework. Namespace is fully clean (bare `github.com/curspan`, `curspan.dev`, `curspan.io` all free; no OSS/registry collisions).

### Scope
Project/repo **identity only**. The consumer-facing `myapp` placeholder binary (179 refs) and the `.myapp` zon package id are **intentionally left unchanged** — that's the example app users rename after generating from the template.

### Changes
**Identity rename (14 files):**
- **Slug** `c23-cli-template` → `curspan`: README badges/URLs, `build.zig` install path (`include/curspan/`), `flake.nix` package name, `docs/CONTRACTS.md`, `.template/` docs, and a test path string.
- **Human title** → `Curspan`: README H1, `APP_TITLE` (`src/core/types.h`), `build.zig` `app-title` default, `opencli.json`, `.github/template.yml`, `justfile`, `setup.sh` banner.
- **`.template/template-vars.json`** updated in lockstep so the "Use this template" replacer keeps keying off the new identity strings.

**CI hardening (2nd commit):**
- The `validate-template` job was skipped via a **hardcoded** `github.repository != '<owner>/<name>'` — brittle precisely because of renames like this. Re-gated on `!github.event.repository.is_template`, which skips on the template repo regardless of its name (and avoids a false failure on `build.zig`'s pkg-config `${{prefix}}` syntax during the rename window). Still runs on consumer repos (`is_template == false`).

### Verification
- `zig build` ✅
- `zig build test` → **85/85 pass** ✅
- Binary now prints `"title": "Curspan"` (and still `"app":"myapp"`).

### Follow-up (manual, not in this PR)
- Rename the GitHub repo `sammyjoyce/c23-cli-template` → `sammyjoyce/curspan` (in-repo URLs/badges already point to the new path, so they 404 until the rename).
- Optionally claim `github.com/curspan`, `curspan.dev`, `curspan.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, URLs, and string defaults; CI skip logic is safer for renames. Links to `sammyjoyce/curspan` 404 until the GitHub repo is renamed manually.
> 
> **Overview**
> Rebrands the GitHub template from **c23-cli-template** / “C23 TUI + CLI Starter” to **Curspan** across docs, metadata, and install paths (`include/curspan/`, default `APP_TITLE`, `opencli.json`, template replacer keys in `.template/template-vars.json`, badges/URLs pointing at `sammyjoyce/curspan`). The example binary name **`myapp`** and zon id **`.myapp`** stay as the post-generate placeholders.
> 
> CI **validate-template** no longer skips via a hardcoded repo name; it uses **`!github.event.repository.is_template`** so the template repo stays exempt after renames while generated repos still get placeholder checks. Template cleanup also scans **`justfile`/`Justfile`**, and a unit test path string was aligned with the sample app name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9eaf19ef6678331da2671a897050ac383de46a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->