### PR TITLE
feat(framework): Add component catalog and registry CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent Instructions
+
+## External References
+
+| Need | File |
+| --- | --- |
+| Project overview and component usage | `README.md` |
+| Contribution workflow and commit style | `CONTRIBUTING.md` |
+| Architecture/module ownership | `docs/ARCHITECTURE.md` |
+| Testing layers | `docs/TESTING.md` |
+| Component catalog API | `docs/COMPONENTS.md` |
+| Theming API | `docs/THEMING.md` |
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Build debug binary | `zig build` |
+| Run CI gate locally | `zig build check` |
+| Run tests | `zig build test` |
+| Run unit tests only | `zig build unit-test` |
+| Validate component registry | `zig build registry` |
+| Check formatting | `zig build fmt-check` |
+| Apply formatting | `zig build fmt` |
+| Build component CLI | `zig build curspan` |
+| List catalog via CLI | `zig build curspan-run -- list` |
+| Copy a component into a project | `zig build curspan-run -- add table --dest <dir>` |
+| TUI/PTY scenarios when touched | `zig build -Denable-tui=true terminal-test` |
+
+## Component Catalog
+
+- Components live in `src/components/cs_*.{c,h}` and render only through `src/surface/`.
+- Component styling uses semantic roles from `src/style/cs_theme.*` and `src/style/ui_theme.*`.
+- Keep `registry/registry.json` in sync with component source files and dependency closures.
+- `zig build test` also runs `curspan check` against `registry/registry.json`.
+
+## Build Boundaries
+
+- Keep `tools/curspan/` pure Zig; it is host-built and should not depend on project C sources.
+- Keep `src/surface/surface_curses.c` and other curses-only code behind TUI-enabled builds.
+- CLI-only or unit-test builds must not require ncurses/PDCurses.
+- Zig formatting covers `build.zig`, `src/`, `test/`, and `tools/` via `zig build fmt-check`.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,37 @@
 [![Zig](https://img.shields.io/badge/Zig-0.16.0-F7A41D?style=for-the-badge&logo=zig)](https://ziglang.org/)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/sammyjoyce/curspan?style=for-the-badge&label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/sammyjoyce/curspan)
 
-A ready-to-use C23 starter for command-line tools and terminal UIs. Click **Use this
-template**, run the cleanup script, and you have a cross-compiling C project with
-argument parsing, a default ncurses TUI, end-to-end tests, and a GitHub
-Actions CI/CD scaffold.
+A high-level framework for building command-line tools and terminal UIs in C23 —
+ShadCN for the terminal. A curated catalog of themeable components, one neutral
+render surface that targets a CLI stream or a TUI window, and a registry + `add`
+CLI that copies a component and its dependencies into your project, so you **own
+the source**.
 
-[Use this template](https://github.com/sammyjoyce/curspan/generate) • [Read the setup guide](.template/TEMPLATE_USAGE.md) • [Report a template issue](https://github.com/sammyjoyce/curspan/issues)
+Use it two ways:
+
+- **Add components to your project** — `curspan add table` copies `cs_table` (and
+  its dependency closure) into your tree. See [COMPONENTS.md](docs/COMPONENTS.md).
+- **Start from the reference app** — click **Use this template** for a complete,
+  cross-compiling C23 CLI + TUI app (argument parsing, a default ncurses UI,
+  end-to-end tests, and a GitHub Actions CI/CD scaffold) with the framework
+  already wired in.
+
+[Use this template](https://github.com/sammyjoyce/curspan/generate) • [Components](docs/COMPONENTS.md) • [Theming](docs/THEMING.md) • [Setup guide](.template/TEMPLATE_USAGE.md)
 
 ---
 
 ## Highlights
+
+The framework:
+
+- **Own your components** - Each component is a self-contained `.c/.h` pair you copy in and edit, not a dependency you link against ([open code](docs/COMPONENTS.md)).
+- **One render surface, two backends** - Components draw through a neutral [`cs_surface`](docs/COMPONENTS.md#the-surface) that targets a CLI byte stream *or* an ncurses window, degrading color per terminal.
+- **Theme by semantic roles** - A [design-token → role → theme](docs/THEMING.md)
+  pipeline; components style themselves through roles, so re-theming is a one-line
+  change. Named themes, per-role overrides, dark/light, and color degradation.
+- **A registry + `add` CLI** - `curspan list` / `info` / `add` copies a component and its dependency closure into your project from a machine-readable [registry](registry/registry.json).
+
+The reference app:
 
 - **Modern C23, no compiler wrangling** - The latest C standard through Zig's bundled toolchain.
 - **CLI and TUI in one** - Argument parsing and colored output, plus a default ncurses/PDCurses interface (`-Denable-tui=false` disables it).
@@ -24,6 +45,35 @@ Actions CI/CD scaffold.
 - **Tested end to end** - Three test layers: in-process unit tests, C23 CLI contract tests, and PTY-driven terminal scenarios for real CLI/TUI behavior.
 - **CI/CD scaffold included** - GitHub Actions for builds, tests, linting, release artifacts, and optional security checks.
 - **OpenCLI-style contract** - A checked-in machine-readable CLI contract your tool can print on demand with `myapp opencli`.
+
+## The framework
+
+Components draw through a neutral surface and style themselves through theme
+roles, so one component renders on a piped CLI, a truecolor terminal, and inside
+a TUI screen:
+
+```c
+#include "curspan.h"
+
+cs_surface_t *s = cs_surface_stream_new(stdout, config, NULL); // NULL => default theme
+cs_heading_render(&(cs_heading_t){.text = "Build report", .underline = true}, s);
+cs_table_render(&(cs_table_t){.columns = cols, .column_count = 2,
+                              .cells = cells, .row_count = n, .header = true}, s);
+cs_surface_free(s);
+```
+
+The catalog (`curspan list`): `cs_rule`, `cs_heading`, `cs_badge`, `cs_note`,
+`cs_keyvalue`, `cs_list`, `cs_table`, `cs_progress`, and `cs_spinner` — built on
+the `surface` and `theme` foundations.
+
+Add one to your project — it copies the component and everything it depends on:
+
+```bash
+zig build curspan                        # build zig-out/bin/curspan
+./zig-out/bin/curspan add table --dest .  # copy cs_table + its deps into ./src/...
+```
+
+Full reference: [COMPONENTS.md](docs/COMPONENTS.md) and [THEMING.md](docs/THEMING.md).
 
 ## Quick Start
 
@@ -256,10 +306,15 @@ The template wires up far more than the starter code. The full inventory:
 
 Start with [**Using This Template**](.template/TEMPLATE_USAGE.md) for the full setup guide.
 
+### Framework
+
+- [**Components**](docs/COMPONENTS.md) - The component catalog, the render surface, and the drawing API
+- [**Theming**](docs/THEMING.md) - Design tokens, semantic roles, named themes, overrides, and color degradation
+
 ### Developer resources
 
-- [**Architecture Overview**](docs/ARCHITECTURE.md) - System design and module structure
-- [**Public Contracts**](docs/CONTRACTS.md) - Supported CLI and TUI seams
+- [**Architecture Overview**](docs/ARCHITECTURE.md) - System design, the framework layer, and module structure
+- [**Public Contracts**](docs/CONTRACTS.md) - Supported framework, CLI, and TUI seams
 - [**Zig Primer for C Developers**](docs/ZIG_PRIMER.md) - Understanding the build system
 - [**Testing CLI And TUI Behavior**](docs/TESTING.md) - End-to-end terminal scenario tests
 - [**Contributing Guide**](CONTRIBUTING.md) - How to contribute to the project
@@ -267,8 +322,8 @@ Start with [**Using This Template**](.template/TEMPLATE_USAGE.md) for the full s
 
 ### Examples and demos
 
-- [**Adding Commands**](examples/adding-a-command.md) - Extend the CLI
-- [**Custom TUI Components**](examples/custom-tui.md) - Build interactive interfaces
+- [**Composing Components**](examples/custom-tui.md) - Render the catalog on a CLI or TUI surface
+- [**Adding Commands**](examples/adding-a-command.md) - Extend the reference app's CLI
 - [**Configuration Guide**](examples/config.json) - Config file examples
 - [**Demo Gallery**](docs/demos/README.md) - Animated demonstrations
 
@@ -299,9 +354,9 @@ For issues with your generated project:
 
 ## License
 
-This template is MIT licensed. See [LICENSE](LICENSE) for details.
+Curspan is MIT licensed. See [LICENSE](LICENSE) for details.
 
-When you use this template, you can choose any license for your project.
+When you start from the reference app, you can choose any license for your project.
 
 ---
 

--- a/build.zig
+++ b/build.zig
@@ -319,8 +319,9 @@ pub fn build(b: *std.Build) void {
     // (app-core, below) and linked into both, instead of being compiled twice.
     // Keep this list to the unconditional intersection: anything gated by
     // -Denable-tui / -Denable-cli-style (design_tokens, text_layout, color_math,
-    // cli/style/*, tui/*) must stay per-target so a minimal build still skips it,
-    // and the mutually-exclusive terminal backends stay per-target too.
+    // ui_theme, cli/style/*, tui/*) must stay per-target so a minimal build
+    // still skips it, and the mutually-exclusive terminal backends stay
+    // per-target too.
     const core_shared_sources = [_][]const u8{
         "src/core/app_info.c",
         "src/core/diagnostics.c",
@@ -426,22 +427,26 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.linkLibrary(core_lib);
 
-    // UI primitives shared by *both* front-ends: UTF-8 text layout and the
-    // design palette. The TUI seeds its truecolor entries from
-    // APP_DESIGN_PALETTE and lays out rows with app_text_*; the CLI styling
-    // layer uses the same helpers. They must compile whenever EITHER front-end
-    // is enabled, so they live outside the cli-style gate below. (Previously
-    // they sat in cli_style_sources, which made `-Denable-cli-style=false` with
-    // the default TUI fail to link APP_DESIGN_PALETTE / app_text_*.)
+    // UI primitives shared by *both* front-ends: UTF-8 text layout, color math,
+    // raw design tokens, and semantic UI roles. The TUI and styled CLI both map
+    // their renderer-specific tokens/pairs through this layer, so color meaning
+    // stays shared while each terminal backend degrades independently.
     const shared_ui_sources = [_][]const u8{
         "src/ui/text_layout.c",
+        "src/style/color_math.c",
         "src/style/design_tokens.c",
+        "src/style/ui_theme.c",
+        // Framework foundation: the public theming API and the neutral render
+        // surface (stream backend + dispatch). Compiled whenever either
+        // front-end is on; the curses backend (surface_curses.c) is appended
+        // with the TUI sources below.
+        "src/style/cs_theme.c",
+        "src/surface/surface.c",
     };
 
-    // CLI styling sources (cli/style renderers + color math). The terminal
-    // backend is chosen at build time: terminfo when available, else ANSI.
+    // CLI styling sources (cli/style renderers). The terminal backend is chosen
+    // at build time: terminfo when available, else ANSI.
     const cli_style_sources = [_][]const u8{
-        "src/style/color_math.c",
         "src/cli/style/cli_term.c",
         "src/cli/style/cli_term_osc11.c",
         "src/cli/style/cli_theme.c",
@@ -499,6 +504,9 @@ pub fn build(b: *std.Build) void {
             "src/tui/tui_menu_adapter.c",
             "src/tui/tui_menu_model.c",
             "src/tui/tui_progress.c",
+            // The cs_surface curses backend. Isolated from surface.c so a
+            // CLI-only build never links ncurses through the surface layer.
+            "src/surface/surface_curses.c",
         };
 
         exe.root_module.addCSourceFiles(.{
@@ -557,13 +565,14 @@ pub fn build(b: *std.Build) void {
             "src/core/error.c",
             "src/utils/logging.c",
             "src/io/terminal.c",
-            // Shared UI primitives the TUI links against: tui.c seeds its
-            // truecolor entries from APP_DESIGN_PALETTE (design_tokens.c) and
-            // lays out menu rows with app_text_* (text_layout.c). Both
-            // definitions must be archived or a consumer of libtui-menu.a fails
-            // to link app_text_truncate_utf8_columns / app_text_wrap_utf8.
-            "src/style/design_tokens.c",
+            // Shared UI primitives the TUI links against: text layout, color
+            // math, raw design tokens, and semantic UI roles. These definitions
+            // must be archived or a consumer of libtui-menu.a fails to link the
+            // standalone menu/window implementation.
             "src/ui/text_layout.c",
+            "src/style/color_math.c",
+            "src/style/design_tokens.c",
+            "src/style/ui_theme.c",
             "src/tui/tui.c",
             "src/tui/tui_menu.c",
             "src/tui/tui_menu_adapter.c",
@@ -669,6 +678,7 @@ pub fn build(b: *std.Build) void {
             "test/unit_config_tests.c",
             "test/unit_input_tests.c",
             "test/unit_tui_menu_tests.c",
+            "test/unit_ui_theme_tests.c",
             "test/unit_cli_style_tests.c",
             "test/unit_cli_osc11_tests.c",
             "test/unit_shared_primitives_tests.c",
@@ -687,6 +697,12 @@ pub fn build(b: *std.Build) void {
             "src/ui/text_layout.c",
             "src/style/color_math.c",
             "src/style/design_tokens.c",
+            "src/style/ui_theme.c",
+            // Framework foundation under test. surface_curses.c is intentionally
+            // excluded: the unit binary links no ncurses, and the stream
+            // backend in surface.c is curses-free.
+            "src/style/cs_theme.c",
+            "src/surface/surface.c",
             "src/cli/style/cli_term.c",
             "src/cli/style/cli_term_osc11.c",
             "src/cli/style/cli_term_ansi.c",

--- a/build.zig
+++ b/build.zig
@@ -584,6 +584,7 @@ pub fn build(b: *std.Build) void {
             "src/style/color_math.c",
             "src/style/design_tokens.c",
             "src/style/ui_theme.c",
+            "src/style/cs_theme.c",
             "src/tui/tui.c",
             "src/tui/tui_menu.c",
             "src/tui/tui_menu_adapter.c",

--- a/build.zig
+++ b/build.zig
@@ -442,6 +442,17 @@ pub fn build(b: *std.Build) void {
         // with the TUI sources below.
         "src/style/cs_theme.c",
         "src/surface/surface.c",
+        // Component catalog: each renders through cs_surface, so the same
+        // component works on a CLI stream and a TUI window.
+        "src/components/cs_rule.c",
+        "src/components/cs_heading.c",
+        "src/components/cs_badge.c",
+        "src/components/cs_note.c",
+        "src/components/cs_keyvalue.c",
+        "src/components/cs_list.c",
+        "src/components/cs_table.c",
+        "src/components/cs_progress.c",
+        "src/components/cs_spinner.c",
     };
 
     // CLI styling sources (cli/style renderers). The terminal backend is chosen
@@ -703,6 +714,17 @@ pub fn build(b: *std.Build) void {
             // backend in surface.c is curses-free.
             "src/style/cs_theme.c",
             "src/surface/surface.c",
+            // Component catalog under test (rendered to a non-TTY stream).
+            "src/components/cs_rule.c",
+            "src/components/cs_heading.c",
+            "src/components/cs_badge.c",
+            "src/components/cs_note.c",
+            "src/components/cs_keyvalue.c",
+            "src/components/cs_list.c",
+            "src/components/cs_table.c",
+            "src/components/cs_progress.c",
+            "src/components/cs_spinner.c",
+            "test/unit_components_tests.c",
             "src/cli/style/cli_term.c",
             "src/cli/style/cli_term_osc11.c",
             "src/cli/style/cli_term_ansi.c",

--- a/build.zig
+++ b/build.zig
@@ -812,6 +812,45 @@ pub fn build(b: *std.Build) void {
         terminal_test_step.dependOn(&skip_cmd.step);
     }
 
+    // The Curspan component CLI: the framework's ShadCN-style `add` mechanism.
+    // A pure-Zig tool (no libc, no project sources) that reads the registry and
+    // copies a component plus its dependency closure into a consumer's tree.
+    // Built for the host so it runs as a dev tool regardless of -Dtarget.
+    const curspan_exe = b.addExecutable(.{
+        .name = "curspan",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/curspan/main.zig"),
+            .target = b.graph.host,
+            .optimize = optimize,
+        }),
+    });
+    const install_curspan = b.addInstallArtifact(curspan_exe, .{});
+    const curspan_step = b.step("curspan", "Build + install the Curspan component CLI (registry list/info/add/check)");
+    curspan_step.dependOn(&install_curspan.step);
+
+    // `zig build curspan-run -- add table --dest path` runs the tool from the
+    // project root so registry-relative paths resolve.
+    const curspan_run = b.addRunArtifact(curspan_exe);
+    if (b.args) |args| {
+        curspan_run.addArgs(args);
+    }
+    const curspan_run_step = b.step("curspan-run", "Run the Curspan CLI, e.g. zig build curspan-run -- add table");
+    curspan_run_step.dependOn(&curspan_run.step);
+
+    // Registry integrity check, wired into the test suite: every file a
+    // component lists must exist, every dependency must resolve, and the graph
+    // must be acyclic. Absolute paths (via LazyPath) keep it correct regardless
+    // of the directory `zig build` was invoked from.
+    const registry_check = b.addRunArtifact(curspan_exe);
+    registry_check.addArg("check");
+    registry_check.addArg("--registry");
+    registry_check.addFileArg(b.path("registry/registry.json"));
+    registry_check.addArg("--root");
+    registry_check.addDirectoryArg(b.path("."));
+    const registry_step = b.step("registry", "Validate the component registry");
+    registry_step.dependOn(&registry_check.step);
+    test_step.dependOn(&registry_check.step);
+
     // Clean command – cross-platform
     const clean_cmd = if (target.result.os.tag == .windows)
         b.addSystemCommand(&.{ "cmd", "/C", "if exist zig-out rmdir /S /Q zig-out & if exist .zig-cache rmdir /S /Q .zig-cache" })
@@ -823,14 +862,14 @@ pub fn build(b: *std.Build) void {
     // Format commands
     const fmt_step = b.step("fmt", "Format all source files");
     const fmt = b.addFmt(.{
-        .paths = &.{ "build.zig", "src", "test" },
+        .paths = &.{ "build.zig", "src", "test", "tools" },
         .check = false,
     });
     fmt_step.dependOn(&fmt.step);
 
     const fmt_check_step = b.step("fmt-check", "Check source formatting");
     const fmt_check = b.addFmt(.{
-        .paths = &.{ "build.zig", "src", "test" },
+        .paths = &.{ "build.zig", "src", "test", "tools" },
         .check = true,
     });
     fmt_check_step.dependOn(&fmt_check.step);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,9 +29,11 @@ graph TD
     CLI --> CMD["cli/commands_*.c - handlers"]
     CMD --> CORE["core/ - config, errors"]
     CMD --> IO["io/ - text + JSON output"]
+    CLI --> STYLE["style/ - shared UI roles"]
     MAIN -. "bare TTY" .-> TUI["tui/ - ncurses"]
     CMD -. "menu, doctor --deep" .-> TUI
-    CORE --> UTILS["utils/ - logging, colors, memory"]
+    TUI --> STYLE
+    CORE --> UTILS["utils/ - logging, color policy, memory"]
     IO --> TERM[stdout / stderr]
     TUI --> CURSES[ncurses / pdcurses]
 ```
@@ -46,8 +48,9 @@ Each directory under `src/` owns one concern. The functions below are representa
 | `core` | `app_info.c`, `diagnostics.c`, `config.c`, `config_json.c`, `request_json.c`, `error.c`, `types.h` | Build/feature metadata, diagnostic checks, layered configuration, config/headless JSON readers, the flag table, and typed errors | `app_build_info()`, `app_feature_table()`, `app_diagnostics_collect()`, `app_config_create()`, `app_request_parse_json()`, `app_strerror()` |
 | `io` | `input.c`, `output.c`, `terminal.c` | Read stdin/files; write human text and versioned JSON; answer basic curses-free terminal facts | `app_read_input_from_stdin()`, `app_output()`, `app_json_write_string()`, `app_terminal_is_interactive()` |
 | `ui` | `action_item.c`, `text_layout.c` | Curses-free UI primitives. `text_layout.c` (text width/truncation/wrapping) is live and shared by the CLI and TUI renderers. `action_item.c` (selectable action descriptors) is a live shared seam: `app_actions_from_commands()` projects the CLI command table into curses-free descriptors, and the TUI's **Commands** screen (`tui/tui_app.c`) builds its menu rows from those descriptors via the adapter below — so this primitive is on the production path. | `app_text_width_utf8()`, `app_text_truncate_utf8_columns()`, `app_actions_from_commands()` |
-| `tui` | `tui.c`, `tui_menu.c`, `tui_menu_adapter.c`, `tui_menu_model.c`, `tui_progress.c`, `tui_app.c` | ncurses lifecycle, modal menus, progress bars, and the demo showcase (compiled by default unless `-Denable-tui=false`). `tui_menu_adapter.c` converts each curses-free `app_action_item_t` into a `tui_menu_item_t`; the showcase's **Commands** screen uses it to render CLI command metadata as menu rows. | `tui_init()`, `tui_cleanup()`, `tui_show_menu()`, `tui_menu_item_from_action()`, `tui_progress_create()` |
-| `utils` | `colors.c`, `logging.c`, `memory.c` | Cross-cutting helpers: color setup, leveled logging, secret zeroing | `app_log_init()`, `app_secret_zero()` |
+| `style` | `design_tokens.c`, `ui_theme.c`, `color_math.c` | Curses-free visual primitives shared by the styled CLI and generated TUI: raw RGB design tokens, semantic UI roles, accent parsing, and RGB→ANSI degradation. CLI SGR tokens and TUI color pairs are renderer adapters over these roles. | `APP_DESIGN_PALETTE`, `app_ui_theme_default_scheme()`, `app_ui_theme_apply_env_overrides()`, `app_color_rgb_to_xterm256()` |
+| `tui` | `tui.c`, `tui_menu.c`, `tui_menu_adapter.c`, `tui_menu_model.c`, `tui_progress.c`, `tui_app.c` | ncurses lifecycle, modal menus, progress bars, and the demo showcase (compiled by default unless `-Denable-tui=false`). `tui_menu_adapter.c` converts each curses-free `app_action_item_t` into a `tui_menu_item_t`; the showcase's **Commands** screen uses it to render CLI command metadata as menu rows. TUI colors are realized from shared `style` roles through curses palette/pair fallbacks. | `tui_init()`, `tui_cleanup()`, `tui_show_menu()`, `tui_menu_item_from_action()`, `tui_progress_create()` |
+| `utils` | `colors.c`, `logging.c`, `memory.c` | Cross-cutting helpers: color-policy env parsing, leveled logging, secret zeroing | `app_log_init()`, `app_color_env_force()`, `app_secret_zero()` |
 
 The command table is the seam to extend. `commands.c` registers the built-in commands,
 and each lives in its own file (`commands_basic.c` for `hello`/`echo`, plus
@@ -80,8 +83,9 @@ Pass `-Denable-tui=false` to skip those sources. A separate `tui-menu-lib` step 
 primitive as a static library with installed headers.
 
 The two front-ends are independent build axes: the shared UI primitives (text
-layout, design tokens) compile whenever *either* the TUI or the CLI styling
-layer is enabled, so every combination links. A stripped `ReleaseSafe` binary
+layout, color math, design tokens, and semantic UI theme roles) compile whenever
+*either* the TUI or the CLI styling layer is enabled, so every combination
+links. A stripped `ReleaseSafe` binary
 ranges from ~139 KB (full TUI + styling) down to a ~68 KB libc-only build with
 both front-ends off; see the [footprint matrix](ZIG_PRIMER.md#binary-footprint).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,12 @@
 # Architecture Overview
 
-A map of how a project generated from this template is put together: the layers, the real modules, how a command runs, and where to add your own code.
+A map of how Curspan is put together: the framework layer (theme → surface →
+components), the reference app built on it, the real modules, how a command runs,
+and where to add your own code.
 
 - [The mental model](#the-mental-model)
+- [The framework layer](#the-framework-layer)
+- [Distribution: the registry and curspan add](#distribution-the-registry-and-curspan-add)
 - [Module map](#module-map)
 - [Request lifecycle](#request-lifecycle)
 - [Build system](#build-system)
@@ -12,11 +16,20 @@ A map of how a project generated from this template is put together: the layers,
 
 ## The mental model
 
-It is a small, layered C23 program. `main.c` parses arguments, resolves configuration,
-selects the TUI, headless JSON, or a named CLI command, and runs command handlers
-through one table. Handlers write text on TTYs or JSON under pipes through one I/O
-layer and signal failure with a typed error code that becomes the process exit
-status.
+Curspan is two things in one repo: a **framework** (a themeable component catalog
+that renders on either terminal front-end) and a **reference app** that uses it.
+
+The framework is three layers — a [theme](THEMING.md) (design tokens → semantic
+roles), a neutral [render surface](COMPONENTS.md#the-surface) with a CLI-stream
+backend and a TUI-window backend, and a [component catalog](COMPONENTS.md) that
+draws through the surface. The umbrella header `curspan.h` exposes all three. See
+[The framework layer](#the-framework-layer).
+
+The reference app is a small, layered C23 program. `main.c` parses arguments,
+resolves configuration, selects the TUI, headless JSON, or a named CLI command,
+and runs command handlers through one table. Handlers write text on TTYs or JSON
+under pipes through one I/O layer and signal failure with a typed error code that
+becomes the process exit status.
 
 The interactive ncurses interface is a separate layer that compiles by default. Pass
 `-Denable-tui=false` when you want a CLI/headless-only build with no curses
@@ -38,6 +51,67 @@ graph TD
     TUI --> CURSES[ncurses / pdcurses]
 ```
 
+## The framework layer
+
+```
+                         curspan.h  (umbrella header)
+   theme (tokens->roles)        surface (neutral)            components
+ ┌───────────────────┐   ┌─────────────────────────┐   ┌────────────────────┐
+ │ design_tokens      │   │ cs_surface (interface)  │   │ cs_rule  cs_heading │
+ │ ui_theme (roles)   │──▶│  ├ stream backend ──────┼──▶│ cs_badge cs_note    │
+ │ cs_theme (public)  │   │  │   (CLI: SGR)          │   │ cs_keyvalue cs_list │
+ │  named themes,     │   │  └ curses backend ───────┼──▶│ cs_table cs_progress│
+ │  per-role override │   │      (TUI: WINDOW*)      │   │ cs_spinner …        │
+ └───────────────────┘   └─────────────────────────┘   └────────────────────┘
+          │                          │
+          └──── shared resolver ─────┘   registry/registry.json + `curspan add`
+```
+
+- **Theme** (`src/style/`): the design-token → semantic-role pipeline, exposed as
+  the public `cs_theme` API (named themes, per-role overrides, mode resolution).
+  One shared resolver (`app_ui_color_resolve`) degrades a role to a concrete
+  color for a terminal profile; both surface backends call it, so a role looks
+  the same everywhere. See [THEMING.md](THEMING.md).
+- **Surface** (`src/surface/`): the neutral `cs_surface_t` every component draws
+  to. `surface.c` holds the public dispatch and the curses-free stream backend;
+  `surface_curses.c` (compiled only under `ENABLE_TUI`) holds all ncurses
+  contact, reached through an ops vtable — so a CLI-only or unit-test build never
+  links a curses symbol. See [COMPONENTS.md](COMPONENTS.md#the-surface).
+- **Components** (`src/components/`): self-contained `cs_<name>.h/.c` widgets with
+  a borrowed-pointer props struct and a `cs_<name>_render(props, surface)` entry
+  point. See [COMPONENTS.md](COMPONENTS.md).
+
+The public framework namespace is `cs_`; the implementation keeps the existing
+`app_`/`tui_` symbols, which stay back-compatible for the reference app and the
+`tui-menu` contract. The whole framework layer compiles whenever either
+front-end is enabled (the curses backend only under `-Denable-tui`), so every
+build flag combination still links.
+
+## Distribution: the registry and curspan add
+
+Components are **open code** — you copy them into your project and own them, the
+way ShadCN distributes UI components. The catalog is described by a
+machine-readable manifest, [`registry/registry.json`](../registry/registry.json):
+each entry lists a component's `files`, its `dependencies` on other entries, and
+metadata. Foundations (`surface`, `theme`, `text-layout`, `color-math`,
+`design-tokens`, `glyphs`) are entries too, so dependency closures resolve.
+
+The `curspan` CLI (`tools/curspan/main.zig`, built with `zig build curspan`)
+reads that manifest:
+
+```bash
+curspan list                 # the catalog, grouped by category
+curspan info table           # a component's files + dependency closure
+curspan add table --dest DIR # copy cs_table + its transitive deps into DIR
+curspan check                # validate the registry (files exist, deps resolve, acyclic)
+```
+
+`add` copies the component **and its transitive dependency closure**, then prints
+the exact `build.zig` source lines to add for the copied `.c` files. `zig build
+registry` runs `curspan check`, and that check is wired into `zig build test`, so
+the manifest can't drift from the source tree. The tooling lives outside the app
+binary, so the `opencli.json` contract is untouched.
+
 ## Module map
 
 Each directory under `src/` owns one concern. The functions below are representative entry points, not the full surface; read the matching header for the rest.
@@ -48,7 +122,9 @@ Each directory under `src/` owns one concern. The functions below are representa
 | `core` | `app_info.c`, `diagnostics.c`, `config.c`, `config_json.c`, `request_json.c`, `error.c`, `types.h` | Build/feature metadata, diagnostic checks, layered configuration, config/headless JSON readers, the flag table, and typed errors | `app_build_info()`, `app_feature_table()`, `app_diagnostics_collect()`, `app_config_create()`, `app_request_parse_json()`, `app_strerror()` |
 | `io` | `input.c`, `output.c`, `terminal.c` | Read stdin/files; write human text and versioned JSON; answer basic curses-free terminal facts | `app_read_input_from_stdin()`, `app_output()`, `app_json_write_string()`, `app_terminal_is_interactive()` |
 | `ui` | `action_item.c`, `text_layout.c` | Curses-free UI primitives. `text_layout.c` (text width/truncation/wrapping) is live and shared by the CLI and TUI renderers. `action_item.c` (selectable action descriptors) is a live shared seam: `app_actions_from_commands()` projects the CLI command table into curses-free descriptors, and the TUI's **Commands** screen (`tui/tui_app.c`) builds its menu rows from those descriptors via the adapter below — so this primitive is on the production path. | `app_text_width_utf8()`, `app_text_truncate_utf8_columns()`, `app_actions_from_commands()` |
-| `style` | `design_tokens.c`, `ui_theme.c`, `color_math.c` | Curses-free visual primitives shared by the styled CLI and generated TUI: raw RGB design tokens, semantic UI roles, accent parsing, and RGB→ANSI degradation. CLI SGR tokens and TUI color pairs are renderer adapters over these roles. | `APP_DESIGN_PALETTE`, `app_ui_theme_default_scheme()`, `app_ui_theme_apply_env_overrides()`, `app_color_rgb_to_xterm256()` |
+| `style` | `design_tokens.c`, `ui_theme.c`, `color_math.c`, `cs_theme.c` | Curses-free visual primitives shared by both front-ends: raw RGB design tokens, semantic UI roles, accent parsing, RGB→ANSI degradation, and one shared color resolver. `cs_theme.c` is the public theming API (named themes, per-role override, mode resolution) over these roles. | `APP_DESIGN_PALETTE`, `app_ui_color_resolve()`, `cs_theme_default()`, `cs_theme_by_name()`, `cs_theme_set_role()` |
+| `surface` | `surface.c`, `surface_curses.c` | The neutral `cs_surface` every component draws to: public dispatch + the curses-free stream (CLI/SGR) backend in `surface.c`; the ncurses (TUI) backend in `surface_curses.c`, behind an ops vtable and gated on `ENABLE_TUI`. | `cs_surface_stream_new()`, `cs_surface_curses_new()`, `cs_surface_set_role()`, `cs_surface_write()` |
+| `components` | `cs_rule.c`, `cs_heading.c`, `cs_badge.c`, `cs_note.c`, `cs_keyvalue.c`, `cs_list.c`, `cs_table.c`, `cs_progress.c`, `cs_spinner.c`, `cs_glyphs.h` | The component catalog. Each is a self-contained widget with a borrowed-pointer props struct that renders through `cs_surface`, so the same call works on a CLI stream and a TUI window. | `cs_table_render()`, `cs_note_render()`, `cs_progress_render()`, `cs_heading_render()` |
 | `tui` | `tui.c`, `tui_menu.c`, `tui_menu_adapter.c`, `tui_menu_model.c`, `tui_progress.c`, `tui_app.c` | ncurses lifecycle, modal menus, progress bars, and the demo showcase (compiled by default unless `-Denable-tui=false`). `tui_menu_adapter.c` converts each curses-free `app_action_item_t` into a `tui_menu_item_t`; the showcase's **Commands** screen uses it to render CLI command metadata as menu rows. TUI colors are realized from shared `style` roles through curses palette/pair fallbacks. | `tui_init()`, `tui_cleanup()`, `tui_show_menu()`, `tui_menu_item_from_action()`, `tui_progress_create()` |
 | `utils` | `colors.c`, `logging.c`, `memory.c` | Cross-cutting helpers: color-policy env parsing, leveled logging, secret zeroing | `app_log_init()`, `app_color_env_force()`, `app_secret_zero()` |
 
@@ -121,6 +197,10 @@ Compiler-level hardening (`-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2`, PIE
 
 | You want to… | Start here |
 | --- | --- |
+| Render a component | [COMPONENTS.md](COMPONENTS.md) — make a `cs_surface`, call `cs_<name>_render` |
+| Add a component to your project | `curspan add <name>` (see [the registry section](#distribution-the-registry-and-curspan-add)) |
+| Re-theme or override a role | [THEMING.md](THEMING.md) — `cs_theme_by_name` / `cs_theme_set_role` |
+| Author a new component | copy an existing `src/components/cs_*.{c,h}`, then add it to `registry/registry.json` |
 | Add a command | [examples/adding-a-command.md](../examples/adding-a-command.md), then register it in `src/cli/commands.c` |
 | Add a config flag | `src/core/config.c` (the flag table) and `src/core/config_json.c` |
 | Add a new exit code | `src/core/error.c`, then regenerate `opencli.json` (see [CONTRACTS.md](CONTRACTS.md)) |

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,342 @@
+# Components
+
+Curspan ships a catalog of terminal-UI components. Each one is a self-contained
+`cs_<name>.h` / `cs_<name>.c` pair that you **own**: copy it into your project
+with [`curspan add`](#getting-a-component) and edit it like your own code. Every
+component renders through one neutral [surface](#the-surface) and styles itself
+through [theme roles](THEMING.md), so the same call draws on a piped CLI, a
+truecolor terminal, and inside a TUI window.
+
+- [The surface](#the-surface)
+- [Drawing API](#drawing-api)
+- [The catalog](#the-catalog)
+- [Component reference](#component-reference)
+- [Glyphs](#glyphs)
+- [Getting a component](#getting-a-component)
+
+## The surface
+
+A `cs_surface_t` is a styled, role-aware drawing target. It hides whether output
+is a byte stream (CLI: SGR escapes, degraded by color profile) or an ncurses
+window (TUI: color pairs). Components never name a raw color or an escape code —
+the surface owns capability detection and color degradation; components stay pure
+layout and semantics.
+
+```c
+#include "curspan.h"
+
+cs_surface_t *s = cs_surface_stream_new(stdout, config, NULL); // NULL => default theme
+cs_heading_render(&(cs_heading_t){.text = "Report", .underline = true}, s);
+cs_surface_free(s);
+```
+
+Create one of two backends:
+
+| Constructor | Backend | Notes |
+| --- | --- | --- |
+| `cs_surface_stream_new(FILE *stream, const app_config_t *config, const cs_theme_t *theme)` | byte stream (CLI) | `config` supplies the color policy (`NO_COLOR` / `--plain` / `--json` …); pass `NULL` for capability-only detection. `theme` is copied; `NULL` => default. |
+| `cs_surface_curses_new(tui_window_t *window, const cs_theme_t *theme)` | ncurses window (TUI) | Only declared under `ENABLE_TUI`. Requires `tui_init()` + `tui_init_colors()` first. |
+
+Free a surface with `cs_surface_free(s)`. The surface borrows the `FILE *` /
+window — freeing the surface never closes your stream or destroys your window.
+
+Introspect what a surface can do and branch on it to degrade gracefully:
+
+```c
+cs_caps_t caps = cs_surface_caps(s);
+// caps.tty, caps.color, caps.unicode, caps.interactive,
+// caps.profile (none/16/256/truecolor), caps.color_count, caps.width
+size_t cols = cs_surface_width(s);
+```
+
+## Drawing API
+
+The surface API is intentionally small. Styling is **additive until
+`cs_surface_reset`** — set a role and/or attributes, write, then reset.
+
+```c
+void cs_surface_set_role(cs_surface_t *s, cs_role_t role);     // foreground role
+void cs_surface_set_role_bg(cs_surface_t *s, cs_role_t role);  // background role (where supported)
+void cs_surface_set_attr(cs_surface_t *s, cs_attr_t attrs);    // CS_ATTR_BOLD/DIM/UNDERLINE/ITALIC
+void cs_surface_reset(cs_surface_t *s);
+
+void cs_surface_write(cs_surface_t *s, const char *utf8);
+void cs_surface_write_n(cs_surface_t *s, const char *utf8, size_t n);
+void cs_surface_repeat(cs_surface_t *s, const char *glyph, size_t count); // rules / padding
+void cs_surface_newline(cs_surface_t *s);
+void cs_surface_move(cs_surface_t *s, int x, int y);  // curses only; no-op on a stream
+
+// Convenience: write `text` in `role` (+ optional attrs) then reset.
+void cs_surface_styled(cs_surface_t *s, cs_role_t role, cs_attr_t attrs, const char *text);
+```
+
+`move()` is a no-op on a stream surface, which flows top-to-bottom; on a curses
+surface it positions the cursor. Writing a component that needs absolute
+positioning therefore ties it to the TUI — most catalog components avoid it.
+
+## The catalog
+
+| Component | Header | Renders |
+| --- | --- | --- |
+| [`cs_rule`](#cs_rule) | `cs_rule.h` | a horizontal divider, optionally with a centered label |
+| [`cs_heading`](#cs_heading) | `cs_heading.h` | a styled section heading, optionally underlined |
+| [`cs_badge`](#cs_badge) | `cs_badge.h` | a small inline status label, colored by variant |
+| [`cs_note`](#cs_note) | `cs_note.h` | a callout block with a colored gutter and wrapped body |
+| [`cs_keyvalue`](#cs_keyvalue) | `cs_keyvalue.h` | an aligned list of key → value rows |
+| [`cs_list`](#cs_list) | `cs_list.h` | a bulleted or numbered list with wrap + hanging indent |
+| [`cs_table`](#cs_table) | `cs_table.h` | a columnar table with alignment and width budgeting |
+| [`cs_progress`](#cs_progress) | `cs_progress.h` | a one-shot progress bar |
+| [`cs_spinner`](#cs_spinner) | `cs_spinner.h` | a frame-based activity indicator |
+
+Pull in the whole catalog with `#include "components/components.h"` (or the
+umbrella `curspan.h`), or include individual `cs_<name>.h` headers for a leaner
+build.
+
+Every component follows the same contract:
+
+- a **props struct** `cs_<name>_t` whose pointer fields are **borrowed** — the
+  component copies nothing, so every pointer must outlive the render call;
+- a render entry point `void cs_<name>_render(const cs_<name>_t *, cs_surface_t *)`
+  (`cs_spinner` also takes a frame index);
+- a `0` / `NULL` value for any role or size field means "use the sensible
+  default" (the documented role, or the surface width);
+- `render(NULL, s)` and `render(p, NULL)` are safe no-ops.
+
+## Component reference
+
+### cs_rule
+
+```c
+typedef struct cs_rule {
+  const char *label;     // optional; centered in the rule (NULL => plain line)
+  cs_role_t role;        // line color role (0 => CS_ROLE_BORDER)
+  cs_role_t label_role;  // label color role (0 => CS_ROLE_TITLE)
+  size_t width;          // total columns (0 => the surface width)
+  const char *glyph;     // line glyph (NULL => unicode "─" / ascii "-")
+} cs_rule_t;
+
+cs_rule_render(&(cs_rule_t){.label = "OPTIONS", .width = 40}, s);
+```
+
+### cs_heading
+
+```c
+typedef struct cs_heading {
+  const char *text;
+  cs_role_t role;  // heading color role (0 => CS_ROLE_TITLE)
+  bool uppercase;  // upper-case the text (ASCII letters only)
+  bool underline;  // draw a rule beneath, as wide as the heading
+} cs_heading_t;
+
+cs_heading_render(&(cs_heading_t){.text = "Usage", .uppercase = true, .underline = true}, s);
+```
+
+### cs_badge
+
+```c
+typedef enum cs_badge_variant {
+  CS_BADGE_NEUTRAL = 0, CS_BADGE_INFO, CS_BADGE_SUCCESS, CS_BADGE_WARNING, CS_BADGE_ERROR,
+} cs_badge_variant_t;
+
+typedef struct cs_badge {
+  const char *text;
+  cs_badge_variant_t variant;
+  bool no_marker;  // omit the leading glyph, render just the bracketed label
+} cs_badge_t;
+
+cs_badge_render(&(cs_badge_t){.text = "OK", .variant = CS_BADGE_SUCCESS}, s);
+```
+
+### cs_note
+
+```c
+typedef enum cs_note_variant {
+  CS_NOTE_INFO = 0, CS_NOTE_SUCCESS, CS_NOTE_WARNING, CS_NOTE_ERROR,
+} cs_note_variant_t;
+
+typedef struct cs_note {
+  cs_note_variant_t variant;
+  const char *title;  // optional
+  const char *body;   // wrapped to the content width
+  size_t width;       // total columns (0 => the surface width)
+} cs_note_t;
+
+cs_note_render(&(cs_note_t){.variant = CS_NOTE_WARNING,
+                            .title = "Heads up",
+                            .body = "This cannot be undone.",
+                            .width = 50}, s);
+```
+
+### cs_keyvalue
+
+```c
+typedef struct cs_keyvalue_pair { const char *key; const char *value; } cs_keyvalue_pair_t;
+
+typedef struct cs_keyvalue {
+  const cs_keyvalue_pair_t *pairs;
+  size_t count;
+  cs_role_t key_role;     // 0 => CS_ROLE_MUTED
+  cs_role_t value_role;   // 0 => CS_ROLE_TEXT
+  const char *separator;  // between key column and value (NULL => "  ")
+} cs_keyvalue_t;
+
+cs_keyvalue_pair_t info[] = {{"Application", "myapp"}, {"Version", "0.1.0"}};
+cs_keyvalue_render(&(cs_keyvalue_t){.pairs = info, .count = 2}, s);
+```
+
+Keys pad to the widest key so values align in a column.
+
+### cs_list
+
+```c
+typedef enum cs_list_style { CS_LIST_BULLET = 0, CS_LIST_NUMBERED } cs_list_style_t;
+
+typedef struct cs_list {
+  const char *const *items;
+  size_t count;
+  cs_list_style_t style;
+  cs_role_t marker_role;  // 0 => CS_ROLE_ACCENT
+  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
+  size_t width;           // 0 => the surface width
+  int start;              // numbered lists: first number (0 => 1)
+} cs_list_t;
+
+const char *steps[] = {"Clone the repo", "Build with zig", "Run the binary"};
+cs_list_render(&(cs_list_t){.items = steps, .count = 3, .style = CS_LIST_NUMBERED}, s);
+```
+
+Long items wrap with a hanging indent aligned under the first character after the
+marker.
+
+### cs_table
+
+```c
+typedef enum cs_align { CS_ALIGN_LEFT = 0, CS_ALIGN_RIGHT } cs_align_t;
+
+typedef struct cs_table_column {
+  const char *header;
+  cs_align_t align;
+  int max_width;  // 0 => unbounded (still subject to the overall width budget)
+} cs_table_column_t;
+
+typedef struct cs_table {
+  const cs_table_column_t *columns;
+  size_t column_count;
+  const char *const *cells;  // row-major, column_count entries per row
+  size_t row_count;
+  bool header;            // render the header row + a separator rule
+  cs_role_t header_role;  // 0 => CS_ROLE_TITLE
+  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
+  cs_role_t border_role;  // 0 => CS_ROLE_BORDER
+  size_t width;           // total budget (0 => the surface width)
+  const char *gap;        // inter-column gap (NULL => "  ")
+} cs_table_t;
+
+cs_table_column_t cols[] = {{.header = "Name"}, {.header = "Status", .align = CS_ALIGN_RIGHT}};
+const char *cells[] = {"build", "ok", "tests", "ok"};
+cs_table_render(&(cs_table_t){.columns = cols, .column_count = 2,
+                              .cells = cells, .row_count = 2,
+                              .header = true, .width = 40}, s);
+```
+
+Columns take their natural width (header vs. widest cell, capped by `max_width`),
+then shrink proportionally to fit the budget; over-long cells truncate. A
+non-zero `row_count` must be matched by a non-NULL `cells`.
+
+### cs_progress
+
+A one-shot bar (distinct from the interactive `tui_progress`): render it once,
+inline, as part of other output.
+
+```c
+typedef struct cs_progress {
+  const char *label;     // optional, shown before the bar
+  double value;          // 0..1 fraction (used when total <= 0)
+  long current;          // with total > 0, fraction = current/total
+  long total;            // 0 => use `value`
+  size_t width;          // total columns (0 => the surface width)
+  cs_role_t bar_role;    // filled portion (0 => CS_ROLE_SUCCESS)
+  cs_role_t track_role;  // empty portion (0 => CS_ROLE_MUTED)
+  bool show_percent;     // append the percentage
+} cs_progress_t;
+
+cs_progress_render(&(cs_progress_t){.label = "Building", .current = 7, .total = 10,
+                                    .width = 40, .show_percent = true}, s);
+```
+
+The fraction is clamped to `[0, 1]` (and a non-finite fraction is treated as 0).
+
+### cs_spinner
+
+Stateless: the caller owns the frame counter and the redraw cadence. Render a
+frame, sleep, advance, and redraw (move the cursor back with `\r` on a stream).
+
+```c
+typedef enum cs_spinner_style {
+  CS_SPINNER_DOTS = 0,  // braille dots (unicode), ASCII line fallback
+  CS_SPINNER_LINE,      // pipe, slash, dash, backslash
+} cs_spinner_style_t;
+
+typedef struct cs_spinner {
+  const char *label;  // optional, shown after the spinner glyph
+  cs_spinner_style_t style;
+  cs_role_t role;  // spinner glyph color (0 => CS_ROLE_ACCENT)
+} cs_spinner_t;
+
+int cs_spinner_frame_count(cs_spinner_style_t style, bool unicode);
+void cs_spinner_render(const cs_spinner_t *spinner, int frame, cs_surface_t *s);
+
+for (int f = 0; working; f++) {
+  fputc('\r', stdout);
+  cs_spinner_render(&(cs_spinner_t){.label = "Working"}, f, s);
+  fflush(stdout);
+  /* sleep, do a slice of work */
+}
+```
+
+`cs_spinner_render` writes inline with no trailing newline; braille frames
+degrade to an ASCII line-spinner when unicode is unavailable.
+
+## Glyphs
+
+Components draw box and marker shapes through `cs_glyphs.h` (header-only). Each
+getter takes the surface's `unicode` capability and returns a UTF-8 glyph or an
+ASCII fallback, so a component draws the same shapes on a modern and a legacy
+terminal without re-deriving the fallbacks:
+
+| Getter | Unicode | ASCII | Getter | Unicode | ASCII |
+| --- | --- | --- | --- | --- | --- |
+| `cs_glyph_hline` | `─` | `-` | `cs_glyph_check` | `✓` | `+` |
+| `cs_glyph_vline` | `│` | `\|` | `cs_glyph_cross` | `✗` | `x` |
+| `cs_glyph_gutter` | `┃` | `\|` | `cs_glyph_warning` | `⚠` | `!` |
+| `cs_glyph_bullet` | `•` | `*` | `cs_glyph_info` | `ℹ` | `i` |
+| `cs_glyph_arrow` | `❯` | `>` | `cs_glyph_bar_full` | `█` | `#` |
+| `cs_glyph_bar_empty` | `░` | `.` | | | |
+
+```c
+cs_caps_t caps = cs_surface_caps(s);
+cs_surface_repeat(s, cs_glyph_hline(caps.unicode), cs_surface_width(s));
+```
+
+## Getting a component
+
+Components are open code — you copy the source into your project and own it. The
+[`curspan` CLI](../registry/registry.json) reads the registry and copies a
+component plus its full dependency closure:
+
+```bash
+zig build curspan                       # build zig-out/bin/curspan
+./zig-out/bin/curspan list              # the catalog, grouped by category
+./zig-out/bin/curspan info table        # a component's files + dependency closure
+./zig-out/bin/curspan add table --dest . # copy cs_table + its deps into ./src/...
+```
+
+`add` prints the exact `build.zig` source lines to add for the copied `.c`
+files. See [the registry section of ARCHITECTURE.md](ARCHITECTURE.md#distribution-the-registry-and-curspan-add)
+for how distribution works.
+
+## See also
+
+- [THEMING.md](THEMING.md) — the roles every component styles itself through
+- [ARCHITECTURE.md](ARCHITECTURE.md) — where the surface and catalog sit
+- [examples/custom-tui.md](../examples/custom-tui.md) — composing components on a TUI surface

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -117,8 +117,9 @@ zig-out/include/curspan/tui/tui_progress.h
 - the `tui_init()` / `tui_cleanup()` lifecycle from `tui.h`
 - `tui_set_color_enabled()` to set the color policy before `tui_init()` — the
   generated app passes `app_use_colors(config)` so the TUI honours the same
-  `NO_COLOR` / `FORCE_COLOR` / `CLICOLOR(_FORCE)` / `--no-color` / `--plain`
-  inputs as the CLI; left unset, the TUI falls back to terminal capability alone
+  `NO_COLOR` / `FORCE_COLOR` / `CLICOLOR(_FORCE)` / `APP_CLI_COLOR=never` /
+  `--no-color` / `--plain` inputs as the CLI; left unset, the TUI falls back
+  to terminal capability alone
 - `tui_show_menu()` from `tui_menu.h`
 - `tui_menu_config_t`, `tui_menu_item_t`, and `tui_menu_result_t`
 - the pointer-lifetime rules documented in `tui_menu.h`
@@ -151,6 +152,9 @@ cc app.c $(pkg-config --cflags tui-menu) \
 
 - `tui_menu_internal.h` and `tui_menu_state_t` internals
 - cell-by-cell rendering details
+- exact colors, palette slots, and color-pair mappings (the CLI and generated
+  TUI intentionally share the same env policy and semantic roles, but not a
+  stable color ABI)
 - exact footer/help text inside the alternate screen
 - terminal-test snapshots, except where a test names a specific invariant
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,12 +1,60 @@
 # Public Contracts
 
-This template is an opinionated reference app built on two reusable seams: a
-machine-readable CLI contract and a small C TUI menu primitive. A "contract" here is a
-stability promise. The surfaces listed as *supported* are safe to build automation or
-downstream code on; everything else (help wording, colors, file layout, internal
-helpers) can change without notice.
+Curspan is a framework plus a reference app built on it. A "contract" here is a
+stability promise: the surfaces listed as *supported* are safe to build
+downstream code or automation on; everything else (help wording, colors, internal
+helpers) can change without notice. The contracts:
 
-Keep mechanism in these seams. Keep local workflow policy in the generated app.
+- the **framework API** — the `cs_` theming, surface, and component surfaces, and
+  the component registry ([Framework contract](#framework-contract));
+- the **CLI contract** — the machine-readable `opencli.json` ([CLI contract](#cli-contract));
+- the **TUI menu primitive** — the reusable `tui-menu` library ([TUI menu contract](#tui-menu-contract)).
+
+Keep mechanism in these seams. Keep local workflow policy in your app.
+
+## Framework contract
+
+The framework's public surface is the `cs_` namespace (`curspan.h`) plus the
+component registry. Because components are **open code** — you copy the source
+into your project and own it — the promise is about the *shape* of the surfaces
+you call, not a binary ABI.
+
+**Supported (stable to depend on):**
+
+- the **theming API** in `cs_theme.h`: the `cs_role_t` role aliases, `cs_theme_t`,
+  and the functions `cs_theme_default`, `cs_theme_by_name`, `cs_theme_names`,
+  `cs_theme_mode_resolve`, `cs_theme_set_role`, `cs_theme_set_role_spec`,
+  `cs_theme_resolve`. The default theme is the amber identity; `APP_CLI_THEME` /
+  `APP_CLI_ACCENT` behave as documented in [THEMING.md](THEMING.md).
+- the **surface API** in `surface.h`: `cs_surface_stream_new`,
+  `cs_surface_curses_new` (under `ENABLE_TUI`), `cs_surface_free`, the
+  introspection calls (`cs_surface_caps`/`width`/`theme`), and the drawing calls
+  (`set_role`/`set_role_bg`/`set_attr`/`reset`/`write`/`write_n`/`repeat`/
+  `newline`/`move`/`styled`). A surface borrows its `FILE *` / window and copies
+  its theme.
+- the **component render contract**: each `cs_<name>_t` props struct borrows its
+  pointers (copies nothing, so they must outlive the call); `cs_<name>_render`
+  (and `cs_spinner_render`'s frame index) is the entry point; a `0`/`NULL` role or
+  size means "use the default"; `render(NULL, …)` / `render(…, NULL)` are no-ops.
+- the **registry manifest** schema (`registry/registry.json`): the per-entry
+  `name`, `category`, `surfaces`, `files`, `dependencies`, `since` fields, and the
+  `curspan list` / `info` / `add` / `check` commands. `zig build test` validates
+  the manifest, so it never references a missing file or an unresolved dependency.
+- the **`CURSPAN_VERSION`** compile-time macro (with `CURSPAN_VERSION_ENCODE`) for
+  feature-detecting the framework across updates.
+
+**Private (may change without notice):**
+
+- the exact glyphs, spacing, and color choices a component renders (style, not
+  contract) — pin specific output in your own tests if you depend on it;
+- the internal `app_ui_*` role implementation behind the `cs_` aliases, the
+  surface's vtable and struct internals, and a component's private helpers;
+- the set of built-in theme names beyond `amber` (the default) and `mono`;
+- the registry's transport (it is local-first; there is no network/remote-fetch
+  promise).
+
+After you copy a component in, it is *your* code — edit it freely. The contract
+covers the catalog you copy *from*, not your fork.
 
 ## CLI contract
 
@@ -127,8 +175,9 @@ zig-out/include/curspan/tui/tui_progress.h
 - the `TUI_MENU_VERSION` compile-time macro (with `TUI_MENU_VERSION_ENCODE`) for feature-detecting the seam across template updates
 
 The archive is self-contained: it bundles the shared UI primitives the menu
-needs (`text_layout.c`, `design_tokens.c`), so linking it requires only a
-curses library. The archive is also self-contained for a foreign toolchain — it
+needs (text layout, color math, design tokens, and semantic UI roles —
+`text_layout.c`, `color_math.c`, `design_tokens.c`, `ui_theme.c`), so linking it
+requires only a curses library. The archive is also self-contained for a foreign toolchain — it
 is compiled with `sanitize_c = .trap`, so its UBSan checks lower to inline traps
 instead of calls into Zig's UBSan runtime, and a plain `cc` link resolves with
 no `__ubsan_handle_*` symbols even from a Debug/ReleaseSafe build.
@@ -160,12 +209,25 @@ cc app.c $(pkg-config --cflags tui-menu) \
 
 ## Not yet
 
-Do not add a plugin API, stable ABI promise, long-running headless service, or
-broad TUI framework until multiple generated projects need the same unsupported
-behavior. Prefer a CLI/spec addition or a small library function before any
-in-process extension system.
+The framework is deliberately a **catalog you copy from**, not a runtime you link
+against. A few things are out of scope until a real need appears across projects:
+
+- **No binary ABI / plugin system.** Distribution is open code via the registry,
+  not a loadable interface. There is no stable ABI promise beyond the source-level
+  `cs_` shapes above and the `tui-menu` archive; prefer copying a component and
+  editing it over a dynamic extension seam.
+- **No network registry.** The registry is local-first (`registry/registry.json`
+  in this repo); there is no remote component fetch or third-party registry
+  protocol.
+- **No new runtime CLI commands or flags** in the reference app that would change
+  the byte-pinned `opencli.json` contract — the framework lives in the `cs_` API
+  and the out-of-band `curspan` tool, not in new subcommands.
+- **No long-running headless service** and **no nested-subcommand engine** until
+  multiple projects need the same behavior.
 
 ## See also
 
+- [COMPONENTS.md](COMPONENTS.md) - the component catalog and the render surface
+- [THEMING.md](THEMING.md) - the theming API and color degradation
 - [ARCHITECTURE.md](ARCHITECTURE.md) - where these seams sit in the codebase
 - [TESTING.md](TESTING.md) - the tests that enforce the CLI contract

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,27 @@
 # Documentation
 
-Developer documentation for working on a project generated from this template. Start here, then jump to the guide that matches your task.
+Developer documentation for the Curspan framework and the reference app built on
+it. Start here, then jump to the guide that matches your task.
+
+## Framework
 
 | Guide | Read it when you want to… |
 | --- | --- |
-| [Architecture Overview](ARCHITECTURE.md) | Understand how the modules fit together and where to add code |
+| [Components](COMPONENTS.md) | Render the component catalog through the surface, or add a component to your project |
+| [Theming](THEMING.md) | Use design tokens, semantic roles, named themes, overrides, and color degradation |
+
+## Building on it
+
+| Guide | Read it when you want to… |
+| --- | --- |
+| [Architecture Overview](ARCHITECTURE.md) | Understand the framework layer, how the modules fit together, and where to add code |
+| [Public Contracts](CONTRACTS.md) | Know which framework, CLI, and TUI seams are stable to build on |
 | [Zig Primer for C Developers](ZIG_PRIMER.md) | Drive the Zig build system with no prior Zig experience |
 | [Testing CLI and TUI Behavior](TESTING.md) | Write and run the CLI contract and PTY/TUI scenario tests |
-| [Public Contracts](CONTRACTS.md) | Know which CLI and TUI seams are stable to build on |
 | [Contributors](CONTRIBUTORS.md) | See maintainers, acknowledgements, and how to contribute |
 
 ## Elsewhere in the repo
 
 - [README](../README.md) - project overview and quick start
 - [CONTRIBUTING](../CONTRIBUTING.md) - workflow, branch, and commit conventions
-- [examples/](../examples/) - task-focused how-tos: add a command, build a TUI, scripting
+- [examples/](../examples/) - task-focused how-tos: compose components, add a command, scripting

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,9 +68,10 @@ zig build terminal-test \
 
 Unit tests link a subset of the production sources directly, so they exercise modules
 like `core/config.c`, `core/error.c`, and `tui/tui_menu_model.c` without spawning a
-process. Add cases to `test/unit_config_tests.c` or `test/unit_tui_menu_tests.c` (or a
-new file registered in the `unit-test` sources in `build.zig`), then run `zig build
-unit-test`.
+process. Shared CLI/TUI style roles are covered in `test/unit_ui_theme_tests.c`, while
+renderer-specific CLI behavior lives in `test/unit_cli_style_tests.c`. Add cases to the
+closest existing file (or a new file registered in the `unit-test` sources in
+`build.zig`), then run `zig build unit-test`.
 
 Reach for a unit test when you can call a function and check its result directly. Reach for a CLI contract test when the behavior is only observable from the outside (exit code, stdout, JSON).
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -1,0 +1,179 @@
+# Theming
+
+Curspan's design system is the framework's core. Every component styles itself
+through **semantic roles**, never hard-coded colors, so re-theming an app — or
+adapting it to a 16-color terminal — is a one-line change, not a sweep through
+render code. This is the terminal-UI analogue of a ShadCN CSS-variable theme.
+
+- [Three layers](#three-layers)
+- [Roles](#roles)
+- [Using a theme](#using-a-theme)
+- [Overriding roles](#overriding-roles)
+- [Light and dark mode](#light-and-dark-mode)
+- [Color degradation](#color-degradation)
+- [Environment contract](#environment-contract)
+
+## Three layers
+
+```
+design tokens          semantic roles              themes
+(raw sRGB values)  ->  (named, adaptive colors) ->  (a named, overridable
+ design_tokens.h        ui_theme.h                   bundle of roles + a mode)
+                                                     cs_theme.h
+```
+
+1. **Design tokens** (`src/style/design_tokens.c`) — the raw sRGB palette. The
+   single source of truth for color *values*. Curspan's default identity is
+   amber-on-near-black (an ayu/gruvbox feel).
+2. **Semantic roles** (`src/style/ui_theme.c`) — each role (e.g. `TITLE`,
+   `BORDER`, `SUCCESS`) is an adaptive color with a `{dark, light}` pair, derived
+   from the tokens. Roles carry an optional 16-color hint so degradation stays
+   faithful.
+3. **Themes** (`src/style/cs_theme.h`) — a `cs_theme_t` is the value components
+   and surfaces consume: a role table (`scheme`), an active light/dark `mode`,
+   and a `name`.
+
+```c
+typedef struct cs_theme {
+  app_ui_color_scheme_t scheme;  // the role table (by value, copyable)
+  cs_mode_t mode;                // active light/dark mode
+  const char *name;              // built-in name, or "custom"
+} cs_theme_t;
+```
+
+## Roles
+
+Components reference roles through render-neutral aliases (`cs_theme.h`), so
+component code reads `cs_surface_set_role(s, CS_ROLE_PRIMARY)` rather than naming
+help-text tokens. The aliases layer over the shared UI roles — no role is
+removed, so the styled CLI and the TUI keep sharing one vocabulary.
+
+| Role | Default meaning |
+| --- | --- |
+| `CS_ROLE_TEXT` | body text |
+| `CS_ROLE_MUTED` | de-emphasized / secondary text |
+| `CS_ROLE_PRIMARY`, `CS_ROLE_ACCENT` | the brand accent (amber) |
+| `CS_ROLE_TITLE`, `CS_ROLE_HEADING` | headings and titles |
+| `CS_ROLE_CODE` | inline code / literals |
+| `CS_ROLE_SUCCESS` | success / ok |
+| `CS_ROLE_WARNING` | warnings |
+| `CS_ROLE_ERROR` | errors |
+| `CS_ROLE_INFO` | informational |
+| `CS_ROLE_BORDER` | rules, separators, frames |
+| `CS_ROLE_SELECTION_FG`, `CS_ROLE_SELECTION_BG` | selected / highlighted row |
+| `CS_ROLE_PANEL` | panel background |
+
+`CS_ROLE_PRIMARY`/`CS_ROLE_ACCENT` and `CS_ROLE_TITLE`/`CS_ROLE_HEADING` are
+aliases for the same underlying role — pick whichever reads best in your code.
+
+## Using a theme
+
+Most apps never touch a theme directly — `cs_surface_stream_new(stream, config,
+NULL)` and `cs_surface_curses_new(window, NULL)` use the default. To pick or
+inspect one:
+
+```c
+#include "curspan.h"
+
+cs_theme_t theme = cs_theme_default();          // "amber", env overrides applied
+cs_theme_by_name("mono", &theme);               // false if the name is unknown
+const char *const *names = cs_theme_names();     // NULL-terminated: "amber", "mono"
+
+cs_surface_t *s = cs_surface_stream_new(stdout, config, &theme); // theme is copied
+```
+
+- `cs_theme_default()` returns the amber identity with `APP_CLI_ACCENT` applied
+  and the mode resolved from the environment. This is what an app gets by default
+  and what every built-in component is tuned against.
+- `cs_theme_by_name(name, &out)` resolves a built-in theme; it returns `false`
+  and leaves `*out` untouched when the name is unknown.
+- The surface **copies** the theme you pass, so a stack `cs_theme_t` is fine.
+
+Built-in themes:
+
+| Name | Identity |
+| --- | --- |
+| `amber` | the default amber-on-near-black palette (full-color) |
+| `mono` | grayscale — every role mapped to a 16-color index, for a no-accent look |
+
+## Overriding roles
+
+Re-theme one slot without forking a theme. Both overrides apply to dark and light
+mode.
+
+```c
+cs_theme_t theme = cs_theme_default();
+
+// Programmatic: supply a parsed color.
+cs_theme_set_role(&theme, CS_ROLE_ACCENT, /* app_ui_color_t */ my_color);
+
+// From a string: "#rrggbb", "rrggbb", or a decimal ANSI index. Returns false
+// (leaving the theme unchanged) on a malformed spec.
+cs_theme_set_role_spec(&theme, CS_ROLE_ACCENT, "#7dd3fc");
+cs_theme_set_role_spec(&theme, CS_ROLE_BORDER, "8");
+```
+
+`cs_theme_set_role` is the general form of the accent override — any role, not
+just the accent.
+
+## Light and dark mode
+
+Each role holds a `{dark, light}` pair; the theme's `mode` selects which is used.
+Mode parsing has a single owner:
+
+```c
+cs_mode_t mode = cs_theme_mode_resolve();  // reads APP_CLI_TEST_THEME / APP_CLI_THEME
+// CS_MODE_DARK or CS_MODE_LIGHT; "auto" and anything unknown resolve to dark.
+```
+
+`cs_theme_default()` / `cs_theme_by_name()` already call this for you. Set
+`theme.mode` directly if you want to force a mode regardless of the environment.
+
+## Color degradation
+
+A theme stores ideal colors; the **surface** resolves each role to what the
+terminal can actually show. Resolution is one shared function
+(`app_ui_color_resolve`) that both the stream and curses backends call, so a
+role degrades identically everywhere:
+
+```c
+app_ui_resolved_color_t c =
+    cs_theme_resolve(&theme, CS_ROLE_TITLE, profile, color_count);
+// c.kind is NONE | DEFAULT | INDEXED (c.index) | RGB (c.rgb)
+```
+
+By profile:
+
+| Profile | An RGB token becomes | An explicit palette index becomes |
+| --- | --- | --- |
+| truecolor | RGB (24-bit) | INDEXED, passed through unchanged |
+| 256-color | nearest xterm-256 index | INDEXED |
+| 16-color | the role's 16-color hint, else nearest ANSI-16 | INDEXED (bright folded to base on true 8-color terminals) |
+| none | no color | no color |
+
+An *explicit* palette index (from `cs_theme_set_role_spec(&t, role, "200")` or an
+all-indexed theme like `mono`) resolves to that index on every profile that can
+render one — including truecolor, where a 24-bit terminal renders palette indices
+fine. (Without this, an all-indexed theme would be colorless on the common
+truecolor profile.)
+
+## Environment contract
+
+Curspan honors the same color/theme environment variables as the styled CLI;
+they are part of the supported [contract](CONTRACTS.md).
+
+| Variable | Effect |
+| --- | --- |
+| `APP_CLI_THEME` | `auto` \| `dark` \| `light` — the light/dark mode (`auto`/unknown => dark) |
+| `APP_CLI_ACCENT` | `#rrggbb` or a decimal ANSI index — overrides the accent role |
+| `APP_CLI_TEST_THEME` | takes precedence over `APP_CLI_THEME` (used by tests) |
+
+Standard color-policy variables (`NO_COLOR`, `FORCE_COLOR`, `CLICOLOR(_FORCE)`,
+`APP_CLI_COLOR`) flow through the `app_config_t` you hand to
+`cs_surface_stream_new`, so a surface respects them without per-component work.
+
+## See also
+
+- [COMPONENTS.md](COMPONENTS.md) — the components that consume these roles
+- [ARCHITECTURE.md](ARCHITECTURE.md#the-framework-layer) — where theming sits
+- [CONTRACTS.md](CONTRACTS.md) — the stability tier of the theming surface

--- a/docs/ZIG_PRIMER.md
+++ b/docs/ZIG_PRIMER.md
@@ -165,7 +165,7 @@ build reaches ~49 KB under `ReleaseSmall`.
    | Array | Compiled when | For |
    | --- | --- | --- |
    | `base_sources` | always | core CLI/app code |
-   | `shared_ui_sources` | TUI **or** CLI styling enabled | text layout + design tokens shared by both front-ends |
+   | `shared_ui_sources` | TUI **or** CLI styling enabled | text layout + color math + design tokens + semantic UI theme roles shared by both front-ends |
    | `cli_style_sources` | `-Denable-cli-style` (default on) | CLI help/error/version renderers |
    | `tui_sources` | `-Denable-tui` (default on) | ncurses screens |
 

--- a/docs/superpowers/specs/2026-06-04-curspan-framework-design.md
+++ b/docs/superpowers/specs/2026-06-04-curspan-framework-design.md
@@ -168,6 +168,7 @@ relevant, degraded-profile output.
 The defining ShadCN feature.
 
 - **`registry/registry.json`** — single source of truth. Each entry:
+
   ```json
   {
     "name": "table",
@@ -180,6 +181,7 @@ The defining ShadCN feature.
     "since": "1.0.0"
   }
   ```
+
   Foundations (`surface`, `theme`, `text-layout`, `color-math`, `design-tokens`) are
   registry entries too, so dependency closures resolve.
 - **`curspan` CLI** (`tools/curspan/main.zig`, built with `zig build curspan` →

--- a/docs/superpowers/specs/2026-06-04-curspan-framework-design.md
+++ b/docs/superpowers/specs/2026-06-04-curspan-framework-design.md
@@ -1,0 +1,281 @@
+# Curspan Framework Design — a ShadCN-style framework for CLIs & TUIs
+
+**Status:** Approved direction (set by repo goal: "refactor to be a proper high level
+framework, think ShadCN, for CLIs and TUIs"). Implemented additively on branch
+`framework-refactor`.
+**Date:** 2026-06-04
+
+## 1. Problem & intent
+
+Curspan today is a high-quality **GitHub template**: you click "Use this template",
+run a cleanup script, and own a generated C23 CLI/TUI app. Its `docs/CONTRACTS.md`
+explicitly says *"Do not add … a broad TUI framework"*. The goal inverts that: make
+Curspan a **framework** in the ShadCN sense — a curated catalog of themeable,
+composable terminal UI components that downstream projects **own** (copy in), driven
+by a shared design-token/semantic-role theme, distributed through a **registry + an
+`add` CLI**.
+
+ShadCN's defining properties, translated to a C23 terminal-UI framework:
+
+| ShadCN pillar | Curspan realization |
+| --- | --- |
+| **Open code** — you own component source | Components are self-contained `.c/.h` pairs you copy into `src/components/`. |
+| **Composition** — one consistent component API | A neutral **render surface** (`cs_surface`) + uniform `cs_<comp>` props/render contract, identical across CLI and TUI. |
+| **Distribution** — `registry.json` + `npx shadcn add` | `registry/registry.json` + a `curspan` CLI: `curspan add table` copies a component and its dependency closure into your project. |
+| **Beautiful defaults** | The existing amber-on-near-black ayu/gruvbox identity, kept as the default theme. |
+| **Theming via tokens** | The existing **design tokens → semantic roles → renderer adapters** pipeline, promoted to the public `cs_theme` API with named themes and per-role overrides. |
+| **AI-ready** | Open, consistent, documented component source with a machine-readable registry. |
+
+## 2. What already exists (and why this is a refactor, not a rewrite)
+
+The substrate is remarkably close already:
+
+- **Theme pipeline** (`src/style/`): raw RGB `APP_DESIGN_PALETTE` → 26 adaptive
+  (dark/light) semantic roles (`APP_UI_ROLE_LIST`) → renderer adapters. This *is*
+  ShadCN's tokens→components model. It is the crown jewel and stays the core.
+- **A stream render surface** (`src/cli/style/cli_term.c`): `app_cli_term_t` owns a
+  `FILE*`+fd, resolves a 4-level color profile (none/16/256/truecolor), emits styled
+  spans, measures width — with a swappable terminfo/ANSI backend. `app_cli_render_ctx_t`
+  is already a "component context" (surface + compiled styles + clamped width).
+  `cli_help_render` / `cli_error_render` / `cli_version_render` are already components.
+- **A curses surface** (`src/tui/tui.c`): windows, borders, wrapped/centered text,
+  color pairs, dialogs — but with **no component-context abstraction**; it threads raw
+  ncurses color pairs and drops to `mvwprintw`/`waddch`.
+- **Shared curses-free primitives** (`src/ui/`): `text_layout` (UTF-8 width/truncate/
+  wrap) and `action_item` (command-table → selectable descriptors), already consumed
+  by both front-ends.
+- **One distributed component**: `tui-menu-lib` (versioned static lib + pkg-config +
+  headers under `curspan/`). This is the *proof of concept* for component distribution.
+
+**Gaps to close:** (a) no neutral surface unifying CLI+TUI, so components can't target
+both; (b) degradation logic duplicated between CLI and TUI; (c) three divergent role
+vocabularies; (d) no component catalog or consistent component API; (e) no public
+theming API (named themes, per-role override); (f) no registry/`add` distribution; (g)
+"template" identity throughout docs.
+
+## 3. Architecture
+
+```
+                         ┌──────────────────────────────┐
+                         │  curspan.h  (umbrella header) │
+                         └──────────────────────────────┘
+   theme (tokens→roles)        surface (neutral)            components
+ ┌───────────────────┐   ┌─────────────────────────┐   ┌────────────────────┐
+ │ design_tokens      │   │ cs_surface (interface)  │   │ cs_rule  cs_heading │
+ │ ui_theme (roles)   │──▶│  ├ stream backend ──────┼──▶│ cs_badge cs_keyval  │
+ │ cs_theme (public)  │   │  │   (app_cli_term_t)    │   │ cs_table cs_note    │
+ │  named themes,     │   │  └ curses backend ───────┼──▶│ cs_list  cs_spinner │
+ │  per-role override │   │      (WINDOW*)           │   │ cs_progress …       │
+ └───────────────────┘   └─────────────────────────┘   │ interactive: menu,  │
+          │                          │                   │ select, confirm,    │
+          └───── shared resolver ────┘                   │ input, progress     │
+            app_ui_resolve(role,mode,profile,colors)     └────────────────────┘
+                                                                   │
+                         registry/registry.json  +  `curspan add`  ◀┘
+```
+
+### 3.1 The neutral render surface — `cs_surface` (`src/surface/`)
+
+The keystone new abstraction. A `cs_surface_t` is a drawing target that components
+write to without knowing whether they render to a byte stream (CLI) or an ncurses
+window (TUI). Two backends:
+
+- **stream backend** — wraps the existing `app_cli_term_t` + compiled styles; emits
+  SGR; degrades by color profile; `move` is a no-op (stream is top-to-bottom).
+- **curses backend** — wraps a `WINDOW*`; draws cells with color pairs resolved via the
+  shared resolver; supports cursor `move`. Only compiled when `ENABLE_TUI`.
+
+Surface API (small, role-driven — components never name raw colors):
+
+```c
+size_t       cs_surface_width(const cs_surface_t *s);
+cs_caps_t    cs_surface_caps(const cs_surface_t *s);   // profile, tty, unicode, interactive
+void         cs_surface_set_role(cs_surface_t *s, cs_role_t role);     // fg
+void         cs_surface_set_role_bg(cs_surface_t *s, cs_role_t role);  // bg (where supported)
+void         cs_surface_set_attr(cs_surface_t *s, cs_attr_t attrs);    // bold/dim/underline/italic
+void         cs_surface_reset(cs_surface_t *s);
+void         cs_surface_write(cs_surface_t *s, const char *utf8);
+void         cs_surface_write_n(cs_surface_t *s, const char *utf8, size_t bytes);
+void         cs_surface_repeat(cs_surface_t *s, const char *glyph, size_t count);
+void         cs_surface_newline(cs_surface_t *s);
+void         cs_surface_move(cs_surface_t *s, int x, int y);  // curses only; no-op on stream
+```
+
+The surface owns degradation + capability; components stay pure layout + semantics.
+
+### 3.2 One shared color resolver
+
+Extract the duplicated `role → concrete color` degradation into one function in
+`src/style/`:
+
+```c
+app_ui_resolved_t app_ui_resolve(app_ui_role_id role,
+                                 app_ui_theme_mode_id mode,
+                                 app_cli_color_profile_id profile,
+                                 int color_count);
+```
+
+Both surface backends call it. **Existing `cli_theme.c` and `tui.c` are left untouched
+in this pass** (their output is byte-pinned by tests); the new resolver is built from
+the same math (`color_math.c`) so it produces identical decisions, and a follow-up can
+migrate the old adapters onto it once snapshot-verified.
+
+### 3.3 Public theming — `cs_theme` (`src/style/cs_theme.h`)
+
+Additive public surface over `app_ui_*`:
+
+- **Named theme registry**: `cs_theme_by_name("amber"|"mono"|…)`, `cs_theme_names()`.
+  Default stays the amber identity. One or two extra schemes prove the catalog.
+- **Per-role override** (not just accent): `cs_theme_set_role(theme, role, color)`.
+- **Mode resolution owned here**: `cs_theme_mode_resolve(env)` — dedupes the
+  `APP_CLI_THEME` parsing currently duplicated in `cli_layout.c` and `tui.c`.
+- **Component-centric role aliases** layered over the help-centric roles
+  (`PRIMARY`, `SECONDARY`, `BORDER`, `MUTED`, `DESTRUCTIVE`, `SUCCESS`, `WARNING`,
+  `INFO`, `SELECTION`) — no existing role removed.
+
+Existing `APP_CLI_ACCENT`/`APP_CLI_THEME` env contract preserved verbatim.
+
+### 3.4 Component catalog (`src/components/`)
+
+Each component is a self-contained `cs_<name>.h/.c` with a **props struct** (caller-owned
+pointers, like the menu) and a render entry point. Two flavors:
+
+- **Render-once** (work on *both* surfaces): `void cs_<name>_render(const cs_<name>_t *, cs_surface_t *)`.
+- **Interactive** (TUI event loop): `cs_<name>_result_t cs_<name>_run(const cs_<name>_t *)`.
+
+Initial catalog (chosen for coverage of the ShadCN "primitives" feel and real CLI/TUI
+utility):
+
+| Component | Surfaces | Notes |
+| --- | --- | --- |
+| `cs_rule` | both | horizontal divider, optional centered label |
+| `cs_heading` | both | section title / banner, role-styled |
+| `cs_badge` | both | inline status pill (success/warn/error/info/muted variants) |
+| `cs_keyvalue` | both | aligned key→value list (used by `info`/`doctor`-style output) |
+| `cs_table` | both | columns with alignment + width budgeting via `text_layout` |
+| `cs_note` | both | callout block (info/success/warning/error) with gutter |
+| `cs_list` | both | bulleted / numbered list with wrap + hanging indent |
+| `cs_spinner` | both | non-interactive frame set (renders one frame; caller drives) |
+| `cs_progress` | both | one-shot progress bar (distinct from interactive `tui_progress`) |
+| `cs_menu` | tui | re-expose the existing reference menu under the umbrella |
+| `cs_select` / `cs_confirm` / `cs_input` | tui | thin, themed wrappers over tui dialogs/menu |
+
+Each ships a unit test asserting plain-surface (escape-free, non-TTY) output and, where
+relevant, degraded-profile output.
+
+### 3.5 Distribution — registry + `curspan` CLI (`registry/`, `tools/curspan/`)
+
+The defining ShadCN feature.
+
+- **`registry/registry.json`** — single source of truth. Each entry:
+  ```json
+  {
+    "name": "table",
+    "title": "Table",
+    "category": "component",
+    "surfaces": ["cli", "tui"],
+    "description": "Columnar table with alignment and width budgeting.",
+    "files": ["src/components/cs_table.c", "src/components/cs_table.h"],
+    "dependencies": ["surface", "theme", "text-layout"],
+    "since": "1.0.0"
+  }
+  ```
+  Foundations (`surface`, `theme`, `text-layout`, `color-math`, `design-tokens`) are
+  registry entries too, so dependency closures resolve.
+- **`curspan` CLI** (`tools/curspan/main.zig`, built with `zig build curspan` →
+  `zig-out/bin/curspan`; convenience steps `zig build registry`, `zig build add -- <name>`):
+  - `curspan list` — print the catalog (grouped by category).
+  - `curspan info <name>` — show a component's files + dependency closure.
+  - `curspan add <name> [--dest DIR] [--dry-run]` — copy the component **and its
+    transitive dependency closure** into `DIR` (default `./src`), then print the exact
+    `build.zig` source lines to add. This is `npx shadcn add` for terminal UI.
+  - Reads `registry/registry.json` via `std.json`; Zig is guaranteed present (it is the
+    build toolchain), so no extra runtime dependency.
+- **Registry integrity test** (`test/unit_registry_tests` or a Zig check): every file
+  referenced exists; every dependency name resolves; no cycles. Keeps the manifest
+  honest as components are added.
+
+The registry tooling lives **outside** the app binary, so `opencli.json` and the 25
+byte-pinned contract cases are untouched.
+
+### 3.6 Public umbrella — `curspan.h`
+
+A single header that includes the public framework surface (`cs_theme`, `cs_surface`,
+the component headers, and the existing `tui`/command-runner seams). Installed as
+`include/curspan/curspan.h` alongside the existing `tui-menu-lib` headers. The `cs_`
+prefix is the public framework namespace; `app_`/`tui_` remain as the implementation
+and stay back-compatible for the existing tests and the `tui-menu` contract.
+
+## 4. Invariants the refactor must NOT break (the safety contract)
+
+Pulled from the codebase map; every one is covered by a test or `opencli.json`:
+
+1. **`opencli.json` byte-match**: `myapp opencli` equals the checked-in file (after the
+   `myapp`→binary rename). Exit codes (0,1,2,3,4,5,6,7,10–17,20–25,130,143), command/
+   flag/arg/example metadata, and the env-var table (`NO_COLOR`, `FORCE_COLOR`,
+   `CLICOLOR(_FORCE)`, `APP_CLI_THEME`, `APP_CLI_COLOR`, `APP_CLI_OSC11`,
+   `APP_CLI_ACCENT`, `APP_LOG_LEVEL`, `APP_CONFIG_PATH`) are frozen. → **No new CLI
+   commands or flags in this pass.**
+2. **25 CLI contract cases**: help content (USAGE/COMMANDS/doctor/debug line/env vars),
+   hidden `menu`, arity errors, `--` semantics, unknown-command suggestions, headless
+   JSON, single-JSON-envelope errors, requires-terminal gating.
+3. **Theme unit invariants**: dark TITLE==palette amber, BORDER==muted (ansi16_hint 7),
+   ERROR_DETAILS==red; light TITLE==RGB(135,94,20); accent reaches SELECTION_BG; color
+   parse semantics; degradation indices (amber→256:180, →16 hint 11, →8:3).
+4. **CLI style invariants**: non-TTY error = `Error: …` + `Try myapp --help for usage.`
+   with **zero escape bytes**; `APP_CLI_COLOR=never` hard-disables; profile forcing.
+5. **Config invariants**: flag-table/enum parallelism, exclusivity (last-wins), atomic
+   load, parse caps, errno mapping, headless `\uXXXX` handling.
+6. **Shared-primitive invariants**: `action_item` skips hidden / contiguous ids 1..N /
+   zero-copy borrows; `text_layout` width/truncate/wrap column accounting + indent
+   preservation + forward progress on bad UTF-8.
+7. **`tui-menu` seam**: `TUI_MENU_VERSION`, `tui_show_menu` API, pointer-lifetime,
+   installed headers under `curspan/`.
+8. **All build flag combinations link**: `-Denable-tui`, `-Denable-cli-style`, both off
+   (libc-only). New sources are gated so a minimal build still links.
+
+**Strategy: additive.** Build the new public layer, surface, resolver, components,
+theming, registry, and umbrella *alongside* the working code. Do not rewrite the
+byte-pinned renderers in this pass. Keep `zig build check` green after every step.
+
+## 5. Build & packaging changes (`build.zig`)
+
+- New `src/surface/*.c`, `src/components/*.c`, `src/style/cs_theme.c`, and the shared
+  resolver compile with the shared UI substrate (gated like `shared_ui_sources`; curses
+  backend gated on `enable_tui`).
+- New unit suites added to the `unit-tests` file list.
+- New `curspan` CLI build step (`tools/curspan/main.zig`) + `registry`/`add` convenience
+  steps; registry-integrity check wired into `test`.
+- Umbrella + component headers installed alongside `tui-menu-lib` (extend the install
+  list); bump nothing that the `tui-menu` pkg-config version pins.
+
+## 6. Documentation reframe (`docs/`, `examples/`, `README.md`)
+
+- **README / ARCHITECTURE**: lead with the framework identity (theme→surface→component,
+  the catalog, `curspan add`). Keep the "use as a starter" path as one workflow, not the
+  whole story.
+- **CONTRACTS.md**: replace "opinionated reference app" framing; rewrite the "Not yet …
+  broad TUI framework" section to describe the now-supported component/theming/registry
+  surfaces and their stability tiers.
+- **New `docs/COMPONENTS.md`** (catalog reference) and **`docs/THEMING.md`** (tokens,
+  roles, named themes, overrides).
+- **examples/custom-tui.md**: replace the raw-ncurses example with component composition
+  through `cs_surface`.
+
+## 7. Build sequence (phases, each ends green)
+
+1. **Foundation**: shared resolver + `cs_theme` (named themes, mode resolve, per-role
+   override, role aliases) + `cs_surface` (stream + curses backends) + `curspan.h`.
+2. **Catalog**: author components (parallelizable — independent files) + unit tests.
+3. **Distribution**: `registry.json` + `curspan` CLI + integrity test + build steps.
+4. **Reframe docs/examples**.
+5. **Wire build across all flag combos**; full `zig build check` green; adversarial
+   review pass; fix; commit.
+
+## 8. Non-goals (YAGNI)
+
+- No plugin/ABI promise beyond the existing `tui-menu` seam and the new headers.
+- No new runtime CLI commands/flags (protects the byte-pinned contract).
+- No network registry / remote component fetching — the registry is local-first.
+- No rewrite of the byte-pinned help/error/version/opencli renderers in this pass.
+- No nested-subcommand engine (noted as a future possibility, not built now).

--- a/examples/custom-tui.md
+++ b/examples/custom-tui.md
@@ -1,110 +1,135 @@
-# Example: Creating a Custom TUI Screen
+# Example: Composing Components on a Surface
 
-The terminal UI is compiled by default (which defines `ENABLE_TUI`). Pass
-`-Denable-tui=false` for a CLI/headless-only build. `tui.h` gives you a window wrapper, dialogs, a progress bar, and one
-modal menu primitive, so command code never calls ncurses directly. Every screen
-follows the same rule: call `tui_init()` first, and `tui_cleanup()` before you return,
-on every path.
+Curspan components draw through one neutral [`cs_surface`](../docs/COMPONENTS.md#the-surface).
+A surface targets either a **CLI byte stream** or a **TUI ncurses window**, so the
+same component calls render in both places — the surface owns capability detection
+and color degradation. This example composes the catalog on each backend, then
+shows where to reach for the interactive TUI primitives.
 
-## 1. A complete screen
+- [On a CLI stream](#1-on-a-cli-stream)
+- [On a TUI window](#2-on-a-tui-window)
+- [Interactive primitives](#3-interactive-primitives)
+- [Theming](#4-theming)
+- [Practices](#5-practices)
 
-This handler opens a bordered window, draws a live value with a bar, and loops on
-keypresses. It drops to raw ncurses (`mvwprintw`, `waddch`) for the drawing, which is
-fine; the wrapper manages lifecycle and layout, not every cell.
+## 1. On a CLI stream
+
+A stream surface needs no TUI build (it works with `-Denable-tui=false`). Build
+one over `stdout`, render components, free it. The `app_config_t` carries the
+color policy (`NO_COLOR` / `--plain` / `--json` …), so the surface respects it
+automatically.
+
+```c
+#include "curspan.h"
+
+static app_error show_report(const app_config_t *config) {
+    cs_surface_t *s = cs_surface_stream_new(stdout, config, NULL); // NULL => default theme
+    if (!s) {
+        return APP_ERROR_MEMORY;
+    }
+
+    cs_heading_render(&(cs_heading_t){.text = "Build report", .underline = true}, s);
+
+    cs_table_column_t cols[] = {
+        {.header = "Step"},
+        {.header = "Result", .align = CS_ALIGN_RIGHT},
+    };
+    const char *cells[] = {
+        "compile", "ok",
+        "link",    "ok",
+        "tests",   "25 passed",
+    };
+    cs_table_render(&(cs_table_t){.columns = cols, .column_count = 2,
+                                  .cells = cells, .row_count = 3,
+                                  .header = true, .width = 48}, s);
+
+    cs_surface_newline(s);
+    cs_note_render(&(cs_note_t){.variant = CS_NOTE_SUCCESS,
+                                .title = "Done",
+                                .body = "Everything is green.",
+                                .width = 48}, s);
+
+    cs_surface_free(s);   // borrows stdout — does not close it
+    return APP_SUCCESS;
+}
+```
+
+The same code degrades on its own: amber on a truecolor terminal, the nearest
+palette index on a 256/16-color one, and plain escape-free text under a pipe.
+
+## 2. On a TUI window
+
+The interactive ncurses interface is compiled by default (which defines
+`ENABLE_TUI`); pass `-Denable-tui=false` for a CLI/headless-only build. Call
+`tui_init()` first (it sets up the color pairs) and `tui_cleanup()` before you
+return on **every** path. A curses surface wraps a `tui_window_t`, so the same
+components draw inside the window:
 
 ```c
 #ifdef ENABLE_TUI
-static app_error show_data_viewer(void) {
-    app_error err = tui_init();
+static app_error show_report_tui(void) {
+    app_error err = tui_init();   // also initializes color pairs
     if (err != APP_SUCCESS) {
         return err;
     }
 
-    int max_y = tui_get_max_y();
-    int max_x = tui_get_max_x();
-
-    tui_window_t *main_win = tui_create_window(max_y - 2, max_x - 2, 1, 1);
-    if (!main_win) {
+    tui_window_t *win = tui_create_window(tui_get_max_y() - 2, tui_get_max_x() - 2, 1, 1);
+    if (!win) {
         tui_cleanup();
         return APP_ERROR_MEMORY;
     }
-    tui_draw_border(main_win);
-    tui_set_window_title(main_win, "Data Viewer");
+    tui_draw_border(win);
+    tui_set_window_title(win, "Build report");
 
-    tui_window_t *data_win = tui_create_window(max_y - 10, max_x - 10, 5, 5);
-    if (!data_win) {
-        tui_destroy_window(main_win);
+    cs_surface_t *s = cs_surface_curses_new(win, NULL);  // NULL => default theme
+    if (!s) {
+        tui_destroy_window(win);
         tui_cleanup();
         return APP_ERROR_MEMORY;
     }
-    tui_draw_border(data_win);
-    tui_set_window_title(data_win, "Live Data");
 
-    bool running = true;
-    int data_value = 0;
+    cs_surface_move(s, 2, 1);   // position inside the border (curses only)
+    cs_heading_render(&(cs_heading_t){.text = "Build report"}, s);
 
-    while (running) {
-        tui_clear_window(data_win);
+    cs_keyvalue_pair_t rows[] = {{"compile", "ok"}, {"link", "ok"}, {"tests", "ok"}};
+    cs_surface_move(s, 2, 3);
+    cs_keyvalue_render(&(cs_keyvalue_t){.pairs = rows, .count = 3}, s);
 
-        tui_set_color(data_win->win, TUI_COLOR_INFO);
-        mvwprintw(data_win->win, 2, 2, "Current Value: %d", data_value);
-        tui_unset_color(data_win->win, TUI_COLOR_INFO);
+    tui_refresh_window(win);
+    tui_get_char();             // wait for a key
 
-        int inner = data_win->width > 4 ? data_win->width - 4 : 0;
-        int bar_width = inner * data_value / 100;
-        mvwprintw(data_win->win, 4, 2, "[");
-        tui_set_color(data_win->win, TUI_COLOR_SUCCESS);
-        for (int i = 0; i < bar_width; i++) {
-            waddch(data_win->win, '=');
-        }
-        tui_unset_color(data_win->win, TUI_COLOR_SUCCESS);
-        mvwprintw(data_win->win, 4, 3 + bar_width, "]");
-
-        mvwprintw(main_win->win, max_y - 4, 2,
-                  "Press: [+] Increase  [-] Decrease  [r] Reset  [q] Quit");
-
-        tui_refresh_window(data_win);
-        tui_refresh_window(main_win);
-
-        switch (tui_get_char()) {
-            case '+': case '=': if (data_value < 100) data_value += 5; break;
-            case '-': case '_': if (data_value > 0)   data_value -= 5; break;
-            case 'r': case 'R': data_value = 0; break;
-            case 'q': case 'Q': case 27 /* ESC */: running = false; break;
-        }
-    }
-
-    tui_destroy_window(data_win);
-    tui_destroy_window(main_win);
+    cs_surface_free(s);         // borrows the window — does not destroy it
+    tui_destroy_window(win);
     tui_cleanup();
     return APP_SUCCESS;
 }
 #endif
 ```
 
-## 2. Wire it to a command
-
-Register a handler in `src/cli/commands.c` with `.requires_terminal = true`, and guard the TUI call so a non-TUI build still gives a clean message instead of failing to link:
+`cs_surface_move(x, y)` positions the cursor on a curses surface and is a no-op on
+a stream (which flows top to bottom), so a component that avoids `move` works on
+both. Wire the handler to a command with `.requires_terminal = true`, and guard
+the TUI call so a non-TUI build still links:
 
 ```c
-app_error app_cmd_viewer(const app_config_t *config, int argc,
-                         char *const argv[]) {
-    (void)config;
-    (void)argc;
-    (void)argv;
+app_error app_cmd_report(const app_config_t *config, int argc, char *const argv[]) {
+    (void)argc; (void)argv;
 #ifdef ENABLE_TUI
-    return show_data_viewer();
-#else
-    fprintf(stderr, "Error: TUI support not compiled in.\n");
-    fprintf(stderr, "Rebuild with TUI enabled (omit -Denable-tui=false).\n");
-    return APP_ERROR_CONFIG;
+    if (config && /* a TTY is available */ true) {
+        return show_report_tui();
+    }
 #endif
+    return show_report(config);  // fall back to the stream surface
 }
 ```
 
-`.requires_terminal = true` makes help and `myapp opencli` mark the command as interactive. See [adding-a-command.md](adding-a-command.md) for the full registration steps.
+See [adding-a-command.md](adding-a-command.md) for the full registration steps.
 
-## 3. Building blocks
+## 3. Interactive primitives
+
+A surface is for **drawing**. For **input** — menus, prompts, confirmations —
+reach for the `tui_` primitives directly. They manage the event loop; render
+components around them.
 
 ### Dialogs
 
@@ -121,7 +146,10 @@ if (tui_input_dialog("Login", "Enter username:", username, sizeof(username)) == 
 }
 ```
 
-### Progress bar
+### Interactive progress
+
+`cs_progress` renders a bar **once** (great inside other output). For a
+long-running task that owns the screen, use the interactive `tui_progress`:
 
 ```c
 tui_progress_t *progress = tui_progress_create("Processing", 100);
@@ -136,10 +164,10 @@ tui_progress_destroy(progress);
 
 ### Menu
 
-The menu is the one reusable primitive that is also shipped as a library
+The menu is the one reusable primitive also shipped as a library
 (`tui-menu-lib`) and covered by the
-[TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the config
-must outlive the call; the menu copies nothing.
+[TUI menu contract](../docs/CONTRACTS.md#tui-menu-contract). All pointers in the
+config must outlive the call; the menu copies nothing.
 
 ```c
 enum { MENU_OPTION_ONE = 1, MENU_OPTION_TWO, MENU_EXIT };
@@ -172,34 +200,42 @@ if (result.status == TUI_MENU_OK) {
 
 `&` in a label marks the mnemonic key (`&&` is a literal `&`). `result.status` is one of `TUI_MENU_OK`, `TUI_MENU_CANCELLED`, `TUI_MENU_INTERRUPTED`, `TUI_MENU_TOO_SMALL`, `TUI_MENU_INVALID_ARG`, or `TUI_MENU_NO_MEMORY`.
 
-## 4. Colors
+## 4. Theming
 
-Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors. The theme is realized in `tui_init_colors()` (`src/tui/tui.c`) from the shared semantic roles in `src/style/ui_theme.c`, which are seeded from `src/style/design_tokens.c`:
+Components never name a raw color — they style themselves through theme roles, and
+the surface degrades each role for the terminal. Pick or override a theme and pass
+it to the surface (it is copied):
 
 ```c
-tui_set_color(window->win, TUI_COLOR_ERROR);
-mvwprintw(window->win, y, x, "Error: %s", message);
-tui_unset_color(window->win, TUI_COLOR_ERROR);
+cs_theme_t theme = cs_theme_default();
+cs_theme_set_role_spec(&theme, CS_ROLE_ACCENT, "#7dd3fc");   // re-accent
+cs_surface_t *s = cs_surface_stream_new(stdout, config, &theme);
 ```
 
-Available pairs: `TUI_COLOR_DEFAULT`, `HIGHLIGHT`, `ERROR`, `SUCCESS`, `WARNING`, `INFO`, `MENU_NORMAL`, `BORDER`, `TITLE`, `ACCENT`, `DIM`.
+`cs_theme_by_name("mono", &theme)` switches to the grayscale theme; both
+front-ends and every component share the same roles. Full detail in
+[THEMING.md](../docs/THEMING.md).
 
 ## 5. Practices
 
 - **Pair every `tui_init()` with `tui_cleanup()`**, including on every error path, or the terminal is left in raw mode.
-- **Handle a failed init.** `tui_init()` returns an `app_error`; fall back to non-interactive output rather than aborting:
+- **Handle a failed init.** `tui_init()` returns an `app_error`; fall back to the stream surface rather than aborting:
 
   ```c
   if (tui_init() != APP_SUCCESS) {
-      fprintf(stderr, "Terminal does not support the TUI; using plain output.\n");
-      return run_plain_version();
+      return show_report(config);  // plain, escape-free output
   }
   ```
 
 - **Respect interrupts.** Check `tui_interrupted()` in long loops and exit cleanly.
+- **Branch on capability, not on the build.** `cs_surface_caps(s)` reports
+  `unicode`, `color`, `width`, and `interactive`; components already use it (e.g.
+  ASCII glyph fallbacks), so a composed screen degrades without `#ifdef`s.
 - **Test both builds.** Confirm `zig build` (default TUI) and `zig build -Denable-tui=false` both compile and behave. Drive TUI screens with the scenario harness in [TESTING.md](../docs/TESTING.md).
 
 ## See also
 
-- [Public Contracts](../docs/CONTRACTS.md#tui-menu-contract) - the stable menu surface
-- [Architecture Overview](../docs/ARCHITECTURE.md) - where `tui/` sits in the codebase
+- [Components](../docs/COMPONENTS.md) - the catalog and the full surface API
+- [Theming](../docs/THEMING.md) - roles, named themes, and color degradation
+- [Public Contracts](../docs/CONTRACTS.md) - the stable framework and menu surfaces
+- [Architecture Overview](../docs/ARCHITECTURE.md) - where the surface and `tui/` sit

--- a/examples/custom-tui.md
+++ b/examples/custom-tui.md
@@ -174,7 +174,7 @@ if (result.status == TUI_MENU_OK) {
 
 ## 4. Colors
 
-Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors. The theme is defined in `tui_init_colors()` (`src/tui/tui.c`), seeded from `src/style/design_tokens.c`:
+Set a color pair before drawing and unset it after. The pairs are roles, not fixed colors. The theme is realized in `tui_init_colors()` (`src/tui/tui.c`) from the shared semantic roles in `src/style/ui_theme.c`, which are seeded from `src/style/design_tokens.c`:
 
 ```c
 tui_set_color(window->win, TUI_COLOR_ERROR);

--- a/opencli.json
+++ b/opencli.json
@@ -321,10 +321,10 @@
           "FORCE_COLOR": "Force colored output on; set 0 (or false) to force off",
           "CLICOLOR_FORCE": "Set to a non-zero value to force colored output on",
           "CLICOLOR": "Set 0 to disable colored output",
-          "APP_CLI_THEME": "CLI theme: auto (detect), dark, or light",
-          "APP_CLI_COLOR": "Color profile: auto, never, 16, 256, truecolor",
+          "APP_CLI_THEME": "Terminal UI theme for styled CLI and generated TUI: auto, dark, or light",
+          "APP_CLI_COLOR": "Terminal UI color profile: auto, never, 16, 256, truecolor",
           "APP_CLI_OSC11": "Set 0 to disable terminal background detection",
-          "APP_CLI_ACCENT": "Override accent color (#rrggbb or palette index)"
+          "APP_CLI_ACCENT": "Override terminal UI accent (#rrggbb or palette index)"
         }
       },
       {

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://curspan.dev/registry.schema.json",
+  "name": "curspan",
+  "version": "0.1.0",
+  "homepage": "https://github.com/sammyjoyce/curspan",
+  "components": [
+    {
+      "name": "color-math",
+      "title": "Color math",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "RGB type, luminance, and truecolor -> xterm256/ansi16 downsampling. The value substrate under the theme.",
+      "files": ["src/style/color_math.h", "src/style/color_math.c"],
+      "dependencies": [],
+      "since": "0.1.0"
+    },
+    {
+      "name": "design-tokens",
+      "title": "Design tokens",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "The raw sRGB palette (the amber-on-near-black identity). The single source of truth for color values.",
+      "files": ["src/style/design_tokens.h", "src/style/design_tokens.c"],
+      "dependencies": ["color-math"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "text-layout",
+      "title": "Text layout",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "UTF-8 width, column-bounded truncation, and word-wrap with hanging indent. Curses-free and allocation-free.",
+      "files": ["src/ui/text_layout.h", "src/ui/text_layout.c"],
+      "dependencies": [],
+      "since": "0.1.0"
+    },
+    {
+      "name": "theme",
+      "title": "Theme",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "Semantic roles + the public cs_theme API: named themes, per-role overrides, mode resolution, and the shared color resolver.",
+      "files": [
+        "src/style/ui_theme.h",
+        "src/style/ui_theme.c",
+        "src/style/cs_theme.h",
+        "src/style/cs_theme.c"
+      ],
+      "dependencies": ["color-math", "design-tokens"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "glyphs",
+      "title": "Glyphs",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "Capability-aware box/marker glyphs (UTF-8 with ASCII fallbacks). Header-only.",
+      "files": ["src/components/cs_glyphs.h"],
+      "dependencies": [],
+      "since": "0.1.0"
+    },
+    {
+      "name": "surface",
+      "title": "Render surface",
+      "category": "foundation",
+      "surfaces": ["cli", "tui"],
+      "description": "The neutral cs_surface every component draws to, with a stream (SGR) backend and a curses backend behind an ops vtable. Requires the Curspan cli-style and/or tui runtime for the backends it enables.",
+      "files": [
+        "src/surface/surface.h",
+        "src/surface/surface_internal.h",
+        "src/surface/surface.c",
+        "src/surface/surface_curses.c"
+      ],
+      "dependencies": ["theme"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "rule",
+      "title": "Rule",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A horizontal divider, optionally with a centered label.",
+      "files": ["src/components/cs_rule.h", "src/components/cs_rule.c"],
+      "dependencies": ["surface", "theme", "text-layout", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "heading",
+      "title": "Heading",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A styled section heading, optionally underlined with a rule.",
+      "files": ["src/components/cs_heading.h", "src/components/cs_heading.c"],
+      "dependencies": ["surface", "theme", "text-layout", "rule"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "badge",
+      "title": "Badge",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A small inline status label, colored by variant.",
+      "files": ["src/components/cs_badge.h", "src/components/cs_badge.c"],
+      "dependencies": ["surface", "theme", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "note",
+      "title": "Note / callout",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A callout block (info/success/warning/error) with a colored gutter and wrapped body.",
+      "files": ["src/components/cs_note.h", "src/components/cs_note.c"],
+      "dependencies": ["surface", "theme", "text-layout", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "keyvalue",
+      "title": "Key/value list",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "An aligned list of key -> value rows.",
+      "files": ["src/components/cs_keyvalue.h", "src/components/cs_keyvalue.c"],
+      "dependencies": ["surface", "theme", "text-layout"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "list",
+      "title": "List",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A bulleted or numbered list with word-wrap and hanging indent.",
+      "files": ["src/components/cs_list.h", "src/components/cs_list.c"],
+      "dependencies": ["surface", "theme", "text-layout", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "table",
+      "title": "Table",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A columnar table with alignment and width budgeting.",
+      "files": ["src/components/cs_table.h", "src/components/cs_table.c"],
+      "dependencies": ["surface", "theme", "text-layout", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "progress",
+      "title": "Progress bar",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A one-shot, surface-agnostic progress bar.",
+      "files": ["src/components/cs_progress.h", "src/components/cs_progress.c"],
+      "dependencies": ["surface", "theme", "text-layout", "glyphs"],
+      "since": "0.1.0"
+    },
+    {
+      "name": "spinner",
+      "title": "Spinner",
+      "category": "component",
+      "surfaces": ["cli", "tui"],
+      "description": "A frame-based activity indicator (braille or ASCII line).",
+      "files": ["src/components/cs_spinner.h", "src/components/cs_spinner.c"],
+      "dependencies": ["surface", "theme"],
+      "since": "0.1.0"
+    }
+  ]
+}

--- a/src/cli/opencli_contract.c
+++ b/src/cli/opencli_contract.c
@@ -30,8 +30,8 @@ static const app_opencli_metadata_field_t environment_fields[] = {
      .description = "Set to a non-zero value to force colored output on"},
     {.name = "CLICOLOR", .description = "Set 0 to disable colored output"},
     {.name = "APP_CLI_THEME",
-     .description =
-         "Terminal UI theme for styled CLI and generated TUI: auto, dark, or light"},
+     .description = "Terminal UI theme for styled CLI and generated TUI: auto, "
+                    "dark, or light"},
     {.name = "APP_CLI_COLOR",
      .description =
          "Terminal UI color profile: auto, never, 16, 256, truecolor"},

--- a/src/cli/opencli_contract.c
+++ b/src/cli/opencli_contract.c
@@ -30,13 +30,15 @@ static const app_opencli_metadata_field_t environment_fields[] = {
      .description = "Set to a non-zero value to force colored output on"},
     {.name = "CLICOLOR", .description = "Set 0 to disable colored output"},
     {.name = "APP_CLI_THEME",
-     .description = "CLI theme: auto (detect), dark, or light"},
+     .description =
+         "Terminal UI theme for styled CLI and generated TUI: auto, dark, or light"},
     {.name = "APP_CLI_COLOR",
-     .description = "Color profile: auto, never, 16, 256, truecolor"},
+     .description =
+         "Terminal UI color profile: auto, never, 16, 256, truecolor"},
     {.name = "APP_CLI_OSC11",
      .description = "Set 0 to disable terminal background detection"},
     {.name = "APP_CLI_ACCENT",
-     .description = "Override accent color (#rrggbb or palette index)"},
+     .description = "Override terminal UI accent (#rrggbb or palette index)"},
 };
 
 static const app_opencli_metadata_field_t configuration_fields[] = {

--- a/src/cli/style/cli_layout.c
+++ b/src/cli/style/cli_layout.c
@@ -37,8 +37,11 @@ bool app_cli_render_ctx_init(app_cli_render_ctx_t *ctx,
   if (ctx->styled) {
     app_cli_color_scheme_t scheme = *app_cli_theme_default_scheme();
     app_cli_theme_apply_env_overrides(&scheme);
-    app_cli_styles_compile(&ctx->styles, &scheme, cs_theme_mode_resolve(),
-                           ctx->term.profile, ctx->term.color_count);
+    const app_cli_theme_mode_id mode = cs_theme_mode_resolve() == CS_MODE_LIGHT
+                                           ? APP_CLI_THEME_MODE_LIGHT
+                                           : APP_CLI_THEME_MODE_DARK;
+    app_cli_styles_compile(&ctx->styles, &scheme, mode, ctx->term.profile,
+                           ctx->term.color_count);
   }
   return ctx->styled;
 }

--- a/src/cli/style/cli_layout.c
+++ b/src/cli/style/cli_layout.c
@@ -8,34 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../../style/cs_theme.h"
 #include "../../ui/text_layout.h"
-
-// Resolve light/dark mode. APP_CLI_THEME (or the APP_CLI_TEST_THEME test hook)
-// can force "dark"/"light"; "auto" or unset triggers OSC 11 background
-// detection (which probes the controlling /dev/tty, not the render stream, and
-// skips when there is no usable controlling terminal or when disabled),
-// defaulting to dark when detection is unavailable.
-static app_cli_theme_mode_id app_cli_resolve_mode(const app_cli_term_t *term,
-                                                  const app_config_t *config) {
-  const char *theme = getenv("APP_CLI_TEST_THEME");
-  if (!theme) {
-    theme = getenv("APP_CLI_THEME");
-  }
-  if (theme) {
-    if (strcmp(theme, "light") == 0) {
-      return APP_CLI_THEME_MODE_LIGHT;
-    }
-    if (strcmp(theme, "dark") == 0) {
-      return APP_CLI_THEME_MODE_DARK;
-    }
-    // Any other value (e.g. "auto") falls through to detection.
-  }
-
-  if (app_cli_term_detect_background(term, config) == APP_CLI_BG_LIGHT) {
-    return APP_CLI_THEME_MODE_LIGHT;
-  }
-  return APP_CLI_THEME_MODE_DARK;
-}
 
 bool app_cli_render_ctx_init(app_cli_render_ctx_t *ctx,
                              const app_config_t *config, FILE *stream,
@@ -63,8 +37,7 @@ bool app_cli_render_ctx_init(app_cli_render_ctx_t *ctx,
   if (ctx->styled) {
     app_cli_color_scheme_t scheme = *app_cli_theme_default_scheme();
     app_cli_theme_apply_env_overrides(&scheme);
-    app_cli_styles_compile(&ctx->styles, &scheme,
-                           app_cli_resolve_mode(&ctx->term, config),
+    app_cli_styles_compile(&ctx->styles, &scheme, cs_theme_mode_resolve(),
                            ctx->term.profile, ctx->term.color_count);
   }
   return ctx->styled;

--- a/src/cli/style/cli_theme.c
+++ b/src/cli/style/cli_theme.c
@@ -5,39 +5,53 @@
 
 #include "cli_theme.h"
 
-#include <ctype.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../style/design_tokens.h"
-
-// RGB token with a semantic ANSI-16 fallback hint.
-#define RGBH(rr, gg, bb, hint)                  \
-  ((app_cli_color_t){.kind = APP_CLI_COLOR_RGB, \
-                     .rgb = {(rr), (gg), (bb)}, \
-                     .has_ansi16_hint = true,   \
-                     .ansi16_hint = (hint)})
-
-#define ADAPT(d, l) ((app_cli_adaptive_color_t){.dark = (d), .light = (l)})
+#include "../../style/ui_theme.h"
 
 // ANSI-16 indices used as hints: 1 red, 2 green, 3 yellow, 7 white,
 // 8 bright-black (gray), 11 bright-yellow, 15 bright-white.
 
-// Build an RGB token from a shared-palette triple plus an ANSI-16 hint.
-static app_cli_color_t app_cli_rgbh(app_rgb_t rgb, uint8_t hint) {
-  return (app_cli_color_t){.kind = APP_CLI_COLOR_RGB,
-                           .rgb = rgb,
-                           .has_ansi16_hint = true,
-                           .ansi16_hint = hint};
+static app_cli_color_kind_id app_cli_color_kind_from_ui(
+    app_ui_color_kind_id kind) {
+  switch (kind) {
+  case APP_UI_COLOR_RGB:
+    return APP_CLI_COLOR_RGB;
+  case APP_UI_COLOR_ANSI256:
+    return APP_CLI_COLOR_ANSI256;
+  case APP_UI_COLOR_ANSI16:
+    return APP_CLI_COLOR_ANSI16;
+  case APP_UI_COLOR_DEFAULT:
+    return APP_CLI_COLOR_DEFAULT;
+  case APP_UI_COLOR_UNSET:
+  default:
+    return APP_CLI_COLOR_UNSET;
+  }
 }
 
-// Default scheme: amber-on-near-black (dark) with a readable light variant.
-// The dark tokens are derived at runtime from the shared design palette
-// (APP_DESIGN_PALETTE in design_tokens.h) so the CLI and TUI stay one source of
-// truth - no hand-maintained "keep in sync" literals. ERROR_HEADER_FG has no
-// palette field and keeps its own literal. The light variants stay as literals.
+static app_cli_color_t app_cli_color_from_ui(app_ui_color_t color) {
+  return (app_cli_color_t){.kind = app_cli_color_kind_from_ui(color.kind),
+                           .rgb = color.rgb,
+                           .ansi256 = color.ansi256,
+                           .ansi16 = color.ansi16,
+                           .has_ansi16_hint = color.has_ansi16_hint,
+                           .ansi16_hint = color.ansi16_hint};
+}
+
+static app_cli_adaptive_color_t app_cli_token_from_role(
+    const app_ui_color_scheme_t *scheme, app_ui_role_id role) {
+  return (app_cli_adaptive_color_t){
+      .dark = app_cli_color_from_ui(scheme->roles[role].dark),
+      .light = app_cli_color_from_ui(scheme->roles[role].light),
+  };
+}
+
+// Default scheme: CLI tokens are an adapter over the shared semantic UI roles
+// in src/style/ui_theme.c. The CLI keeps Fang-style token names for renderer
+// readability, while the actual color meaning is shared with the ncurses TUI.
 static app_cli_color_scheme_t APP_CLI_DEFAULT_SCHEME;
 static bool APP_CLI_DEFAULT_SCHEME_READY;
 
@@ -45,44 +59,45 @@ static void app_cli_theme_init_default_scheme(void) {
   if (APP_CLI_DEFAULT_SCHEME_READY) {
     return;
   }
-  const app_design_palette_t *p = &APP_DESIGN_PALETTE;
+
+  const app_ui_color_scheme_t *ui = app_ui_theme_default_scheme();
   APP_CLI_DEFAULT_SCHEME = (app_cli_color_scheme_t){
       .tokens =
           {
               [APP_CLI_COLOR_TOKEN_BASE] =
-                  ADAPT(app_cli_rgbh(p->fg, 7), RGBH(60, 56, 54, 0)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_TEXT),
               [APP_CLI_COLOR_TOKEN_TITLE] =
-                  ADAPT(app_cli_rgbh(p->amber, 11), RGBH(135, 94, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_TITLE),
               [APP_CLI_COLOR_TOKEN_DESCRIPTION] =
-                  ADAPT(app_cli_rgbh(p->fg, 7), RGBH(60, 56, 54, 0)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_DESCRIPTION),
               [APP_CLI_COLOR_TOKEN_CODEBLOCK] =
-                  ADAPT(app_cli_rgbh(p->amber, 3), RGBH(110, 78, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_CODE),
               [APP_CLI_COLOR_TOKEN_PROGRAM] =
-                  ADAPT(app_cli_rgbh(p->amber, 11), RGBH(135, 94, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_PROGRAM),
               [APP_CLI_COLOR_TOKEN_DIMMED_ARGUMENT] =
-                  ADAPT(app_cli_rgbh(p->muted, 8), RGBH(120, 112, 105, 8)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_MUTED),
               [APP_CLI_COLOR_TOKEN_COMMENT] =
-                  ADAPT(app_cli_rgbh(p->muted, 8), RGBH(120, 112, 105, 8)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_COMMENT),
               [APP_CLI_COLOR_TOKEN_FLAG] =
-                  ADAPT(app_cli_rgbh(p->amber, 11), RGBH(135, 94, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_FLAG),
               [APP_CLI_COLOR_TOKEN_FLAG_DEFAULT] =
-                  ADAPT(app_cli_rgbh(p->muted, 8), RGBH(120, 112, 105, 8)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_FLAG_DEFAULT),
               [APP_CLI_COLOR_TOKEN_COMMAND] =
-                  ADAPT(app_cli_rgbh(p->amber, 11), RGBH(135, 94, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_COMMAND),
               [APP_CLI_COLOR_TOKEN_QUOTED_STRING] =
-                  ADAPT(app_cli_rgbh(p->green, 2), RGBH(75, 115, 55, 2)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_QUOTED_STRING),
               [APP_CLI_COLOR_TOKEN_ARGUMENT] =
-                  ADAPT(app_cli_rgbh(p->fg, 7), RGBH(60, 56, 54, 0)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_ARGUMENT),
               [APP_CLI_COLOR_TOKEN_HELP] =
-                  ADAPT(app_cli_rgbh(p->amber, 11), RGBH(135, 94, 20, 3)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_HELP),
               [APP_CLI_COLOR_TOKEN_DASH] =
-                  ADAPT(app_cli_rgbh(p->muted, 8), RGBH(120, 112, 105, 8)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_DASH),
               [APP_CLI_COLOR_TOKEN_ERROR_HEADER_FG] =
-                  ADAPT(RGBH(255, 245, 235, 15), RGBH(255, 255, 255, 15)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_ERROR_HEADER_FG),
               [APP_CLI_COLOR_TOKEN_ERROR_HEADER_BG] =
-                  ADAPT(app_cli_rgbh(p->red, 1), RGBH(180, 55, 50, 1)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_ERROR_HEADER_BG),
               [APP_CLI_COLOR_TOKEN_ERROR_DETAILS] =
-                  ADAPT(app_cli_rgbh(p->red, 1), RGBH(145, 40, 35, 1)),
+                  app_cli_token_from_role(ui, APP_UI_ROLE_ERROR_DETAILS),
           },
   };
   APP_CLI_DEFAULT_SCHEME_READY = true;
@@ -110,56 +125,49 @@ static app_cli_attr_mask_t app_cli_token_attrs(app_cli_color_token_id token) {
   }
 }
 
+// CLI tokens and the shared UI roles use structurally identical color types;
+// resolution is the one shared degradation policy in style/ui_theme.c. Convert
+// to the UI color, delegate, and map the result back so the stream surface, the
+// curses surface, and these help/error styles all degrade identically.
+static app_ui_color_kind_id app_ui_color_kind_from_cli(
+    app_cli_color_kind_id kind) {
+  switch (kind) {
+  case APP_CLI_COLOR_RGB:
+    return APP_UI_COLOR_RGB;
+  case APP_CLI_COLOR_ANSI256:
+    return APP_UI_COLOR_ANSI256;
+  case APP_CLI_COLOR_ANSI16:
+    return APP_UI_COLOR_ANSI16;
+  case APP_CLI_COLOR_DEFAULT:
+    return APP_UI_COLOR_DEFAULT;
+  case APP_CLI_COLOR_UNSET:
+  default:
+    return APP_UI_COLOR_UNSET;
+  }
+}
+
 static app_cli_resolved_color_t app_cli_color_resolve(
     app_cli_color_t color, app_cli_color_profile_id profile, int color_count) {
-  switch (color.kind) {
-  case APP_CLI_COLOR_UNSET:
-    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_NONE};
-  case APP_CLI_COLOR_DEFAULT:
-    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_DEFAULT};
-  default:
-    break;
-  }
-
-  if (profile == APP_CLI_COLOR_PROFILE_TRUECOLOR &&
-      color.kind == APP_CLI_COLOR_RGB) {
+  app_ui_color_t ui = {.kind = app_ui_color_kind_from_cli(color.kind),
+                       .rgb = color.rgb,
+                       .ansi256 = color.ansi256,
+                       .ansi16 = color.ansi16,
+                       .has_ansi16_hint = color.has_ansi16_hint,
+                       .ansi16_hint = color.ansi16_hint};
+  app_ui_resolved_color_t r = app_ui_color_resolve(ui, profile, color_count);
+  switch (r.kind) {
+  case APP_UI_RESOLVED_INDEXED:
+    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_INDEXED,
+                                      .index = r.index};
+  case APP_UI_RESOLVED_RGB:
     return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_RGB,
-                                      .rgb = color.rgb};
+                                      .rgb = r.rgb};
+  case APP_UI_RESOLVED_DEFAULT:
+    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_DEFAULT};
+  case APP_UI_RESOLVED_NONE:
+  default:
+    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_NONE};
   }
-
-  if (profile == APP_CLI_COLOR_PROFILE_ANSI256) {
-    uint8_t index;
-    if (color.kind == APP_CLI_COLOR_ANSI256) {
-      index = color.ansi256;
-    } else if (color.kind == APP_CLI_COLOR_ANSI16) {
-      index = color.ansi16;
-    } else {
-      index = app_color_rgb_to_xterm256(color.rgb);
-    }
-    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_INDEXED,
-                                      .index = index};
-  }
-
-  if (profile == APP_CLI_COLOR_PROFILE_ANSI16) {
-    uint8_t index;
-    if (color.kind == APP_CLI_COLOR_ANSI16) {
-      index = color.ansi16;
-    } else if (color.has_ansi16_hint) {
-      index = color.ansi16_hint;
-    } else if (color.kind == APP_CLI_COLOR_ANSI256) {
-      index = color.ansi256 < 16 ? color.ansi256 : 7;
-    } else {
-      index = app_color_rgb_to_ansi16(color.rgb);
-    }
-    // Fold bright colors onto the base 8 for true 8-color terminals.
-    if (color_count > 0 && color_count < 16 && index >= 8) {
-      index = (uint8_t)(index - 8);
-    }
-    return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_INDEXED,
-                                      .index = index};
-  }
-
-  return (app_cli_resolved_color_t){.kind = APP_CLI_RESOLVED_COLOR_NONE};
 }
 
 static app_cli_color_t app_cli_pick(const app_cli_adaptive_color_t *adaptive,
@@ -205,66 +213,15 @@ const app_cli_style_t *app_cli_style(const app_cli_styles_t *styles,
 }
 
 bool app_cli_color_parse(const char *spec, app_cli_color_t *out) {
-  if (!spec || !out || !spec[0]) {
+  if (!out) {
     return false;
   }
-  const char *s = (spec[0] == '#') ? spec + 1 : spec;
-  size_t len = strlen(s);
-
-  // Hex RGB: exactly 6 hex digits, optionally '#'-prefixed.
-  bool all_hex = len == 6;
-  for (size_t i = 0; all_hex && i < len; i++) {
-    if (!isxdigit((unsigned char)s[i])) {
-      all_hex = false;
-    }
+  app_ui_color_t parsed;
+  if (!app_ui_color_parse(spec, &parsed)) {
+    return false;
   }
-  if (all_hex) {
-    // Parse each two-digit channel through the shared hex reader so #RRGGBB and
-    // OSC 11 share one code path (a two-digit field has max 0xff, so the scale
-    // is the identity here).
-    const char *p = s;
-    uint8_t ch[3];
-    for (int i = 0; i < 3; i++) {
-      unsigned value;
-      unsigned field_max;
-      if (!app_color_read_hex(&p, p + 2, 2, &value, &field_max)) {
-        return false;
-      }
-      ch[i] = app_color_channel_to_u8(value, field_max);
-    }
-    app_rgb_t rgb = {ch[0], ch[1], ch[2]};
-    *out = (app_cli_color_t){.kind = APP_CLI_COLOR_RGB,
-                             .rgb = rgb,
-                             .has_ansi16_hint = true,
-                             .ansi16_hint = app_color_rgb_to_ansi16(rgb)};
-    return true;
-  }
-
-  // Decimal ANSI palette index (not valid with a '#' prefix).
-  if (spec[0] != '#' && len > 0) {
-    bool all_digits = true;
-    for (size_t i = 0; i < len; i++) {
-      if (!isdigit((unsigned char)s[i])) {
-        all_digits = false;
-        break;
-      }
-    }
-    if (all_digits) {
-      long v = strtol(s, NULL, 10);
-      if (v < 0 || v > 255) {
-        return false;
-      }
-      if (v < 16) {
-        *out = (app_cli_color_t){.kind = APP_CLI_COLOR_ANSI16,
-                                 .ansi16 = (uint8_t)v};
-      } else {
-        *out = (app_cli_color_t){.kind = APP_CLI_COLOR_ANSI256,
-                                 .ansi256 = (uint8_t)v};
-      }
-      return true;
-    }
-  }
-  return false;
+  *out = app_cli_color_from_ui(parsed);
+  return true;
 }
 
 void app_cli_theme_apply_env_overrides(app_cli_color_scheme_t *scheme) {

--- a/src/cli/style/cli_theme.h
+++ b/src/cli/style/cli_theme.h
@@ -8,10 +8,9 @@
  *   2. app_cli_styles_t        — those tokens resolved to indexed/RGB colors +
  *      attributes for the detected terminal.
  *
- * The default scheme's dark tokens are derived at runtime from the shared
- * design palette (design_tokens.h / APP_DESIGN_PALETTE) so the CLI matches the
- * TUI from a single source of truth - no hand-maintained duplicate literals.
- * The scheme degrades to ANSI-256/ANSI-16 per the detected profile (each token
+ * The default scheme's tokens are projected from the shared semantic UI theme
+ * (style/ui_theme.h) so the CLI and TUI share role meaning instead of
+ * hand-maintained duplicate palettes. The scheme degrades to ANSI-256/ANSI-16 per the detected profile (each token
  * carries a semantic ANSI-16 fallback hint), and callers may apply per-token
  * overrides.
  */

--- a/src/cli/style/cli_theme.h
+++ b/src/cli/style/cli_theme.h
@@ -10,9 +10,9 @@
  *
  * The default scheme's tokens are projected from the shared semantic UI theme
  * (style/ui_theme.h) so the CLI and TUI share role meaning instead of
- * hand-maintained duplicate palettes. The scheme degrades to ANSI-256/ANSI-16 per the detected profile (each token
- * carries a semantic ANSI-16 fallback hint), and callers may apply per-token
- * overrides.
+ * hand-maintained duplicate palettes. The scheme degrades to ANSI-256/ANSI-16
+ * per the detected profile (each token carries a semantic ANSI-16 fallback
+ * hint), and callers may apply per-token overrides.
  */
 
 #pragma once

--- a/src/components/components.h
+++ b/src/components/components.h
@@ -1,0 +1,19 @@
+/*
+ * components.h — the Curspan component catalog in one include.
+ *
+ * Pull in the whole catalog, or include individual cs_<name>.h headers for a
+ * leaner build. Every component renders through a cs_surface and styles itself
+ * through theme roles, so the same call works on a CLI stream or a TUI window.
+ */
+
+#pragma once
+
+#include "cs_badge.h"
+#include "cs_heading.h"
+#include "cs_keyvalue.h"
+#include "cs_list.h"
+#include "cs_note.h"
+#include "cs_progress.h"
+#include "cs_rule.h"
+#include "cs_spinner.h"
+#include "cs_table.h"

--- a/src/components/cs_badge.c
+++ b/src/components/cs_badge.c
@@ -1,0 +1,58 @@
+/*
+ * cs_badge — inline status label. See cs_badge.h.
+ */
+
+#include "cs_badge.h"
+
+#include "cs_glyphs.h"
+
+static cs_role_t cs_badge_role(cs_badge_variant_t variant) {
+  switch (variant) {
+  case CS_BADGE_INFO:
+    return CS_ROLE_INFO;
+  case CS_BADGE_SUCCESS:
+    return CS_ROLE_SUCCESS;
+  case CS_BADGE_WARNING:
+    return CS_ROLE_WARNING;
+  case CS_BADGE_ERROR:
+    return CS_ROLE_ERROR;
+  case CS_BADGE_NEUTRAL:
+  default:
+    return CS_ROLE_MUTED;
+  }
+}
+
+static const char *cs_badge_marker(cs_badge_variant_t variant, bool unicode) {
+  switch (variant) {
+  case CS_BADGE_INFO:
+    return cs_glyph_info(unicode);
+  case CS_BADGE_SUCCESS:
+    return cs_glyph_check(unicode);
+  case CS_BADGE_WARNING:
+    return cs_glyph_warning(unicode);
+  case CS_BADGE_ERROR:
+    return cs_glyph_cross(unicode);
+  case CS_BADGE_NEUTRAL:
+  default:
+    return cs_glyph_bullet(unicode);
+  }
+}
+
+void cs_badge_render(const cs_badge_t *badge, cs_surface_t *s) {
+  if (!badge || !s || !badge->text) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  cs_role_t role = cs_badge_role(badge->variant);
+
+  cs_surface_set_role(s, role);
+  cs_surface_set_attr(s, CS_ATTR_BOLD);
+  cs_surface_write(s, "[");
+  if (!badge->no_marker) {
+    cs_surface_write(s, cs_badge_marker(badge->variant, caps.unicode));
+    cs_surface_write(s, " ");
+  }
+  cs_surface_write(s, badge->text);
+  cs_surface_write(s, "]");
+  cs_surface_reset(s);
+}

--- a/src/components/cs_badge.h
+++ b/src/components/cs_badge.h
@@ -1,0 +1,31 @@
+/*
+ * cs_badge — a small inline status label, colored by variant.
+ *
+ *   cs_badge_render(&(cs_badge_t){.text = "OK", .variant = CS_BADGE_SUCCESS},
+ * s);
+ *
+ * Renders inline (no trailing newline) so badges can sit next to other text,
+ * e.g. a doctor check row or a table cell. A leading marker glyph (✓ ⚠ ✗ ℹ •)
+ * reinforces the variant; it degrades to ASCII and the label stays colored even
+ * when glyphs are off.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef enum cs_badge_variant {
+  CS_BADGE_NEUTRAL = 0,
+  CS_BADGE_INFO,
+  CS_BADGE_SUCCESS,
+  CS_BADGE_WARNING,
+  CS_BADGE_ERROR,
+} cs_badge_variant_t;
+
+typedef struct cs_badge {
+  const char *text;
+  cs_badge_variant_t variant;
+  bool no_marker;  // omit the leading glyph, render just the bracketed label
+} cs_badge_t;
+
+void cs_badge_render(const cs_badge_t *badge, cs_surface_t *s);

--- a/src/components/cs_glyphs.h
+++ b/src/components/cs_glyphs.h
@@ -1,0 +1,46 @@
+/*
+ * cs_glyphs — capability-aware glyph picks shared by components.
+ *
+ * Header-only: every glyph getter takes the surface's `unicode` capability and
+ * returns a UTF-8 box/marker glyph or a plain-ASCII fallback, so components
+ * draw the same shapes on a UTF-8 terminal and a legacy/ASCII one without each
+ * re-deriving the fallbacks.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+static inline const char *cs_glyph_hline(bool unicode) {
+  return unicode ? "\xe2\x94\x80" : "-";  // ─
+}
+static inline const char *cs_glyph_vline(bool unicode) {
+  return unicode ? "\xe2\x94\x82" : "|";  // │
+}
+static inline const char *cs_glyph_gutter(bool unicode) {
+  return unicode ? "\xe2\x94\x83" : "|";  // ┃ (heavy vertical)
+}
+static inline const char *cs_glyph_bullet(bool unicode) {
+  return unicode ? "\xe2\x80\xa2" : "*";  // •
+}
+static inline const char *cs_glyph_check(bool unicode) {
+  return unicode ? "\xe2\x9c\x93" : "+";  // ✓
+}
+static inline const char *cs_glyph_cross(bool unicode) {
+  return unicode ? "\xe2\x9c\x97" : "x";  // ✗
+}
+static inline const char *cs_glyph_warning(bool unicode) {
+  return unicode ? "\xe2\x9a\xa0" : "!";  // ⚠
+}
+static inline const char *cs_glyph_info(bool unicode) {
+  return unicode ? "\xe2\x84\xb9" : "i";  // ℹ
+}
+static inline const char *cs_glyph_arrow(bool unicode) {
+  return unicode ? "\xe2\x9d\xaf" : ">";  // ❯
+}
+static inline const char *cs_glyph_bar_full(bool unicode) {
+  return unicode ? "\xe2\x96\x88" : "#";  // █
+}
+static inline const char *cs_glyph_bar_empty(bool unicode) {
+  return unicode ? "\xe2\x96\x91" : ".";  // ░
+}

--- a/src/components/cs_heading.c
+++ b/src/components/cs_heading.c
@@ -44,7 +44,9 @@ void cs_heading_render(const cs_heading_t *heading, cs_surface_t *s) {
   if (heading->underline) {
     int cols = app_text_width_utf8(heading->text);
     if (cols > 0) {
-      cs_rule_render(&(cs_rule_t){.width = (size_t)cols, .role = role}, s);
+      cs_rule_render(
+          &(cs_rule_t){.width = (size_t)cols, .role = role, .role_set = true},
+          s);
     }
   }
 }

--- a/src/components/cs_heading.c
+++ b/src/components/cs_heading.c
@@ -14,17 +14,26 @@ void cs_heading_render(const cs_heading_t *heading, cs_surface_t *s) {
   if (!heading || !s || !heading->text) {
     return;
   }
-  cs_role_t role = heading->role ? heading->role : CS_ROLE_TITLE;
+  cs_role_t role =
+      cs_role_or_default(heading->role, heading->role_set, CS_ROLE_TITLE);
 
   cs_surface_set_role(s, role);
   cs_surface_set_attr(s, CS_ATTR_BOLD);
   if (heading->uppercase) {
     // Upper-case ASCII bytes only; multibyte UTF-8 sequences (bytes >= 0x80)
     // pass through untouched so this never corrupts a code point.
+    char buf[256];
+    size_t len = 0;
     for (const char *p = heading->text; *p; p++) {
       unsigned char c = (unsigned char)*p;
-      char up = (c < 0x80) ? (char)toupper(c) : *p;
-      cs_surface_write_n(s, &up, 1);
+      buf[len++] = (c < 0x80) ? (char)toupper(c) : *p;
+      if (len == sizeof(buf)) {
+        cs_surface_write_n(s, buf, len);
+        len = 0;
+      }
+    }
+    if (len > 0) {
+      cs_surface_write_n(s, buf, len);
     }
   } else {
     cs_surface_write(s, heading->text);

--- a/src/components/cs_heading.c
+++ b/src/components/cs_heading.c
@@ -1,0 +1,41 @@
+/*
+ * cs_heading — styled section heading. See cs_heading.h.
+ */
+
+#include "cs_heading.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#include "../ui/text_layout.h"
+#include "cs_rule.h"
+
+void cs_heading_render(const cs_heading_t *heading, cs_surface_t *s) {
+  if (!heading || !s || !heading->text) {
+    return;
+  }
+  cs_role_t role = heading->role ? heading->role : CS_ROLE_TITLE;
+
+  cs_surface_set_role(s, role);
+  cs_surface_set_attr(s, CS_ATTR_BOLD);
+  if (heading->uppercase) {
+    // Upper-case ASCII bytes only; multibyte UTF-8 sequences (bytes >= 0x80)
+    // pass through untouched so this never corrupts a code point.
+    for (const char *p = heading->text; *p; p++) {
+      unsigned char c = (unsigned char)*p;
+      char up = (c < 0x80) ? (char)toupper(c) : *p;
+      cs_surface_write_n(s, &up, 1);
+    }
+  } else {
+    cs_surface_write(s, heading->text);
+  }
+  cs_surface_reset(s);
+  cs_surface_newline(s);
+
+  if (heading->underline) {
+    int cols = app_text_width_utf8(heading->text);
+    if (cols > 0) {
+      cs_rule_render(&(cs_rule_t){.width = (size_t)cols, .role = role}, s);
+    }
+  }
+}

--- a/src/components/cs_heading.h
+++ b/src/components/cs_heading.h
@@ -1,0 +1,22 @@
+/*
+ * cs_heading — a styled section heading, optionally underlined with a rule.
+ *
+ *   cs_heading_render(&(cs_heading_t){.text = "Usage", .underline = true}, s);
+ *
+ * Emits the heading line (and the underline, if requested) with trailing
+ * newlines. The CLI help renderer's "USAGE"/"COMMANDS" section titles are the
+ * same idea; this is the reusable, theme-aware form.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef struct cs_heading {
+  const char *text;
+  cs_role_t role;  // heading color role (0 => CS_ROLE_TITLE)
+  bool uppercase;  // upper-case the text (ASCII letters only)
+  bool underline;  // draw a rule beneath, as wide as the heading
+} cs_heading_t;
+
+void cs_heading_render(const cs_heading_t *heading, cs_surface_t *s);

--- a/src/components/cs_heading.h
+++ b/src/components/cs_heading.h
@@ -14,7 +14,8 @@
 
 typedef struct cs_heading {
   const char *text;
-  cs_role_t role;  // heading color role (0 => CS_ROLE_TITLE)
+  cs_role_t role;  // heading color role (default: CS_ROLE_TITLE)
+  bool role_set;   // true when `role` is intentional (allows CS_ROLE_TEXT)
   bool uppercase;  // upper-case the text (ASCII letters only)
   bool underline;  // draw a rule beneath, as wide as the heading
 } cs_heading_t;

--- a/src/components/cs_keyvalue.c
+++ b/src/components/cs_keyvalue.c
@@ -1,0 +1,45 @@
+/*
+ * cs_keyvalue — aligned key/value rows. See cs_keyvalue.h.
+ */
+
+#include "cs_keyvalue.h"
+
+#include "../ui/text_layout.h"
+
+void cs_keyvalue_render(const cs_keyvalue_t *kv, cs_surface_t *s) {
+  if (!kv || !s || !kv->pairs || kv->count == 0) {
+    return;
+  }
+  cs_role_t key_role = kv->key_role ? kv->key_role : CS_ROLE_MUTED;
+  cs_role_t value_role = kv->value_role ? kv->value_role : CS_ROLE_TEXT;
+  const char *separator = kv->separator ? kv->separator : "  ";
+
+  int key_width = 0;
+  for (size_t i = 0; i < kv->count; i++) {
+    const char *key = kv->pairs[i].key ? kv->pairs[i].key : "";
+    int w = app_text_width_utf8(key);
+    if (w > key_width) {
+      key_width = w;
+    }
+  }
+
+  for (size_t i = 0; i < kv->count; i++) {
+    const char *key = kv->pairs[i].key ? kv->pairs[i].key : "";
+    const char *value = kv->pairs[i].value ? kv->pairs[i].value : "";
+
+    cs_surface_set_role(s, key_role);
+    cs_surface_write(s, key);
+    cs_surface_reset(s);
+    int pad = key_width - app_text_width_utf8(key);
+    for (int p = 0; p < pad; p++) {
+      cs_surface_write(s, " ");
+    }
+
+    cs_surface_write(s, separator);
+
+    cs_surface_set_role(s, value_role);
+    cs_surface_write(s, value);
+    cs_surface_reset(s);
+    cs_surface_newline(s);
+  }
+}

--- a/src/components/cs_keyvalue.c
+++ b/src/components/cs_keyvalue.c
@@ -10,8 +10,10 @@ void cs_keyvalue_render(const cs_keyvalue_t *kv, cs_surface_t *s) {
   if (!kv || !s || !kv->pairs || kv->count == 0) {
     return;
   }
-  cs_role_t key_role = kv->key_role ? kv->key_role : CS_ROLE_MUTED;
-  cs_role_t value_role = kv->value_role ? kv->value_role : CS_ROLE_TEXT;
+  cs_role_t key_role =
+      cs_role_or_default(kv->key_role, kv->key_role_set, CS_ROLE_MUTED);
+  cs_role_t value_role =
+      cs_role_or_default(kv->value_role, kv->value_role_set, CS_ROLE_TEXT);
   const char *separator = kv->separator ? kv->separator : "  ";
 
   int key_width = 0;
@@ -31,8 +33,8 @@ void cs_keyvalue_render(const cs_keyvalue_t *kv, cs_surface_t *s) {
     cs_surface_write(s, key);
     cs_surface_reset(s);
     int pad = key_width - app_text_width_utf8(key);
-    for (int p = 0; p < pad; p++) {
-      cs_surface_write(s, " ");
+    if (pad > 0) {
+      cs_surface_repeat(s, " ", (size_t)pad);
     }
 
     cs_surface_write(s, separator);

--- a/src/components/cs_keyvalue.h
+++ b/src/components/cs_keyvalue.h
@@ -25,8 +25,10 @@ typedef struct cs_keyvalue_pair {
 typedef struct cs_keyvalue {
   const cs_keyvalue_pair_t *pairs;
   size_t count;
-  cs_role_t key_role;     // 0 => CS_ROLE_MUTED
-  cs_role_t value_role;   // 0 => CS_ROLE_TEXT
+  cs_role_t key_role;     // default: CS_ROLE_MUTED
+  cs_role_t value_role;   // default: CS_ROLE_TEXT
+  bool key_role_set;      // true when `key_role` is intentional
+  bool value_role_set;    // true when `value_role` is intentional
   const char *separator;  // between key column and value (NULL => "  ")
 } cs_keyvalue_t;
 

--- a/src/components/cs_keyvalue.h
+++ b/src/components/cs_keyvalue.h
@@ -1,0 +1,33 @@
+/*
+ * cs_keyvalue — an aligned list of key → value rows.
+ *
+ *   cs_keyvalue_render(&(cs_keyvalue_t){
+ *       .pairs = (cs_keyvalue_pair_t[]){
+ *           {"Application", "myapp"},
+ *           {"Version",     "0.1.0"},
+ *       },
+ *       .count = 2,
+ *   }, s);
+ *
+ * Keys are right-padded to the widest key so values line up. One row per pair,
+ * each with a trailing newline. The `info` command's output is this shape.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef struct cs_keyvalue_pair {
+  const char *key;
+  const char *value;
+} cs_keyvalue_pair_t;
+
+typedef struct cs_keyvalue {
+  const cs_keyvalue_pair_t *pairs;
+  size_t count;
+  cs_role_t key_role;     // 0 => CS_ROLE_MUTED
+  cs_role_t value_role;   // 0 => CS_ROLE_TEXT
+  const char *separator;  // between key column and value (NULL => "  ")
+} cs_keyvalue_t;
+
+void cs_keyvalue_render(const cs_keyvalue_t *kv, cs_surface_t *s);

--- a/src/components/cs_list.c
+++ b/src/components/cs_list.c
@@ -21,8 +21,8 @@ static bool cs_list_emit_line(void *user, const char *bytes, size_t byte_count,
   (void)columns;
   cs_list_emit_ctx_t *ctx = user;
   if (ctx->line_index > 0) {
-    for (int i = 0; i < ctx->marker_cols; i++) {
-      cs_surface_write(ctx->surface, " ");
+    if (ctx->marker_cols > 0) {
+      cs_surface_repeat(ctx->surface, " ", (size_t)ctx->marker_cols);
     }
   }
   cs_surface_set_role(ctx->surface, ctx->text_role);
@@ -38,9 +38,10 @@ void cs_list_render(const cs_list_t *list, cs_surface_t *s) {
     return;
   }
   cs_caps_t caps = cs_surface_caps(s);
-  cs_role_t marker_role =
-      list->marker_role ? list->marker_role : CS_ROLE_ACCENT;
-  cs_role_t text_role = list->text_role ? list->text_role : CS_ROLE_TEXT;
+  cs_role_t marker_role = cs_role_or_default(
+      list->marker_role, list->marker_role_set, CS_ROLE_ACCENT);
+  cs_role_t text_role =
+      cs_role_or_default(list->text_role, list->text_role_set, CS_ROLE_TEXT);
   size_t width = list->width ? list->width : cs_surface_width(s);
   if (width == 0) {
     width = 80;

--- a/src/components/cs_list.c
+++ b/src/components/cs_list.c
@@ -1,0 +1,79 @@
+/*
+ * cs_list — bulleted/numbered list. See cs_list.h.
+ */
+
+#include "cs_list.h"
+
+#include <stdio.h>
+
+#include "../ui/text_layout.h"
+#include "cs_glyphs.h"
+
+typedef struct {
+  cs_surface_t *surface;
+  cs_role_t text_role;
+  int marker_cols;  // columns to indent continuation lines under the text
+  int line_index;   // 0 for the first line of an item
+} cs_list_emit_ctx_t;
+
+static bool cs_list_emit_line(void *user, const char *bytes, size_t byte_count,
+                              int columns) {
+  (void)columns;
+  cs_list_emit_ctx_t *ctx = user;
+  if (ctx->line_index > 0) {
+    for (int i = 0; i < ctx->marker_cols; i++) {
+      cs_surface_write(ctx->surface, " ");
+    }
+  }
+  cs_surface_set_role(ctx->surface, ctx->text_role);
+  cs_surface_write_n(ctx->surface, bytes, byte_count);
+  cs_surface_reset(ctx->surface);
+  cs_surface_newline(ctx->surface);
+  ctx->line_index++;
+  return true;
+}
+
+void cs_list_render(const cs_list_t *list, cs_surface_t *s) {
+  if (!list || !s || !list->items || list->count == 0) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  cs_role_t marker_role =
+      list->marker_role ? list->marker_role : CS_ROLE_ACCENT;
+  cs_role_t text_role = list->text_role ? list->text_role : CS_ROLE_TEXT;
+  size_t width = list->width ? list->width : cs_surface_width(s);
+  if (width == 0) {
+    width = 80;
+  }
+  int start = list->start ? list->start : 1;
+
+  for (size_t i = 0; i < list->count; i++) {
+    const char *item = list->items[i] ? list->items[i] : "";
+
+    char marker[24];
+    if (list->style == CS_LIST_NUMBERED) {
+      snprintf(marker, sizeof(marker), "%d. ", start + (int)i);
+    } else {
+      snprintf(marker, sizeof(marker), "%s ", cs_glyph_bullet(caps.unicode));
+    }
+    int marker_cols = app_text_width_utf8(marker);
+
+    cs_surface_set_role(s, marker_role);
+    cs_surface_write(s, marker);
+    cs_surface_reset(s);
+
+    int content = (int)width - marker_cols;
+    if (content < 1) {
+      content = 1;
+    }
+    cs_list_emit_ctx_t ctx = {.surface = s,
+                              .text_role = text_role,
+                              .marker_cols = marker_cols,
+                              .line_index = 0};
+    app_text_wrap_utf8(item, content, 0, 0, cs_list_emit_line, &ctx);
+    // An empty item still needs to terminate its row.
+    if (ctx.line_index == 0) {
+      cs_surface_newline(s);
+    }
+  }
+}

--- a/src/components/cs_list.h
+++ b/src/components/cs_list.h
@@ -22,8 +22,10 @@ typedef struct cs_list {
   const char *const *items;
   size_t count;
   cs_list_style_t style;
-  cs_role_t marker_role;  // 0 => CS_ROLE_ACCENT
-  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
+  cs_role_t marker_role;  // default: CS_ROLE_ACCENT
+  cs_role_t text_role;    // default: CS_ROLE_TEXT
+  bool marker_role_set;   // true when `marker_role` is intentional
+  bool text_role_set;     // true when `text_role` is intentional
   size_t width;           // 0 => the surface width
   int start;              // numbered lists: first number (0 => 1)
 } cs_list_t;

--- a/src/components/cs_list.h
+++ b/src/components/cs_list.h
@@ -1,0 +1,31 @@
+/*
+ * cs_list — a bulleted or numbered list with word-wrap and hanging indent.
+ *
+ *   const char *items[] = {"First point", "A longer second point that wraps"};
+ *   cs_list_render(&(cs_list_t){.items = items, .count = 2}, s);
+ *
+ * Each item wraps to the surface width; continuation lines align under the
+ * item text (hanging indent), so long items stay readable. One block per call,
+ * trailing newline after each item.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef enum cs_list_style {
+  CS_LIST_BULLET = 0,
+  CS_LIST_NUMBERED,
+} cs_list_style_t;
+
+typedef struct cs_list {
+  const char *const *items;
+  size_t count;
+  cs_list_style_t style;
+  cs_role_t marker_role;  // 0 => CS_ROLE_ACCENT
+  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
+  size_t width;           // 0 => the surface width
+  int start;              // numbered lists: first number (0 => 1)
+} cs_list_t;
+
+void cs_list_render(const cs_list_t *list, cs_surface_t *s);

--- a/src/components/cs_note.c
+++ b/src/components/cs_note.c
@@ -1,0 +1,83 @@
+/*
+ * cs_note — callout block. See cs_note.h.
+ */
+
+#include "cs_note.h"
+
+#include "../ui/text_layout.h"
+#include "cs_glyphs.h"
+
+static cs_role_t cs_note_role(cs_note_variant_t variant) {
+  switch (variant) {
+  case CS_NOTE_SUCCESS:
+    return CS_ROLE_SUCCESS;
+  case CS_NOTE_WARNING:
+    return CS_ROLE_WARNING;
+  case CS_NOTE_ERROR:
+    return CS_ROLE_ERROR;
+  case CS_NOTE_INFO:
+  default:
+    return CS_ROLE_INFO;
+  }
+}
+
+typedef struct {
+  cs_surface_t *surface;
+  const char *gutter;
+  cs_role_t gutter_role;
+  cs_role_t text_role;
+} cs_note_emit_ctx_t;
+
+static void cs_note_gutter(cs_note_emit_ctx_t *ctx) {
+  cs_surface_set_role(ctx->surface, ctx->gutter_role);
+  cs_surface_write(ctx->surface, ctx->gutter);
+  cs_surface_reset(ctx->surface);
+  cs_surface_write(ctx->surface, " ");
+}
+
+static bool cs_note_emit_line(void *user, const char *bytes, size_t byte_count,
+                              int columns) {
+  (void)columns;
+  cs_note_emit_ctx_t *ctx = user;
+  cs_note_gutter(ctx);
+  cs_surface_set_role(ctx->surface, ctx->text_role);
+  cs_surface_write_n(ctx->surface, bytes, byte_count);
+  cs_surface_reset(ctx->surface);
+  cs_surface_newline(ctx->surface);
+  return true;
+}
+
+void cs_note_render(const cs_note_t *note, cs_surface_t *s) {
+  if (!note || !s) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  cs_role_t role = cs_note_role(note->variant);
+  size_t width = note->width ? note->width : cs_surface_width(s);
+  if (width == 0) {
+    width = 80;
+  }
+  // content = width minus the gutter glyph and its trailing space.
+  int content = (int)width - 2;
+  if (content < 1) {
+    content = 1;
+  }
+
+  cs_note_emit_ctx_t ctx = {.surface = s,
+                            .gutter = cs_glyph_gutter(caps.unicode),
+                            .gutter_role = role,
+                            .text_role = CS_ROLE_TEXT};
+
+  if (note->title && note->title[0]) {
+    cs_note_gutter(&ctx);
+    cs_surface_set_role(s, role);
+    cs_surface_set_attr(s, CS_ATTR_BOLD);
+    cs_surface_write(s, note->title);
+    cs_surface_reset(s);
+    cs_surface_newline(s);
+  }
+
+  if (note->body && note->body[0]) {
+    app_text_wrap_utf8(note->body, content, 0, 0, cs_note_emit_line, &ctx);
+  }
+}

--- a/src/components/cs_note.h
+++ b/src/components/cs_note.h
@@ -1,0 +1,33 @@
+/*
+ * cs_note — a callout block (info / success / warning / error).
+ *
+ *   cs_note_render(&(cs_note_t){
+ *       .variant = CS_NOTE_WARNING,
+ *       .title   = "Heads up",
+ *       .body    = "This action cannot be undone.",
+ *   }, s);
+ *
+ * Draws a colored gutter bar down the left edge, an optional bold title, and a
+ * word-wrapped body. Width defaults to the surface width. Emits trailing
+ * newlines.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef enum cs_note_variant {
+  CS_NOTE_INFO = 0,
+  CS_NOTE_SUCCESS,
+  CS_NOTE_WARNING,
+  CS_NOTE_ERROR,
+} cs_note_variant_t;
+
+typedef struct cs_note {
+  cs_note_variant_t variant;
+  const char *title;  // optional
+  const char *body;   // wrapped to the content width
+  size_t width;       // total columns (0 => the surface width)
+} cs_note_t;
+
+void cs_note_render(const cs_note_t *note, cs_surface_t *s);

--- a/src/components/cs_progress.c
+++ b/src/components/cs_progress.c
@@ -1,0 +1,78 @@
+/*
+ * cs_progress — one-shot progress bar. See cs_progress.h.
+ */
+
+#include "cs_progress.h"
+
+#include <stdio.h>
+
+#include "../ui/text_layout.h"
+#include "cs_glyphs.h"
+
+void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s) {
+  if (!progress || !s) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  double fraction = progress->total > 0
+                        ? (double)progress->current / (double)progress->total
+                        : progress->value;
+  if (fraction < 0.0) {
+    fraction = 0.0;
+  }
+  if (fraction > 1.0) {
+    fraction = 1.0;
+  }
+
+  cs_role_t bar_role =
+      progress->bar_role ? progress->bar_role : CS_ROLE_SUCCESS;
+  cs_role_t track_role =
+      progress->track_role ? progress->track_role : CS_ROLE_MUTED;
+  size_t width = progress->width ? progress->width : cs_surface_width(s);
+  if (width == 0) {
+    width = 80;
+  }
+
+  char percent[8] = {0};
+  int percent_cols = 0;
+  if (progress->show_percent) {
+    snprintf(percent, sizeof(percent), " %3d%%", (int)(fraction * 100.0 + 0.5));
+    percent_cols = app_text_width_utf8(percent);
+  }
+
+  int label_cols = 0;
+  if (progress->label && progress->label[0]) {
+    label_cols = app_text_width_utf8(progress->label) + 2;  // label + "  "
+  }
+
+  int bar_cols = (int)width - label_cols - percent_cols;
+  if (bar_cols < 1) {
+    bar_cols = 1;
+  }
+  int filled = (int)(fraction * bar_cols + 0.5);
+  if (filled > bar_cols) {
+    filled = bar_cols;
+  }
+
+  if (progress->label && progress->label[0]) {
+    cs_surface_set_role(s, CS_ROLE_TEXT);
+    cs_surface_write(s, progress->label);
+    cs_surface_reset(s);
+    cs_surface_write(s, "  ");
+  }
+
+  cs_surface_set_role(s, bar_role);
+  cs_surface_repeat(s, cs_glyph_bar_full(caps.unicode), (size_t)filled);
+  cs_surface_reset(s);
+  cs_surface_set_role(s, track_role);
+  cs_surface_repeat(s, cs_glyph_bar_empty(caps.unicode),
+                    (size_t)(bar_cols - filled));
+  cs_surface_reset(s);
+
+  if (progress->show_percent) {
+    cs_surface_set_role(s, CS_ROLE_MUTED);
+    cs_surface_write(s, percent);
+    cs_surface_reset(s);
+  }
+  cs_surface_newline(s);
+}

--- a/src/components/cs_progress.c
+++ b/src/components/cs_progress.c
@@ -23,6 +23,13 @@ void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s) {
   if (fraction > 1.0) {
     fraction = 1.0;
   }
+  // A NaN passes both comparisons above (every compare with NaN is false), so
+  // guard it explicitly: an unhandled NaN would make (int)(fraction * cols) UB
+  // and the bar-fill repeat counts wrap to a near-infinite loop. (+/-inf are
+  // already folded to 1.0 / 0.0 by the clamps.)
+  if (fraction != fraction) {
+    fraction = 0.0;
+  }
 
   cs_role_t bar_role =
       progress->bar_role ? progress->bar_role : CS_ROLE_SUCCESS;

--- a/src/components/cs_progress.c
+++ b/src/components/cs_progress.c
@@ -31,10 +31,10 @@ void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s) {
     fraction = 0.0;
   }
 
-  cs_role_t bar_role =
-      progress->bar_role ? progress->bar_role : CS_ROLE_SUCCESS;
-  cs_role_t track_role =
-      progress->track_role ? progress->track_role : CS_ROLE_MUTED;
+  cs_role_t bar_role = cs_role_or_default(
+      progress->bar_role, progress->bar_role_set, CS_ROLE_SUCCESS);
+  cs_role_t track_role = cs_role_or_default(
+      progress->track_role, progress->track_role_set, CS_ROLE_MUTED);
   size_t width = progress->width ? progress->width : cs_surface_width(s);
   if (width == 0) {
     width = 80;
@@ -47,10 +47,19 @@ void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s) {
     percent_cols = app_text_width_utf8(percent);
   }
 
-  int label_cols = 0;
+  // Truncate the label so the label + "  " separator + a >=1-column bar + the
+  // percent never overflow `width` (matches cs_table's per-cell truncation).
+  // Writing the label untruncated would smear a constrained line.
+  size_t label_bytes = 0;
+  int label_used = 0;
   if (progress->label && progress->label[0]) {
-    label_cols = app_text_width_utf8(progress->label) + 2;  // label + "  "
+    int label_budget = (int)width - percent_cols - 1 - 2;  // bar>=1, "  " sep
+    if (label_budget > 0) {
+      label_bytes = app_text_truncate_utf8_columns(progress->label,
+                                                   label_budget, &label_used);
+    }
   }
+  int label_cols = label_used > 0 ? label_used + 2 : 0;  // include "  " sep
 
   int bar_cols = (int)width - label_cols - percent_cols;
   if (bar_cols < 1) {
@@ -61,9 +70,9 @@ void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s) {
     filled = bar_cols;
   }
 
-  if (progress->label && progress->label[0]) {
+  if (label_used > 0) {
     cs_surface_set_role(s, CS_ROLE_TEXT);
-    cs_surface_write(s, progress->label);
+    cs_surface_write_n(s, progress->label, label_bytes);
     cs_surface_reset(s);
     cs_surface_write(s, "  ");
   }

--- a/src/components/cs_progress.h
+++ b/src/components/cs_progress.h
@@ -1,0 +1,30 @@
+/*
+ * cs_progress — a one-shot progress bar rendered to any surface.
+ *
+ *   cs_progress_render(&(cs_progress_t){
+ *       .label = "Building", .current = 7, .total = 10, .show_percent = true,
+ *   }, s);
+ *   // Building  ████████████░░░░░░░░   70%
+ *
+ * This is the stateless, surface-agnostic bar (distinct from the interactive
+ * tui_progress, which owns a window and animates). Set either `value` (0..1) or
+ * `current`/`total`. Emits one line with a trailing newline; for an animated
+ * line, render onto a curses surface or print "\r" yourself between frames.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef struct cs_progress {
+  const char *label;     // optional, shown before the bar
+  double value;          // 0..1 fraction (used when total <= 0)
+  long current;          // with total > 0, fraction = current/total
+  long total;            // 0 => use `value`
+  size_t width;          // total columns (0 => the surface width)
+  cs_role_t bar_role;    // filled portion (0 => CS_ROLE_SUCCESS)
+  cs_role_t track_role;  // empty portion (0 => CS_ROLE_MUTED)
+  bool show_percent;     // append the percentage
+} cs_progress_t;
+
+void cs_progress_render(const cs_progress_t *progress, cs_surface_t *s);

--- a/src/components/cs_progress.h
+++ b/src/components/cs_progress.h
@@ -22,8 +22,10 @@ typedef struct cs_progress {
   long current;          // with total > 0, fraction = current/total
   long total;            // 0 => use `value`
   size_t width;          // total columns (0 => the surface width)
-  cs_role_t bar_role;    // filled portion (0 => CS_ROLE_SUCCESS)
-  cs_role_t track_role;  // empty portion (0 => CS_ROLE_MUTED)
+  cs_role_t bar_role;    // filled portion (default: CS_ROLE_SUCCESS)
+  cs_role_t track_role;  // empty portion (default: CS_ROLE_MUTED)
+  bool bar_role_set;     // true when `bar_role` is intentional
+  bool track_role_set;   // true when `track_role` is intentional
   bool show_percent;     // append the percentage
 } cs_progress_t;
 

--- a/src/components/cs_rule.c
+++ b/src/components/cs_rule.c
@@ -17,8 +17,10 @@ void cs_rule_render(const cs_rule_t *rule, cs_surface_t *s) {
     width = 80;
   }
   const char *glyph = rule->glyph ? rule->glyph : cs_glyph_hline(caps.unicode);
-  cs_role_t line_role = rule->role ? rule->role : CS_ROLE_BORDER;
-  cs_role_t label_role = rule->label_role ? rule->label_role : CS_ROLE_TITLE;
+  cs_role_t line_role =
+      cs_role_or_default(rule->role, rule->role_set, CS_ROLE_BORDER);
+  cs_role_t label_role =
+      cs_role_or_default(rule->label_role, rule->label_role_set, CS_ROLE_TITLE);
 
   if (!rule->label || !rule->label[0]) {
     cs_surface_set_role(s, line_role);

--- a/src/components/cs_rule.c
+++ b/src/components/cs_rule.c
@@ -1,0 +1,57 @@
+/*
+ * cs_rule — horizontal divider. See cs_rule.h.
+ */
+
+#include "cs_rule.h"
+
+#include "../ui/text_layout.h"
+#include "cs_glyphs.h"
+
+void cs_rule_render(const cs_rule_t *rule, cs_surface_t *s) {
+  if (!rule || !s) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  size_t width = rule->width ? rule->width : cs_surface_width(s);
+  if (width == 0) {
+    width = 80;
+  }
+  const char *glyph = rule->glyph ? rule->glyph : cs_glyph_hline(caps.unicode);
+  cs_role_t line_role = rule->role ? rule->role : CS_ROLE_BORDER;
+  cs_role_t label_role = rule->label_role ? rule->label_role : CS_ROLE_TITLE;
+
+  if (!rule->label || !rule->label[0]) {
+    cs_surface_set_role(s, line_role);
+    cs_surface_repeat(s, glyph, width);
+    cs_surface_reset(s);
+    cs_surface_newline(s);
+    return;
+  }
+
+  // " label " centered between two glyph runs.
+  int label_cols = app_text_width_utf8(rule->label) + 2;  // surrounding spaces
+  if (label_cols <= 0 || (size_t)label_cols >= width) {
+    cs_surface_styled(s, label_role, CS_ATTR_BOLD, rule->label);
+    cs_surface_newline(s);
+    return;
+  }
+  size_t remaining = width - (size_t)label_cols;
+  size_t left = remaining / 2;
+  size_t right = remaining - left;
+
+  cs_surface_set_role(s, line_role);
+  cs_surface_repeat(s, glyph, left);
+  cs_surface_reset(s);
+
+  cs_surface_set_role(s, label_role);
+  cs_surface_set_attr(s, CS_ATTR_BOLD);
+  cs_surface_write(s, " ");
+  cs_surface_write(s, rule->label);
+  cs_surface_write(s, " ");
+  cs_surface_reset(s);
+
+  cs_surface_set_role(s, line_role);
+  cs_surface_repeat(s, glyph, right);
+  cs_surface_reset(s);
+  cs_surface_newline(s);
+}

--- a/src/components/cs_rule.h
+++ b/src/components/cs_rule.h
@@ -15,8 +15,10 @@
 
 typedef struct cs_rule {
   const char *label;     // optional; centered in the rule (NULL => plain line)
-  cs_role_t role;        // line color role (0 => CS_ROLE_BORDER)
-  cs_role_t label_role;  // label color role (0 => CS_ROLE_TITLE)
+  cs_role_t role;        // line color role (default: CS_ROLE_BORDER)
+  cs_role_t label_role;  // label color role (default: CS_ROLE_TITLE)
+  bool role_set;         // true when `role` is intentional
+  bool label_role_set;   // true when `label_role` is intentional
   size_t width;          // total columns (0 => the surface width)
   const char *glyph;     // line glyph (NULL => unicode "─" / ascii "-")
 } cs_rule_t;

--- a/src/components/cs_rule.h
+++ b/src/components/cs_rule.h
@@ -1,0 +1,24 @@
+/*
+ * cs_rule — a horizontal divider, optionally with a centered label.
+ *
+ *   cs_rule_render(&(cs_rule_t){0}, s);                  // a plain full-width
+ * rule cs_rule_render(&(cs_rule_t){.label = "OPTIONS"}, s); // ──── OPTIONS
+ * ────
+ *
+ * Renders on any surface (CLI stream or TUI window) and emits a trailing
+ * newline. Zero-initialised fields fall back to sensible defaults.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef struct cs_rule {
+  const char *label;     // optional; centered in the rule (NULL => plain line)
+  cs_role_t role;        // line color role (0 => CS_ROLE_BORDER)
+  cs_role_t label_role;  // label color role (0 => CS_ROLE_TITLE)
+  size_t width;          // total columns (0 => the surface width)
+  const char *glyph;     // line glyph (NULL => unicode "─" / ascii "-")
+} cs_rule_t;
+
+void cs_rule_render(const cs_rule_t *rule, cs_surface_t *s);

--- a/src/components/cs_spinner.c
+++ b/src/components/cs_spinner.c
@@ -37,7 +37,8 @@ void cs_spinner_render(const cs_spinner_t *spinner, int frame,
     return;
   }
   cs_caps_t caps = cs_surface_caps(s);
-  cs_role_t role = spinner->role ? spinner->role : CS_ROLE_ACCENT;
+  cs_role_t role =
+      cs_role_or_default(spinner->role, spinner->role_set, CS_ROLE_ACCENT);
 
   cs_surface_set_role(s, role);
   cs_surface_set_attr(s, CS_ATTR_BOLD);

--- a/src/components/cs_spinner.c
+++ b/src/components/cs_spinner.c
@@ -1,0 +1,53 @@
+/*
+ * cs_spinner — frame-based activity indicator. See cs_spinner.h.
+ */
+
+#include "cs_spinner.h"
+
+// Braille dot frames (UTF-8). Ten frames give a smooth spin.
+static const char *const CS_SPINNER_DOTS_FRAMES[] = {
+    "\xe2\xa0\x8b", "\xe2\xa0\x99", "\xe2\xa0\xb9", "\xe2\xa0\xb8",
+    "\xe2\xa0\xbc", "\xe2\xa0\xb4", "\xe2\xa0\xa6", "\xe2\xa0\xa7",
+    "\xe2\xa0\x87", "\xe2\xa0\x8f",
+};
+static const char *const CS_SPINNER_LINE_FRAMES[] = {"|", "/", "-", "\\"};
+
+int cs_spinner_frame_count(cs_spinner_style_t style, bool unicode) {
+  if (style == CS_SPINNER_DOTS && unicode) {
+    return (int)(sizeof(CS_SPINNER_DOTS_FRAMES) /
+                 sizeof(CS_SPINNER_DOTS_FRAMES[0]));
+  }
+  return (int)(sizeof(CS_SPINNER_LINE_FRAMES) /
+               sizeof(CS_SPINNER_LINE_FRAMES[0]));
+}
+
+const char *cs_spinner_frame(cs_spinner_style_t style, bool unicode,
+                             int frame) {
+  int count = cs_spinner_frame_count(style, unicode);
+  int idx = ((frame % count) + count) % count;  // tolerate negative frames
+  if (style == CS_SPINNER_DOTS && unicode) {
+    return CS_SPINNER_DOTS_FRAMES[idx];
+  }
+  return CS_SPINNER_LINE_FRAMES[idx];
+}
+
+void cs_spinner_render(const cs_spinner_t *spinner, int frame,
+                       cs_surface_t *s) {
+  if (!spinner || !s) {
+    return;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  cs_role_t role = spinner->role ? spinner->role : CS_ROLE_ACCENT;
+
+  cs_surface_set_role(s, role);
+  cs_surface_set_attr(s, CS_ATTR_BOLD);
+  cs_surface_write(s, cs_spinner_frame(spinner->style, caps.unicode, frame));
+  cs_surface_reset(s);
+
+  if (spinner->label && spinner->label[0]) {
+    cs_surface_write(s, " ");
+    cs_surface_set_role(s, CS_ROLE_TEXT);
+    cs_surface_write(s, spinner->label);
+    cs_surface_reset(s);
+  }
+}

--- a/src/components/cs_spinner.h
+++ b/src/components/cs_spinner.h
@@ -27,7 +27,8 @@ typedef enum cs_spinner_style {
 typedef struct cs_spinner {
   const char *label;  // optional, shown after the spinner glyph
   cs_spinner_style_t style;
-  cs_role_t role;  // spinner glyph color (0 => CS_ROLE_ACCENT)
+  cs_role_t role;  // spinner glyph color (default: CS_ROLE_ACCENT)
+  bool role_set;   // true when `role` is intentional
 } cs_spinner_t;
 
 // Number of distinct frames for a style at a given unicode capability.

--- a/src/components/cs_spinner.h
+++ b/src/components/cs_spinner.h
@@ -1,0 +1,40 @@
+/*
+ * cs_spinner — a frame-based activity indicator.
+ *
+ * Stateless: the caller owns the frame counter and the redraw cadence. Render a
+ * frame, sleep, advance, repeat — moving the cursor back with "\r" on a stream
+ * or redrawing the cell on a curses surface:
+ *
+ *   for (int f = 0; working; f++) {
+ *       fputc('\r', stdout);
+ *       cs_spinner_render(&(cs_spinner_t){.label = "Working"}, f, s);
+ *       fflush(stdout); nap();
+ *   }
+ *
+ * Renders inline (no trailing newline). Braille frames degrade to an ASCII
+ * line-spinner when unicode is unavailable.
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef enum cs_spinner_style {
+  CS_SPINNER_DOTS = 0,  // braille dots (unicode), ASCII line fallback
+  CS_SPINNER_LINE,      // pipe, slash, dash, backslash
+} cs_spinner_style_t;
+
+typedef struct cs_spinner {
+  const char *label;  // optional, shown after the spinner glyph
+  cs_spinner_style_t style;
+  cs_role_t role;  // spinner glyph color (0 => CS_ROLE_ACCENT)
+} cs_spinner_t;
+
+// Number of distinct frames for a style at a given unicode capability.
+int cs_spinner_frame_count(cs_spinner_style_t style, bool unicode);
+
+// The glyph for `frame` (taken modulo the frame count).
+const char *cs_spinner_frame(cs_spinner_style_t style, bool unicode, int frame);
+
+// Render one frame inline (glyph + optional label), no trailing newline.
+void cs_spinner_render(const cs_spinner_t *spinner, int frame, cs_surface_t *s);

--- a/src/components/cs_table.c
+++ b/src/components/cs_table.c
@@ -45,6 +45,12 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
   if (!table || !s || !table->columns || table->column_count == 0) {
     return;
   }
+  // A non-zero row_count promises a cells array; without this guard the natural-
+  // width scan would dereference a NULL base pointer. (A header-only table is
+  // expressed as cells == NULL with row_count == 0.)
+  if (table->row_count > 0 && !table->cells) {
+    return;
+  }
   const size_t ncol = table->column_count;
   cs_caps_t caps = cs_surface_caps(s);
   cs_role_t header_role =
@@ -108,6 +114,22 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
     // Hand any rounding leftover to the first column.
     if (remaining > 0) {
       widths[0] += remaining;
+    }
+    // The min-1 clamp above can push the assigned widths past the budget when
+    // several columns floor to 0 and round up. Reclaim that overrun from the
+    // widest columns so the table never renders wider than requested.
+    while (remaining < 0) {
+      size_t widest = 0;
+      for (size_t c = 1; c < ncol; c++) {
+        if (widths[c] > widths[widest]) {
+          widest = c;
+        }
+      }
+      if (widths[widest] <= 1) {
+        break;  // every column is already at its 1-column floor
+      }
+      widths[widest]--;
+      remaining++;
     }
   }
 

--- a/src/components/cs_table.c
+++ b/src/components/cs_table.c
@@ -1,0 +1,150 @@
+/*
+ * cs_table — columnar table. See cs_table.h.
+ */
+
+#include "cs_table.h"
+
+#include <stdlib.h>
+
+#include "../ui/text_layout.h"
+#include "cs_glyphs.h"
+
+static const char *cs_table_cell(const cs_table_t *t, size_t row, size_t col) {
+  const char *c = t->cells[row * t->column_count + col];
+  return c ? c : "";
+}
+
+// Write `text` truncated to `col_width` columns, padded to fill the column,
+// honoring alignment.
+static void cs_table_write_cell(cs_surface_t *s, cs_role_t role,
+                                const char *text, int col_width,
+                                cs_align_t align) {
+  int used = 0;
+  size_t bytes = app_text_truncate_utf8_columns(text, col_width, &used);
+  int pad = col_width - used;
+  if (pad < 0) {
+    pad = 0;
+  }
+
+  if (align == CS_ALIGN_RIGHT) {
+    for (int i = 0; i < pad; i++) {
+      cs_surface_write(s, " ");
+    }
+  }
+  cs_surface_set_role(s, role);
+  cs_surface_write_n(s, text, bytes);
+  cs_surface_reset(s);
+  if (align == CS_ALIGN_LEFT) {
+    for (int i = 0; i < pad; i++) {
+      cs_surface_write(s, " ");
+    }
+  }
+}
+
+void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
+  if (!table || !s || !table->columns || table->column_count == 0) {
+    return;
+  }
+  const size_t ncol = table->column_count;
+  cs_caps_t caps = cs_surface_caps(s);
+  cs_role_t header_role =
+      table->header_role ? table->header_role : CS_ROLE_TITLE;
+  cs_role_t text_role = table->text_role ? table->text_role : CS_ROLE_TEXT;
+  cs_role_t border_role =
+      table->border_role ? table->border_role : CS_ROLE_BORDER;
+  const char *gap = table->gap ? table->gap : "  ";
+  int gap_cols = app_text_width_utf8(gap);
+  size_t budget = table->width ? table->width : cs_surface_width(s);
+  if (budget == 0) {
+    budget = 80;
+  }
+
+  int *widths = malloc(ncol * sizeof(int));
+  if (!widths) {
+    return;
+  }
+
+  // Natural width per column: max(header, cells), capped by max_width.
+  for (size_t c = 0; c < ncol; c++) {
+    int w = table->header
+                ? app_text_width_utf8(
+                      table->columns[c].header ? table->columns[c].header : "")
+                : 0;
+    for (size_t r = 0; r < table->row_count; r++) {
+      int cw = app_text_width_utf8(cs_table_cell(table, r, c));
+      if (cw > w) {
+        w = cw;
+      }
+    }
+    if (w < 1) {
+      w = 1;
+    }
+    if (table->columns[c].max_width > 0 && w > table->columns[c].max_width) {
+      w = table->columns[c].max_width;
+    }
+    widths[c] = w;
+  }
+
+  // Shrink proportionally if the row overflows the budget.
+  int gaps_total = (ncol > 1) ? (int)(ncol - 1) * gap_cols : 0;
+  int content_budget = (int)budget - gaps_total;
+  if (content_budget < (int)ncol) {
+    content_budget = (int)ncol;  // at least 1 column per cell
+  }
+  int sum = 0;
+  for (size_t c = 0; c < ncol; c++) {
+    sum += widths[c];
+  }
+  if (sum > content_budget) {
+    int remaining = content_budget;
+    for (size_t c = 0; c < ncol; c++) {
+      int scaled = (int)((long)widths[c] * content_budget / sum);
+      if (scaled < 1) {
+        scaled = 1;
+      }
+      widths[c] = scaled;
+      remaining -= scaled;
+    }
+    // Hand any rounding leftover to the first column.
+    if (remaining > 0) {
+      widths[0] += remaining;
+    }
+  }
+
+  int total = gaps_total;
+  for (size_t c = 0; c < ncol; c++) {
+    total += widths[c];
+  }
+
+  // Header row + separator.
+  if (table->header) {
+    for (size_t c = 0; c < ncol; c++) {
+      if (c > 0) {
+        cs_surface_write(s, gap);
+      }
+      const char *h = table->columns[c].header ? table->columns[c].header : "";
+      cs_surface_set_attr(s, CS_ATTR_BOLD);
+      cs_table_write_cell(s, header_role, h, widths[c],
+                          table->columns[c].align);
+    }
+    cs_surface_newline(s);
+    cs_surface_set_role(s, border_role);
+    cs_surface_repeat(s, cs_glyph_hline(caps.unicode), (size_t)total);
+    cs_surface_reset(s);
+    cs_surface_newline(s);
+  }
+
+  // Body rows.
+  for (size_t r = 0; r < table->row_count; r++) {
+    for (size_t c = 0; c < ncol; c++) {
+      if (c > 0) {
+        cs_surface_write(s, gap);
+      }
+      cs_table_write_cell(s, text_role, cs_table_cell(table, r, c), widths[c],
+                          table->columns[c].align);
+    }
+    cs_surface_newline(s);
+  }
+
+  free(widths);
+}

--- a/src/components/cs_table.c
+++ b/src/components/cs_table.c
@@ -122,8 +122,7 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
     int min_width = ncol <= (size_t)content_budget ? 1 : 0;
     int remaining = content_budget;
     for (size_t c = 0; c < ncol; c++) {
-      int scaled =
-          sum > 0 ? (int)((long long)widths[c] * content_budget / sum) : 0;
+      int scaled = (int)((long long)widths[c] * content_budget / sum);
       if (scaled < min_width) {
         scaled = min_width;
       }

--- a/src/components/cs_table.c
+++ b/src/components/cs_table.c
@@ -4,6 +4,7 @@
 
 #include "cs_table.h"
 
+#include <limits.h>
 #include <stdlib.h>
 
 #include "../ui/text_layout.h"
@@ -27,16 +28,16 @@ static void cs_table_write_cell(cs_surface_t *s, cs_role_t role,
   }
 
   if (align == CS_ALIGN_RIGHT) {
-    for (int i = 0; i < pad; i++) {
-      cs_surface_write(s, " ");
+    if (pad > 0) {
+      cs_surface_repeat(s, " ", (size_t)pad);
     }
   }
   cs_surface_set_role(s, role);
   cs_surface_write_n(s, text, bytes);
   cs_surface_reset(s);
   if (align == CS_ALIGN_LEFT) {
-    for (int i = 0; i < pad; i++) {
-      cs_surface_write(s, " ");
+    if (pad > 0) {
+      cs_surface_repeat(s, " ", (size_t)pad);
     }
   }
 }
@@ -45,19 +46,20 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
   if (!table || !s || !table->columns || table->column_count == 0) {
     return;
   }
-  // A non-zero row_count promises a cells array; without this guard the natural-
-  // width scan would dereference a NULL base pointer. (A header-only table is
-  // expressed as cells == NULL with row_count == 0.)
+  // A non-zero row_count promises a cells array; without this guard the
+  // natural width scan would dereference a NULL base pointer. (A header-only
+  // table is expressed as cells == NULL with row_count == 0.)
   if (table->row_count > 0 && !table->cells) {
     return;
   }
   const size_t ncol = table->column_count;
   cs_caps_t caps = cs_surface_caps(s);
-  cs_role_t header_role =
-      table->header_role ? table->header_role : CS_ROLE_TITLE;
-  cs_role_t text_role = table->text_role ? table->text_role : CS_ROLE_TEXT;
-  cs_role_t border_role =
-      table->border_role ? table->border_role : CS_ROLE_BORDER;
+  cs_role_t header_role = cs_role_or_default(
+      table->header_role, table->header_role_set, CS_ROLE_TITLE);
+  cs_role_t text_role =
+      cs_role_or_default(table->text_role, table->text_role_set, CS_ROLE_TEXT);
+  cs_role_t border_role = cs_role_or_default(
+      table->border_role, table->border_role_set, CS_ROLE_BORDER);
   const char *gap = table->gap ? table->gap : "  ";
   int gap_cols = app_text_width_utf8(gap);
   size_t budget = table->width ? table->width : cs_surface_width(s);
@@ -92,21 +94,38 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
   }
 
   // Shrink proportionally if the row overflows the budget.
-  int gaps_total = (ncol > 1) ? (int)(ncol - 1) * gap_cols : 0;
-  int content_budget = (int)budget - gaps_total;
-  if (content_budget < (int)ncol) {
-    content_budget = (int)ncol;  // at least 1 column per cell
+  const int budget_cols = budget > (size_t)INT_MAX ? INT_MAX : (int)budget;
+  const size_t gap_count = ncol > 1 ? ncol - 1 : 0;
+  if (gap_cols < 0) {
+    gap_cols = 0;
+  }
+  int gaps_total = (gap_cols > 0 && gap_count > (size_t)(INT_MAX / gap_cols))
+                       ? INT_MAX
+                       : (int)gap_count * gap_cols;
+  if (gaps_total >= budget_cols) {
+    // If separators alone would exhaust the whole row, drop them before
+    // shrinking cells. Rendering content under the caller's width budget beats
+    // preserving cosmetic inter-column whitespace.
+    gap = "";
+    gap_cols = 0;
+    gaps_total = 0;
+  }
+  int content_budget = budget_cols - gaps_total;
+  if (content_budget < 0) {
+    content_budget = 0;
   }
   int sum = 0;
   for (size_t c = 0; c < ncol; c++) {
     sum += widths[c];
   }
   if (sum > content_budget) {
+    int min_width = ncol <= (size_t)content_budget ? 1 : 0;
     int remaining = content_budget;
     for (size_t c = 0; c < ncol; c++) {
-      int scaled = (int)((long)widths[c] * content_budget / sum);
-      if (scaled < 1) {
-        scaled = 1;
+      int scaled =
+          sum > 0 ? (int)((long long)widths[c] * content_budget / sum) : 0;
+      if (scaled < min_width) {
+        scaled = min_width;
       }
       widths[c] = scaled;
       remaining -= scaled;
@@ -125,8 +144,8 @@ void cs_table_render(const cs_table_t *table, cs_surface_t *s) {
           widest = c;
         }
       }
-      if (widths[widest] <= 1) {
-        break;  // every column is already at its 1-column floor
+      if (widths[widest] <= min_width) {
+        break;  // every column is already at its floor
       }
       widths[widest]--;
       remaining++;

--- a/src/components/cs_table.h
+++ b/src/components/cs_table.h
@@ -1,0 +1,45 @@
+/*
+ * cs_table — a columnar table with alignment and width budgeting.
+ *
+ *   cs_table_column_t cols[] = {{.header = "Name"}, {.header = "Status"}};
+ *   const char *cells[] = {"build", "ok", "tests", "ok"}; // row-major
+ *   cs_table_render(&(cs_table_t){
+ *       .columns = cols, .column_count = 2,
+ *       .cells = cells, .row_count = 2,
+ *       .header = true,
+ *   }, s);
+ *
+ * Column widths are sized to their content (header + cells), capped per column
+ * and shrunk proportionally to fit the surface width; cells that exceed their
+ * column are truncated. Cells are addressed row-major: cells[row*cols + col].
+ */
+
+#pragma once
+
+#include "../surface/surface.h"
+
+typedef enum cs_align {
+  CS_ALIGN_LEFT = 0,
+  CS_ALIGN_RIGHT,
+} cs_align_t;
+
+typedef struct cs_table_column {
+  const char *header;
+  cs_align_t align;
+  int max_width;  // 0 => unbounded (still subject to the overall width budget)
+} cs_table_column_t;
+
+typedef struct cs_table {
+  const cs_table_column_t *columns;
+  size_t column_count;
+  const char *const *cells;  // row-major, column_count entries per row
+  size_t row_count;
+  bool header;            // render the header row + a separator rule
+  cs_role_t header_role;  // 0 => CS_ROLE_TITLE
+  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
+  cs_role_t border_role;  // 0 => CS_ROLE_BORDER
+  size_t width;           // total budget (0 => the surface width)
+  const char *gap;        // inter-column gap (NULL => "  ")
+} cs_table_t;
+
+void cs_table_render(const cs_table_t *table, cs_surface_t *s);

--- a/src/components/cs_table.h
+++ b/src/components/cs_table.h
@@ -35,9 +35,12 @@ typedef struct cs_table {
   const char *const *cells;  // row-major, column_count entries per row
   size_t row_count;
   bool header;            // render the header row + a separator rule
-  cs_role_t header_role;  // 0 => CS_ROLE_TITLE
-  cs_role_t text_role;    // 0 => CS_ROLE_TEXT
-  cs_role_t border_role;  // 0 => CS_ROLE_BORDER
+  cs_role_t header_role;  // default: CS_ROLE_TITLE
+  cs_role_t text_role;    // default: CS_ROLE_TEXT
+  cs_role_t border_role;  // default: CS_ROLE_BORDER
+  bool header_role_set;   // true when `header_role` is intentional
+  bool text_role_set;     // true when `text_role` is intentional
+  bool border_role_set;   // true when `border_role` is intentional
   size_t width;           // total budget (0 => the surface width)
   const char *gap;        // inter-column gap (NULL => "  ")
 } cs_table_t;

--- a/src/curspan.h
+++ b/src/curspan.h
@@ -1,0 +1,37 @@
+/*
+ * curspan.h — the Curspan framework umbrella header.
+ *
+ * Curspan is a high-level framework for building command-line tools and
+ * terminal UIs in C23. One include gives you the public surface:
+ *
+ *   - theming   : design tokens -> semantic roles -> named, overridable themes
+ *                 (cs_theme.h)
+ *   - surface   : a neutral render target that draws to a CLI stream or a TUI
+ *                 window and degrades color per terminal (surface.h)
+ *   - components: a catalog of themeable widgets that render on either surface
+ *                 (components.h)
+ *
+ * Components are "open code": you own the source. The `curspan` CLI copies a
+ * component and its dependency closure into your project from registry.json,
+ * the same way ShadCN distributes UI components. See docs/COMPONENTS.md and
+ * docs/THEMING.md.
+ *
+ * This header is safe to include in any build configuration; the TUI-only and
+ * CLI-only surfaces are selected at compile time.
+ */
+
+#pragma once
+
+#include "components/components.h"
+#include "style/cs_theme.h"
+#include "surface/surface.h"
+
+// Compile-time framework version, for feature detection across updates.
+#define CURSPAN_VERSION_MAJOR 0
+#define CURSPAN_VERSION_MINOR 1
+#define CURSPAN_VERSION_PATCH 0
+#define CURSPAN_VERSION_ENCODE(major, minor, patch) \
+  (((major) * 1000000) + ((minor) * 1000) + (patch))
+#define CURSPAN_VERSION                                                \
+  CURSPAN_VERSION_ENCODE(CURSPAN_VERSION_MAJOR, CURSPAN_VERSION_MINOR, \
+                         CURSPAN_VERSION_PATCH)

--- a/src/style/cs_theme.c
+++ b/src/style/cs_theme.c
@@ -7,6 +7,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef APP_ENABLE_CLI_STYLE
+#include "../cli/style/cli_term.h"
+#endif
+
 cs_mode_t cs_theme_mode_resolve(void) {
   const char *theme = getenv("APP_CLI_TEST_THEME");
   if (!theme || !theme[0]) {
@@ -15,6 +19,16 @@ cs_mode_t cs_theme_mode_resolve(void) {
   if (theme && strcmp(theme, "light") == 0) {
     return CS_MODE_LIGHT;
   }
+  if (theme && strcmp(theme, "dark") == 0) {
+    return CS_MODE_DARK;
+  }
+#ifdef APP_ENABLE_CLI_STYLE
+  // Match the styled CLI resolver: unset, "auto", and unknown values query OSC
+  // 11 when policy allows it, then fall back to dark when detection cannot run.
+  if (app_cli_term_detect_background(NULL, NULL) == APP_CLI_BG_LIGHT) {
+    return CS_MODE_LIGHT;
+  }
+#endif
   return CS_MODE_DARK;
 }
 

--- a/src/style/cs_theme.c
+++ b/src/style/cs_theme.c
@@ -1,0 +1,156 @@
+/*
+ * cs_theme — public theming API. See cs_theme.h.
+ */
+
+#include "cs_theme.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+cs_mode_t cs_theme_mode_resolve(void) {
+  const char *theme = getenv("APP_CLI_TEST_THEME");
+  if (!theme || !theme[0]) {
+    theme = getenv("APP_CLI_THEME");
+  }
+  if (theme && strcmp(theme, "light") == 0) {
+    return CS_MODE_LIGHT;
+  }
+  return CS_MODE_DARK;
+}
+
+void cs_theme_set_role(cs_theme_t *theme, cs_role_t role, app_ui_color_t color) {
+  if (!theme || role < 0 || role >= APP_UI_ROLE_COUNT) {
+    return;
+  }
+  theme->scheme.roles[role].dark = color;
+  theme->scheme.roles[role].light = color;
+}
+
+bool cs_theme_set_role_spec(cs_theme_t *theme, cs_role_t role,
+                            const char *spec) {
+  app_ui_color_t color;
+  if (!theme || !app_ui_color_parse(spec, &color)) {
+    return false;
+  }
+  cs_theme_set_role(theme, role, color);
+  return true;
+}
+
+app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme, cs_role_t role,
+                                         app_cli_color_profile_id profile,
+                                         int color_count) {
+  if (!theme) {
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_NONE};
+  }
+  return app_ui_theme_resolve(&theme->scheme, role, theme->mode, profile,
+                              color_count);
+}
+
+// ---- Built-in themes ------------------------------------------------------
+
+// "mono": a hueless theme. Every role degrades to white / gray / black so the
+// same components render cleanly on monochrome or e-ink-style terminals. Built
+// by reclassifying the default role table rather than hand-coding 26 entries,
+// so it tracks any future role additions.
+static app_ui_color_t mono_ansi16(uint8_t index) {
+  return (app_ui_color_t){.kind = APP_UI_COLOR_ANSI16,
+                          .ansi16 = index,
+                          .has_ansi16_hint = true,
+                          .ansi16_hint = index};
+}
+
+static void cs_theme_make_mono(app_ui_color_scheme_t *scheme) {
+  for (int role = 0; role < APP_UI_ROLE_COUNT; role++) {
+    uint8_t fg = 7; // white by default
+    switch (role) {
+    case APP_UI_ROLE_MUTED:
+    case APP_UI_ROLE_COMMENT:
+    case APP_UI_ROLE_FLAG_DEFAULT:
+    case APP_UI_ROLE_DASH:
+    case APP_UI_ROLE_BORDER:
+    case APP_UI_ROLE_PANEL:
+    case APP_UI_ROLE_PANEL_ALT:
+      fg = 8; // bright black (gray)
+      break;
+    case APP_UI_ROLE_ERROR_HEADER_FG:
+    case APP_UI_ROLE_SELECTION_FG:
+      fg = 0; // black text for the inverted bars below
+      break;
+    case APP_UI_ROLE_ERROR_HEADER_BG:
+    case APP_UI_ROLE_SELECTION_BG:
+      fg = 7; // white bar
+      break;
+    case APP_UI_ROLE_TITLE:
+    case APP_UI_ROLE_PROGRAM:
+    case APP_UI_ROLE_ACCENT:
+    case APP_UI_ROLE_HELP:
+      fg = 15; // bright white for emphasis
+      break;
+    default:
+      fg = 7;
+      break;
+    }
+    app_ui_color_t c = mono_ansi16(fg);
+    scheme->roles[role].dark = c;
+    scheme->roles[role].light = c;
+  }
+}
+
+// Build a named scheme. Returns false for unknown names.
+static bool cs_theme_build_scheme(const char *name,
+                                  app_ui_color_scheme_t *out) {
+  if (strcmp(name, "amber") == 0) {
+    *out = *app_ui_theme_default_scheme();
+    return true;
+  }
+  if (strcmp(name, "mono") == 0) {
+    *out = *app_ui_theme_default_scheme();
+    cs_theme_make_mono(out);
+    return true;
+  }
+  return false;
+}
+
+// Apply the shared env overrides (APP_CLI_ACCENT) to a built scheme.
+static void cs_theme_apply_env(app_ui_color_scheme_t *scheme) {
+  app_ui_theme_apply_env_overrides(scheme);
+}
+
+bool cs_theme_by_name(const char *name, cs_theme_t *out) {
+  if (!name || !out) {
+    return false;
+  }
+  app_ui_color_scheme_t scheme;
+  if (!cs_theme_build_scheme(name, &scheme)) {
+    return false;
+  }
+  cs_theme_apply_env(&scheme);
+  // Match the built-in name to its stable string literal for theme->name.
+  const char *const *names = cs_theme_names();
+  const char *canonical = "custom";
+  for (size_t i = 0; names[i]; i++) {
+    if (strcmp(names[i], name) == 0) {
+      canonical = names[i];
+      break;
+    }
+  }
+  *out = (cs_theme_t){
+      .scheme = scheme, .mode = cs_theme_mode_resolve(), .name = canonical};
+  return true;
+}
+
+cs_theme_t cs_theme_default(void) {
+  cs_theme_t theme;
+  // "amber" always exists; fall back to a zeroed theme defensively.
+  if (!cs_theme_by_name("amber", &theme)) {
+    theme = (cs_theme_t){.scheme = *app_ui_theme_default_scheme(),
+                         .mode = cs_theme_mode_resolve(),
+                         .name = "amber"};
+  }
+  return theme;
+}
+
+const char *const *cs_theme_names(void) {
+  static const char *const names[] = {"amber", "mono", NULL};
+  return names;
+}

--- a/src/style/cs_theme.c
+++ b/src/style/cs_theme.c
@@ -18,7 +18,8 @@ cs_mode_t cs_theme_mode_resolve(void) {
   return CS_MODE_DARK;
 }
 
-void cs_theme_set_role(cs_theme_t *theme, cs_role_t role, app_ui_color_t color) {
+void cs_theme_set_role(cs_theme_t *theme, cs_role_t role,
+                       app_ui_color_t color) {
   if (!theme || role < 0 || role >= APP_UI_ROLE_COUNT) {
     return;
   }
@@ -36,7 +37,8 @@ bool cs_theme_set_role_spec(cs_theme_t *theme, cs_role_t role,
   return true;
 }
 
-app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme, cs_role_t role,
+app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme,
+                                         cs_role_t role,
                                          app_cli_color_profile_id profile,
                                          int color_count) {
   if (!theme) {
@@ -61,7 +63,7 @@ static app_ui_color_t mono_ansi16(uint8_t index) {
 
 static void cs_theme_make_mono(app_ui_color_scheme_t *scheme) {
   for (int role = 0; role < APP_UI_ROLE_COUNT; role++) {
-    uint8_t fg = 7; // white by default
+    uint8_t fg = 7;  // white by default
     switch (role) {
     case APP_UI_ROLE_MUTED:
     case APP_UI_ROLE_COMMENT:
@@ -70,21 +72,21 @@ static void cs_theme_make_mono(app_ui_color_scheme_t *scheme) {
     case APP_UI_ROLE_BORDER:
     case APP_UI_ROLE_PANEL:
     case APP_UI_ROLE_PANEL_ALT:
-      fg = 8; // bright black (gray)
+      fg = 8;  // bright black (gray)
       break;
     case APP_UI_ROLE_ERROR_HEADER_FG:
     case APP_UI_ROLE_SELECTION_FG:
-      fg = 0; // black text for the inverted bars below
+      fg = 0;  // black text for the inverted bars below
       break;
     case APP_UI_ROLE_ERROR_HEADER_BG:
     case APP_UI_ROLE_SELECTION_BG:
-      fg = 7; // white bar
+      fg = 7;  // white bar
       break;
     case APP_UI_ROLE_TITLE:
     case APP_UI_ROLE_PROGRAM:
     case APP_UI_ROLE_ACCENT:
     case APP_UI_ROLE_HELP:
-      fg = 15; // bright white for emphasis
+      fg = 15;  // bright white for emphasis
       break;
     default:
       fg = 7;

--- a/src/style/cs_theme.h
+++ b/src/style/cs_theme.h
@@ -6,15 +6,16 @@
  *   2. semantic roles  — named, adaptive {dark,light} colors (ui_theme.h)
  *   3. themes          — a named, overridable bundle of roles + a mode
  *
- * A cs_theme_t is the value components and surfaces consume. Built-in themes are
- * resolvable by name; any role can be overridden; the active light/dark mode is
- * resolved from the environment. This is the terminal-UI analogue of a ShadCN
- * CSS-variable theme: every component styles itself through these roles, never
- * through hard-coded colors, so re-theming an app is a one-line change.
+ * A cs_theme_t is the value components and surfaces consume. Built-in themes
+ * are resolvable by name; any role can be overridden; the active light/dark
+ * mode is resolved from the environment. This is the terminal-UI analogue of a
+ * ShadCN CSS-variable theme: every component styles itself through these roles,
+ * never through hard-coded colors, so re-theming an app is a one-line change.
  *
  * This is an additive public surface over the existing app_ui_* internals; the
- * default theme is the same amber-on-near-black identity the CLI and TUI already
- * share, and the APP_CLI_THEME / APP_CLI_ACCENT environment contract is honored.
+ * default theme is the same amber-on-near-black identity the CLI and TUI
+ * already share, and the APP_CLI_THEME / APP_CLI_ACCENT environment contract is
+ * honored.
  */
 
 #pragma once
@@ -49,9 +50,9 @@ typedef app_ui_theme_mode_id cs_mode_t;
 #define CS_MODE_LIGHT APP_UI_THEME_MODE_LIGHT
 
 typedef struct cs_theme {
-  app_ui_color_scheme_t scheme; // the role table (by value, ~copyable)
-  cs_mode_t mode;               // active light/dark mode
-  const char *name;             // built-in name, or "custom"
+  app_ui_color_scheme_t scheme;  // the role table (by value, ~copyable)
+  cs_mode_t mode;                // active light/dark mode
+  const char *name;              // built-in name, or "custom"
 } cs_theme_t;
 
 // The default theme ("amber"): the shared amber-on-near-black identity, with
@@ -77,9 +78,11 @@ void cs_theme_set_role(cs_theme_t *theme, cs_role_t role, app_ui_color_t color);
 
 // Parse "#rrggbb" / "rrggbb" / decimal ANSI index and override a role. Returns
 // false on a malformed spec (leaving the theme unchanged).
-bool cs_theme_set_role_spec(cs_theme_t *theme, cs_role_t role, const char *spec);
+bool cs_theme_set_role_spec(cs_theme_t *theme, cs_role_t role,
+                            const char *spec);
 
 // Resolve a role in this theme to a concrete color for a terminal profile.
-app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme, cs_role_t role,
+app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme,
+                                         cs_role_t role,
                                          app_cli_color_profile_id profile,
                                          int color_count);

--- a/src/style/cs_theme.h
+++ b/src/style/cs_theme.h
@@ -1,0 +1,85 @@
+/*
+ * cs_theme — Curspan's public theming API.
+ *
+ * Curspan's design system is three layers (see docs/THEMING.md):
+ *   1. design tokens   — raw sRGB palette values (design_tokens.h)
+ *   2. semantic roles  — named, adaptive {dark,light} colors (ui_theme.h)
+ *   3. themes          — a named, overridable bundle of roles + a mode
+ *
+ * A cs_theme_t is the value components and surfaces consume. Built-in themes are
+ * resolvable by name; any role can be overridden; the active light/dark mode is
+ * resolved from the environment. This is the terminal-UI analogue of a ShadCN
+ * CSS-variable theme: every component styles itself through these roles, never
+ * through hard-coded colors, so re-theming an app is a one-line change.
+ *
+ * This is an additive public surface over the existing app_ui_* internals; the
+ * default theme is the same amber-on-near-black identity the CLI and TUI already
+ * share, and the APP_CLI_THEME / APP_CLI_ACCENT environment contract is honored.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "ui_theme.h"
+
+// A role is a semantic slot in the theme. Curspan exposes the shared UI roles
+// under render-neutral, component-centric aliases so component code reads as
+// cs_surface_set_role(s, CS_ROLE_PRIMARY) rather than naming help-text tokens.
+typedef app_ui_role_id cs_role_t;
+typedef app_ui_theme_mode_id cs_mode_t;
+
+#define CS_ROLE_TEXT APP_UI_ROLE_TEXT
+#define CS_ROLE_MUTED APP_UI_ROLE_MUTED
+#define CS_ROLE_PRIMARY APP_UI_ROLE_ACCENT
+#define CS_ROLE_ACCENT APP_UI_ROLE_ACCENT
+#define CS_ROLE_TITLE APP_UI_ROLE_TITLE
+#define CS_ROLE_HEADING APP_UI_ROLE_TITLE
+#define CS_ROLE_CODE APP_UI_ROLE_CODE
+#define CS_ROLE_SUCCESS APP_UI_ROLE_SUCCESS
+#define CS_ROLE_WARNING APP_UI_ROLE_WARNING
+#define CS_ROLE_ERROR APP_UI_ROLE_ERROR_DETAILS
+#define CS_ROLE_INFO APP_UI_ROLE_INFO
+#define CS_ROLE_BORDER APP_UI_ROLE_BORDER
+#define CS_ROLE_SELECTION_FG APP_UI_ROLE_SELECTION_FG
+#define CS_ROLE_SELECTION_BG APP_UI_ROLE_SELECTION_BG
+#define CS_ROLE_PANEL APP_UI_ROLE_PANEL
+
+#define CS_MODE_DARK APP_UI_THEME_MODE_DARK
+#define CS_MODE_LIGHT APP_UI_THEME_MODE_LIGHT
+
+typedef struct cs_theme {
+  app_ui_color_scheme_t scheme; // the role table (by value, ~copyable)
+  cs_mode_t mode;               // active light/dark mode
+  const char *name;             // built-in name, or "custom"
+} cs_theme_t;
+
+// The default theme ("amber"): the shared amber-on-near-black identity, with
+// APP_CLI_ACCENT applied and the mode resolved from APP_CLI_THEME. This is what
+// an app gets by default and what every built-in component is tuned against.
+cs_theme_t cs_theme_default(void);
+
+// Resolve a built-in theme by name. Returns false (leaving *out untouched) when
+// the name is unknown. The result has env overrides applied and mode resolved,
+// exactly like cs_theme_default().
+bool cs_theme_by_name(const char *name, cs_theme_t *out);
+
+// NULL-terminated list of built-in theme names, for `theme` listings and docs.
+const char *const *cs_theme_names(void);
+
+// Resolve the active mode from APP_CLI_TEST_THEME / APP_CLI_THEME
+// (auto|dark|light). "auto" and anything unknown resolve to dark. This is the
+// single owner of mode parsing (previously duplicated in cli_layout.c + tui.c).
+cs_mode_t cs_theme_mode_resolve(void);
+
+// Override one role for both modes (the general form of the accent override).
+void cs_theme_set_role(cs_theme_t *theme, cs_role_t role, app_ui_color_t color);
+
+// Parse "#rrggbb" / "rrggbb" / decimal ANSI index and override a role. Returns
+// false on a malformed spec (leaving the theme unchanged).
+bool cs_theme_set_role_spec(cs_theme_t *theme, cs_role_t role, const char *spec);
+
+// Resolve a role in this theme to a concrete color for a terminal profile.
+app_ui_resolved_color_t cs_theme_resolve(const cs_theme_t *theme, cs_role_t role,
+                                         app_cli_color_profile_id profile,
+                                         int color_count);

--- a/src/style/cs_theme.h
+++ b/src/style/cs_theme.h
@@ -49,6 +49,22 @@ typedef app_ui_theme_mode_id cs_mode_t;
 #define CS_MODE_DARK APP_UI_THEME_MODE_DARK
 #define CS_MODE_LIGHT APP_UI_THEME_MODE_LIGHT
 
+// Optional role fields in component props are zero-initialized for their
+// component-specific defaults, but CS_ROLE_TEXT is also enum value zero. Pair a
+// role field with a `*_role_set` flag when CS_ROLE_TEXT must be selected
+// explicitly where the default is another role.
+static inline bool cs_role_valid(cs_role_t role) {
+  return role >= 0 && role < APP_UI_ROLE_COUNT;
+}
+
+static inline cs_role_t cs_role_or_default(cs_role_t role, bool role_set,
+                                           cs_role_t default_role) {
+  if (role_set || role != CS_ROLE_TEXT) {
+    return cs_role_valid(role) ? role : default_role;
+  }
+  return default_role;
+}
+
 typedef struct cs_theme {
   app_ui_color_scheme_t scheme;  // the role table (by value, ~copyable)
   cs_mode_t mode;                // active light/dark mode
@@ -69,8 +85,9 @@ bool cs_theme_by_name(const char *name, cs_theme_t *out);
 const char *const *cs_theme_names(void);
 
 // Resolve the active mode from APP_CLI_TEST_THEME / APP_CLI_THEME
-// (auto|dark|light). "auto" and anything unknown resolve to dark. This is the
-// single owner of mode parsing (previously duplicated in cli_layout.c + tui.c).
+// (auto|dark|light). "auto" and anything unknown use the same OSC 11
+// background detection as the styled CLI when available, then fall back to
+// dark.
 cs_mode_t cs_theme_mode_resolve(void);
 
 // Override one role for both modes (the general form of the accent override).

--- a/src/style/ui_theme.c
+++ b/src/style/ui_theme.c
@@ -1,0 +1,264 @@
+/*
+ * Shared semantic terminal UI theme. See ui_theme.h.
+ */
+
+#include "ui_theme.h"
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "design_tokens.h"
+
+#define UI_RGBH(rr, gg, bb, hint)             \
+  ((app_ui_color_t){.kind = APP_UI_COLOR_RGB, \
+                    .rgb = {(rr), (gg), (bb)}, \
+                    .has_ansi16_hint = true,  \
+                    .ansi16_hint = (hint)})
+
+#define UI_ADAPT(d, l) \
+  ((app_ui_adaptive_color_t){.dark = (d), .light = (l)})
+
+static app_ui_color_t app_ui_rgbh(app_rgb_t rgb, uint8_t hint) {
+  return (app_ui_color_t){.kind = APP_UI_COLOR_RGB,
+                          .rgb = rgb,
+                          .has_ansi16_hint = true,
+                          .ansi16_hint = hint};
+}
+
+static app_ui_color_scheme_t APP_UI_DEFAULT_SCHEME;
+static bool APP_UI_DEFAULT_SCHEME_READY;
+
+static void app_ui_theme_init_default_scheme(void) {
+  if (APP_UI_DEFAULT_SCHEME_READY) {
+    return;
+  }
+
+  const app_design_palette_t *p = &APP_DESIGN_PALETTE;
+  APP_UI_DEFAULT_SCHEME = (app_ui_color_scheme_t){
+      .roles =
+          {
+              [APP_UI_ROLE_TEXT] =
+                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+              [APP_UI_ROLE_TITLE] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_DESCRIPTION] =
+                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+              [APP_UI_ROLE_CODE] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 3), UI_RGBH(110, 78, 20, 3)),
+              [APP_UI_ROLE_PROGRAM] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_MUTED] =
+                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
+              [APP_UI_ROLE_ACCENT] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_COMMENT] =
+                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
+              [APP_UI_ROLE_FLAG] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_FLAG_DEFAULT] =
+                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
+              [APP_UI_ROLE_COMMAND] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_QUOTED_STRING] =
+                  UI_ADAPT(app_ui_rgbh(p->green, 2), UI_RGBH(75, 115, 55, 2)),
+              [APP_UI_ROLE_ARGUMENT] =
+                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+              [APP_UI_ROLE_HELP] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_DASH] =
+                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
+              [APP_UI_ROLE_ERROR_HEADER_FG] =
+                  UI_ADAPT(UI_RGBH(255, 245, 235, 15), UI_RGBH(255, 255, 255, 15)),
+              [APP_UI_ROLE_ERROR_HEADER_BG] =
+                  UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(180, 55, 50, 1)),
+              [APP_UI_ROLE_ERROR_DETAILS] =
+                  UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(145, 40, 35, 1)),
+              [APP_UI_ROLE_SUCCESS] =
+                  UI_ADAPT(app_ui_rgbh(p->green, 2), UI_RGBH(75, 115, 55, 2)),
+              [APP_UI_ROLE_WARNING] =
+                  UI_ADAPT(app_ui_rgbh(p->yellow, 3), UI_RGBH(145, 105, 25, 3)),
+              [APP_UI_ROLE_INFO] =
+                  UI_ADAPT(app_ui_rgbh(p->blue, 4), UI_RGBH(60, 110, 145, 4)),
+              [APP_UI_ROLE_BORDER] =
+                  UI_ADAPT(app_ui_rgbh(p->muted, 7), UI_RGBH(165, 158, 150, 8)),
+              [APP_UI_ROLE_SELECTION_FG] =
+                  UI_ADAPT(app_ui_rgbh(p->near_black, 0), UI_RGBH(255, 255, 255, 15)),
+              [APP_UI_ROLE_SELECTION_BG] =
+                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
+              [APP_UI_ROLE_PANEL] =
+                  UI_ADAPT(app_ui_rgbh(p->panel, 0), UI_RGBH(250, 248, 244, 15)),
+              [APP_UI_ROLE_PANEL_ALT] =
+                  UI_ADAPT(app_ui_rgbh(p->panel_alt, 0), UI_RGBH(242, 238, 232, 7)),
+          },
+  };
+
+  APP_UI_DEFAULT_SCHEME_READY = true;
+}
+
+const app_ui_color_scheme_t *app_ui_theme_default_scheme(void) {
+  app_ui_theme_init_default_scheme();
+  return &APP_UI_DEFAULT_SCHEME;
+}
+
+app_ui_color_t app_ui_theme_pick(const app_ui_color_scheme_t *scheme,
+                                 app_ui_role_id role,
+                                 app_ui_theme_mode_id mode) {
+  if (!scheme || role < 0 || role >= APP_UI_ROLE_COUNT) {
+    return (app_ui_color_t){.kind = APP_UI_COLOR_UNSET};
+  }
+  const app_ui_adaptive_color_t *adaptive = &scheme->roles[role];
+  return mode == APP_UI_THEME_MODE_LIGHT ? adaptive->light : adaptive->dark;
+}
+
+app_ui_resolved_color_t app_ui_color_resolve(app_ui_color_t color,
+                                             app_cli_color_profile_id profile,
+                                             int color_count) {
+  switch (color.kind) {
+  case APP_UI_COLOR_UNSET:
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_NONE};
+  case APP_UI_COLOR_DEFAULT:
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_DEFAULT};
+  default:
+    break;
+  }
+
+  if (profile == APP_CLI_COLOR_PROFILE_TRUECOLOR &&
+      color.kind == APP_UI_COLOR_RGB) {
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_RGB,
+                                     .rgb = color.rgb};
+  }
+
+  if (profile == APP_CLI_COLOR_PROFILE_ANSI256) {
+    uint8_t index;
+    if (color.kind == APP_UI_COLOR_ANSI256) {
+      index = color.ansi256;
+    } else if (color.kind == APP_UI_COLOR_ANSI16) {
+      index = color.ansi16;
+    } else {
+      index = app_color_rgb_to_xterm256(color.rgb);
+    }
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_INDEXED,
+                                     .index = index};
+  }
+
+  if (profile == APP_CLI_COLOR_PROFILE_ANSI16) {
+    uint8_t index;
+    if (color.kind == APP_UI_COLOR_ANSI16) {
+      index = color.ansi16;
+    } else if (color.has_ansi16_hint) {
+      index = color.ansi16_hint;
+    } else if (color.kind == APP_UI_COLOR_ANSI256) {
+      index = color.ansi256 < 16 ? color.ansi256 : 7;
+    } else {
+      index = app_color_rgb_to_ansi16(color.rgb);
+    }
+    // Fold bright colors onto the base 8 for true 8-color terminals.
+    if (color_count > 0 && color_count < 16 && index >= 8) {
+      index = (uint8_t)(index - 8);
+    }
+    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_INDEXED,
+                                     .index = index};
+  }
+
+  return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_NONE};
+}
+
+app_ui_resolved_color_t app_ui_theme_resolve(
+    const app_ui_color_scheme_t *scheme, app_ui_role_id role,
+    app_ui_theme_mode_id mode, app_cli_color_profile_id profile,
+    int color_count) {
+  return app_ui_color_resolve(app_ui_theme_pick(scheme, role, mode), profile,
+                              color_count);
+}
+
+bool app_ui_color_parse(const char *spec, app_ui_color_t *out) {
+  if (!spec || !out || !spec[0]) {
+    return false;
+  }
+  const char *s = (spec[0] == '#') ? spec + 1 : spec;
+  size_t len = strlen(s);
+
+  bool all_hex = len == 6;
+  for (size_t i = 0; all_hex && i < len; i++) {
+    if (!isxdigit((unsigned char)s[i])) {
+      all_hex = false;
+    }
+  }
+  if (all_hex) {
+    const char *p = s;
+    uint8_t ch[3];
+    for (int i = 0; i < 3; i++) {
+      unsigned value;
+      unsigned field_max;
+      if (!app_color_read_hex(&p, p + 2, 2, &value, &field_max)) {
+        return false;
+      }
+      ch[i] = app_color_channel_to_u8(value, field_max);
+    }
+    app_rgb_t rgb = {ch[0], ch[1], ch[2]};
+    *out = (app_ui_color_t){.kind = APP_UI_COLOR_RGB,
+                            .rgb = rgb,
+                            .has_ansi16_hint = true,
+                            .ansi16_hint = app_color_rgb_to_ansi16(rgb)};
+    return true;
+  }
+
+  if (spec[0] != '#' && len > 0) {
+    bool all_digits = true;
+    for (size_t i = 0; i < len; i++) {
+      if (!isdigit((unsigned char)s[i])) {
+        all_digits = false;
+        break;
+      }
+    }
+    if (all_digits) {
+      long v = strtol(s, NULL, 10);
+      if (v < 0 || v > 255) {
+        return false;
+      }
+      if (v < 16) {
+        *out = (app_ui_color_t){.kind = APP_UI_COLOR_ANSI16,
+                                .ansi16 = (uint8_t)v};
+      } else {
+        *out = (app_ui_color_t){.kind = APP_UI_COLOR_ANSI256,
+                                .ansi256 = (uint8_t)v};
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void app_ui_theme_apply_accent(app_ui_color_scheme_t *scheme,
+                               app_ui_color_t accent) {
+  if (!scheme) {
+    return;
+  }
+  static const app_ui_role_id accent_roles[] = {
+      APP_UI_ROLE_TITLE,        APP_UI_ROLE_PROGRAM,
+      APP_UI_ROLE_COMMAND,      APP_UI_ROLE_FLAG,
+      APP_UI_ROLE_HELP,         APP_UI_ROLE_CODE,
+      APP_UI_ROLE_ACCENT,       APP_UI_ROLE_SELECTION_BG,
+  };
+  for (size_t i = 0; i < sizeof(accent_roles) / sizeof(accent_roles[0]); i++) {
+    scheme->roles[accent_roles[i]].dark = accent;
+    scheme->roles[accent_roles[i]].light = accent;
+  }
+}
+
+void app_ui_theme_apply_env_overrides(app_ui_color_scheme_t *scheme) {
+  if (!scheme) {
+    return;
+  }
+  const char *accent = getenv("APP_CLI_ACCENT");
+  if (!accent || !accent[0]) {
+    return;
+  }
+  app_ui_color_t color;
+  if (app_ui_color_parse(accent, &color)) {
+    app_ui_theme_apply_accent(scheme, color);
+  }
+}

--- a/src/style/ui_theme.c
+++ b/src/style/ui_theme.c
@@ -11,14 +11,13 @@
 
 #include "design_tokens.h"
 
-#define UI_RGBH(rr, gg, bb, hint)             \
-  ((app_ui_color_t){.kind = APP_UI_COLOR_RGB, \
+#define UI_RGBH(rr, gg, bb, hint)              \
+  ((app_ui_color_t){.kind = APP_UI_COLOR_RGB,  \
                     .rgb = {(rr), (gg), (bb)}, \
-                    .has_ansi16_hint = true,  \
+                    .has_ansi16_hint = true,   \
                     .ansi16_hint = (hint)})
 
-#define UI_ADAPT(d, l) \
-  ((app_ui_adaptive_color_t){.dark = (d), .light = (l)})
+#define UI_ADAPT(d, l) ((app_ui_adaptive_color_t){.dark = (d), .light = (l)})
 
 static app_ui_color_t app_ui_rgbh(app_rgb_t rgb, uint8_t hint) {
   return (app_ui_color_t){.kind = APP_UI_COLOR_RGB,
@@ -36,63 +35,67 @@ static void app_ui_theme_init_default_scheme(void) {
   }
 
   const app_design_palette_t *p = &APP_DESIGN_PALETTE;
-  APP_UI_DEFAULT_SCHEME = (app_ui_color_scheme_t){
-      .roles =
-          {
-              [APP_UI_ROLE_TEXT] =
-                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
-              [APP_UI_ROLE_TITLE] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_DESCRIPTION] =
-                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
-              [APP_UI_ROLE_CODE] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 3), UI_RGBH(110, 78, 20, 3)),
-              [APP_UI_ROLE_PROGRAM] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_MUTED] =
-                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
-              [APP_UI_ROLE_ACCENT] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_COMMENT] =
-                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
-              [APP_UI_ROLE_FLAG] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_FLAG_DEFAULT] =
-                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
-              [APP_UI_ROLE_COMMAND] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_QUOTED_STRING] =
-                  UI_ADAPT(app_ui_rgbh(p->green, 2), UI_RGBH(75, 115, 55, 2)),
-              [APP_UI_ROLE_ARGUMENT] =
-                  UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
-              [APP_UI_ROLE_HELP] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_DASH] =
-                  UI_ADAPT(app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
-              [APP_UI_ROLE_ERROR_HEADER_FG] =
-                  UI_ADAPT(UI_RGBH(255, 245, 235, 15), UI_RGBH(255, 255, 255, 15)),
-              [APP_UI_ROLE_ERROR_HEADER_BG] =
-                  UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(180, 55, 50, 1)),
-              [APP_UI_ROLE_ERROR_DETAILS] =
-                  UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(145, 40, 35, 1)),
-              [APP_UI_ROLE_SUCCESS] =
-                  UI_ADAPT(app_ui_rgbh(p->green, 2), UI_RGBH(75, 115, 55, 2)),
-              [APP_UI_ROLE_WARNING] =
-                  UI_ADAPT(app_ui_rgbh(p->yellow, 3), UI_RGBH(145, 105, 25, 3)),
-              [APP_UI_ROLE_INFO] =
-                  UI_ADAPT(app_ui_rgbh(p->blue, 4), UI_RGBH(60, 110, 145, 4)),
-              [APP_UI_ROLE_BORDER] =
-                  UI_ADAPT(app_ui_rgbh(p->muted, 7), UI_RGBH(165, 158, 150, 8)),
-              [APP_UI_ROLE_SELECTION_FG] =
-                  UI_ADAPT(app_ui_rgbh(p->near_black, 0), UI_RGBH(255, 255, 255, 15)),
-              [APP_UI_ROLE_SELECTION_BG] =
-                  UI_ADAPT(app_ui_rgbh(p->amber, 11), UI_RGBH(135, 94, 20, 3)),
-              [APP_UI_ROLE_PANEL] =
-                  UI_ADAPT(app_ui_rgbh(p->panel, 0), UI_RGBH(250, 248, 244, 15)),
-              [APP_UI_ROLE_PANEL_ALT] =
-                  UI_ADAPT(app_ui_rgbh(p->panel_alt, 0), UI_RGBH(242, 238, 232, 7)),
-          },
-  };
+  APP_UI_DEFAULT_SCHEME =
+      (app_ui_color_scheme_t){
+          .roles =
+              {
+                  [APP_UI_ROLE_TEXT] =
+                      UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+                  [APP_UI_ROLE_TITLE] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                 UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_DESCRIPTION] =
+                      UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+                  [APP_UI_ROLE_CODE] = UI_ADAPT(app_ui_rgbh(p->amber, 3),
+                                                UI_RGBH(110, 78, 20, 3)),
+                  [APP_UI_ROLE_PROGRAM] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                   UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_MUTED] = UI_ADAPT(app_ui_rgbh(p->muted, 8),
+                                                 UI_RGBH(120, 112, 105, 8)),
+                  [APP_UI_ROLE_ACCENT] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                  UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_COMMENT] = UI_ADAPT(app_ui_rgbh(p->muted, 8),
+                                                   UI_RGBH(120, 112, 105, 8)),
+                  [APP_UI_ROLE_FLAG] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_FLAG_DEFAULT] = UI_ADAPT(
+                      app_ui_rgbh(p->muted, 8), UI_RGBH(120, 112, 105, 8)),
+                  [APP_UI_ROLE_COMMAND] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                   UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_QUOTED_STRING] = UI_ADAPT(
+                      app_ui_rgbh(p->green, 2), UI_RGBH(75, 115, 55, 2)),
+                  [APP_UI_ROLE_ARGUMENT] =
+                      UI_ADAPT(app_ui_rgbh(p->fg, 7), UI_RGBH(60, 56, 54, 0)),
+                  [APP_UI_ROLE_HELP] = UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                                                UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_DASH] = UI_ADAPT(app_ui_rgbh(p->muted, 8),
+                                                UI_RGBH(120, 112, 105, 8)),
+                  [APP_UI_ROLE_ERROR_HEADER_FG] = UI_ADAPT(
+                      UI_RGBH(255, 245, 235, 15), UI_RGBH(255, 255, 255, 15)),
+                  [APP_UI_ROLE_ERROR_HEADER_BG] =
+                      UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(180, 55, 50, 1)),
+                  [APP_UI_ROLE_ERROR_DETAILS] =
+                      UI_ADAPT(app_ui_rgbh(p->red, 1), UI_RGBH(145, 40, 35, 1)),
+                  [APP_UI_ROLE_SUCCESS] = UI_ADAPT(app_ui_rgbh(p->green, 2),
+                                                   UI_RGBH(75, 115, 55, 2)),
+                  [APP_UI_ROLE_WARNING] = UI_ADAPT(app_ui_rgbh(p->yellow, 3),
+                                                   UI_RGBH(145, 105, 25, 3)),
+                  [APP_UI_ROLE_INFO] = UI_ADAPT(app_ui_rgbh(p->blue, 4),
+                                                UI_RGBH(60, 110, 145, 4)),
+                  [APP_UI_ROLE_BORDER] = UI_ADAPT(app_ui_rgbh(p->muted, 7),
+                                                  UI_RGBH(165, 158, 150, 8)),
+                  [APP_UI_ROLE_SELECTION_FG] =
+                      UI_ADAPT(app_ui_rgbh(p->near_black, 0),
+                               UI_RGBH(255, 255, 255, 15)),
+                  [APP_UI_ROLE_SELECTION_BG] =
+                      UI_ADAPT(app_ui_rgbh(p->amber, 11),
+                               UI_RGBH(135, 94, 20, 3)),
+                  [APP_UI_ROLE_PANEL] = UI_ADAPT(app_ui_rgbh(p->panel, 0),
+                                                 UI_RGBH(250, 248, 244, 15)),
+                  [APP_UI_ROLE_PANEL_ALT] =
+                      UI_ADAPT(app_ui_rgbh(p->panel_alt, 0),
+                               UI_RGBH(242, 238, 232, 7)),
+              },
+      };
 
   APP_UI_DEFAULT_SCHEME_READY = true;
 }
@@ -233,8 +236,8 @@ bool app_ui_color_parse(const char *spec, app_ui_color_t *out) {
         return false;
       }
       if (v < 16) {
-        *out = (app_ui_color_t){.kind = APP_UI_COLOR_ANSI16,
-                                .ansi16 = (uint8_t)v};
+        *out =
+            (app_ui_color_t){.kind = APP_UI_COLOR_ANSI16, .ansi16 = (uint8_t)v};
       } else {
         *out = (app_ui_color_t){.kind = APP_UI_COLOR_ANSI256,
                                 .ansi256 = (uint8_t)v};
@@ -252,10 +255,9 @@ void app_ui_theme_apply_accent(app_ui_color_scheme_t *scheme,
     return;
   }
   static const app_ui_role_id accent_roles[] = {
-      APP_UI_ROLE_TITLE,        APP_UI_ROLE_PROGRAM,
-      APP_UI_ROLE_COMMAND,      APP_UI_ROLE_FLAG,
-      APP_UI_ROLE_HELP,         APP_UI_ROLE_CODE,
-      APP_UI_ROLE_ACCENT,       APP_UI_ROLE_SELECTION_BG,
+      APP_UI_ROLE_TITLE,  APP_UI_ROLE_PROGRAM,      APP_UI_ROLE_COMMAND,
+      APP_UI_ROLE_FLAG,   APP_UI_ROLE_HELP,         APP_UI_ROLE_CODE,
+      APP_UI_ROLE_ACCENT, APP_UI_ROLE_SELECTION_BG,
   };
   for (size_t i = 0; i < sizeof(accent_roles) / sizeof(accent_roles[0]); i++) {
     scheme->roles[accent_roles[i]].dark = accent;

--- a/src/style/ui_theme.c
+++ b/src/style/ui_theme.c
@@ -124,10 +124,24 @@ app_ui_resolved_color_t app_ui_color_resolve(app_ui_color_t color,
     break;
   }
 
-  if (profile == APP_CLI_COLOR_PROFILE_TRUECOLOR &&
-      color.kind == APP_UI_COLOR_RGB) {
-    return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_RGB,
-                                     .rgb = color.rgb};
+  if (profile == APP_CLI_COLOR_PROFILE_TRUECOLOR) {
+    if (color.kind == APP_UI_COLOR_RGB) {
+      return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_RGB,
+                                       .rgb = color.rgb};
+    }
+    // An explicit palette index renders fine on a truecolor terminal, so pass
+    // it through as INDEXED rather than dropping it. Without this, an
+    // all-indexed theme (e.g. "mono", whose every role is an ANSI16 index)
+    // would resolve to NONE and render colorless on the common truecolor
+    // profile.
+    if (color.kind == APP_UI_COLOR_ANSI256) {
+      return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_INDEXED,
+                                       .index = color.ansi256};
+    }
+    if (color.kind == APP_UI_COLOR_ANSI16) {
+      return (app_ui_resolved_color_t){.kind = APP_UI_RESOLVED_INDEXED,
+                                       .index = color.ansi16};
+    }
   }
 
   if (profile == APP_CLI_COLOR_PROFILE_ANSI256) {

--- a/src/style/ui_theme.h
+++ b/src/style/ui_theme.h
@@ -41,32 +41,32 @@ typedef enum app_ui_theme_mode_id {
   APP_UI_THEME_MODE_LIGHT,
 } app_ui_theme_mode_id;
 
-#define APP_UI_ROLE_LIST(X)                         \
-  X(TEXT, text, "Text")                            \
-  X(TITLE, title, "Title")                         \
-  X(DESCRIPTION, description, "Description")       \
-  X(CODE, code, "Code")                            \
-  X(PROGRAM, program, "Program")                   \
-  X(MUTED, muted, "Muted")                         \
-  X(ACCENT, accent, "Accent")                      \
-  X(COMMENT, comment, "Comment")                   \
-  X(FLAG, flag, "Flag")                            \
-  X(FLAG_DEFAULT, flag_default, "FlagDefault")     \
-  X(COMMAND, command, "Command")                   \
-  X(QUOTED_STRING, quoted_string, "QuotedString")  \
-  X(ARGUMENT, argument, "Argument")                \
-  X(HELP, help, "Help")                            \
-  X(DASH, dash, "Dash")                            \
+#define APP_UI_ROLE_LIST(X)                            \
+  X(TEXT, text, "Text")                                \
+  X(TITLE, title, "Title")                             \
+  X(DESCRIPTION, description, "Description")           \
+  X(CODE, code, "Code")                                \
+  X(PROGRAM, program, "Program")                       \
+  X(MUTED, muted, "Muted")                             \
+  X(ACCENT, accent, "Accent")                          \
+  X(COMMENT, comment, "Comment")                       \
+  X(FLAG, flag, "Flag")                                \
+  X(FLAG_DEFAULT, flag_default, "FlagDefault")         \
+  X(COMMAND, command, "Command")                       \
+  X(QUOTED_STRING, quoted_string, "QuotedString")      \
+  X(ARGUMENT, argument, "Argument")                    \
+  X(HELP, help, "Help")                                \
+  X(DASH, dash, "Dash")                                \
   X(ERROR_HEADER_FG, error_header_fg, "ErrorHeaderFg") \
   X(ERROR_HEADER_BG, error_header_bg, "ErrorHeaderBg") \
-  X(ERROR_DETAILS, error_details, "ErrorDetails")  \
-  X(SUCCESS, success, "Success")                   \
-  X(WARNING, warning, "Warning")                   \
-  X(INFO, info, "Info")                            \
-  X(BORDER, border, "Border")                      \
-  X(SELECTION_FG, selection_fg, "SelectionFg")     \
-  X(SELECTION_BG, selection_bg, "SelectionBg")     \
-  X(PANEL, panel, "Panel")                         \
+  X(ERROR_DETAILS, error_details, "ErrorDetails")      \
+  X(SUCCESS, success, "Success")                       \
+  X(WARNING, warning, "Warning")                       \
+  X(INFO, info, "Info")                                \
+  X(BORDER, border, "Border")                          \
+  X(SELECTION_FG, selection_fg, "SelectionFg")         \
+  X(SELECTION_BG, selection_bg, "SelectionBg")         \
+  X(PANEL, panel, "Panel")                             \
   X(PANEL_ALT, panel_alt, "PanelAlt")
 
 typedef enum app_ui_role_id {
@@ -114,11 +114,10 @@ app_ui_resolved_color_t app_ui_color_resolve(app_ui_color_t color,
                                              int color_count);
 
 /* Resolve a role from a scheme for a mode + profile in one call. */
-app_ui_resolved_color_t app_ui_theme_resolve(const app_ui_color_scheme_t *scheme,
-                                             app_ui_role_id role,
-                                             app_ui_theme_mode_id mode,
-                                             app_cli_color_profile_id profile,
-                                             int color_count);
+app_ui_resolved_color_t app_ui_theme_resolve(
+    const app_ui_color_scheme_t *scheme, app_ui_role_id role,
+    app_ui_theme_mode_id mode, app_cli_color_profile_id profile,
+    int color_count);
 
 /* Parse "#rrggbb"/"rrggbb" RGB or decimal ANSI palette index 0..255. */
 bool app_ui_color_parse(const char *spec, app_ui_color_t *out);

--- a/src/style/ui_theme.h
+++ b/src/style/ui_theme.h
@@ -1,0 +1,132 @@
+/*
+ * Shared semantic terminal UI theme.
+ *
+ * design_tokens.* owns raw RGB palette values. This module gives those values
+ * names that both renderers can agree on: CLI SGR tokens and ncurses color
+ * pairs map to these roles, then degrade through their own terminal backends.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "color_math.h"
+
+typedef enum app_ui_color_kind_id {
+  APP_UI_COLOR_UNSET = 0,
+  APP_UI_COLOR_RGB,
+  APP_UI_COLOR_ANSI256,
+  APP_UI_COLOR_ANSI16,
+  APP_UI_COLOR_DEFAULT,
+} app_ui_color_kind_id;
+
+typedef struct app_ui_color {
+  app_ui_color_kind_id kind;
+  app_rgb_t rgb;
+  uint8_t ansi256;
+  uint8_t ansi16;
+  /* Semantic ANSI-16 fallback hint so amber degrades to yellow, not gray. */
+  bool has_ansi16_hint;
+  uint8_t ansi16_hint;
+} app_ui_color_t;
+
+typedef struct app_ui_adaptive_color {
+  app_ui_color_t dark;
+  app_ui_color_t light;
+} app_ui_adaptive_color_t;
+
+typedef enum app_ui_theme_mode_id {
+  APP_UI_THEME_MODE_DARK = 0,
+  APP_UI_THEME_MODE_LIGHT,
+} app_ui_theme_mode_id;
+
+#define APP_UI_ROLE_LIST(X)                         \
+  X(TEXT, text, "Text")                            \
+  X(TITLE, title, "Title")                         \
+  X(DESCRIPTION, description, "Description")       \
+  X(CODE, code, "Code")                            \
+  X(PROGRAM, program, "Program")                   \
+  X(MUTED, muted, "Muted")                         \
+  X(ACCENT, accent, "Accent")                      \
+  X(COMMENT, comment, "Comment")                   \
+  X(FLAG, flag, "Flag")                            \
+  X(FLAG_DEFAULT, flag_default, "FlagDefault")     \
+  X(COMMAND, command, "Command")                   \
+  X(QUOTED_STRING, quoted_string, "QuotedString")  \
+  X(ARGUMENT, argument, "Argument")                \
+  X(HELP, help, "Help")                            \
+  X(DASH, dash, "Dash")                            \
+  X(ERROR_HEADER_FG, error_header_fg, "ErrorHeaderFg") \
+  X(ERROR_HEADER_BG, error_header_bg, "ErrorHeaderBg") \
+  X(ERROR_DETAILS, error_details, "ErrorDetails")  \
+  X(SUCCESS, success, "Success")                   \
+  X(WARNING, warning, "Warning")                   \
+  X(INFO, info, "Info")                            \
+  X(BORDER, border, "Border")                      \
+  X(SELECTION_FG, selection_fg, "SelectionFg")     \
+  X(SELECTION_BG, selection_bg, "SelectionBg")     \
+  X(PANEL, panel, "Panel")                         \
+  X(PANEL_ALT, panel_alt, "PanelAlt")
+
+typedef enum app_ui_role_id {
+#define APP_UI_ROLE_ENUM(upper, field, label) APP_UI_ROLE_##upper,
+  APP_UI_ROLE_LIST(APP_UI_ROLE_ENUM)
+#undef APP_UI_ROLE_ENUM
+      APP_UI_ROLE_COUNT,
+} app_ui_role_id;
+
+typedef struct app_ui_color_scheme {
+  app_ui_adaptive_color_t roles[APP_UI_ROLE_COUNT];
+} app_ui_color_scheme_t;
+
+const app_ui_color_scheme_t *app_ui_theme_default_scheme(void);
+
+app_ui_color_t app_ui_theme_pick(const app_ui_color_scheme_t *scheme,
+                                 app_ui_role_id role,
+                                 app_ui_theme_mode_id mode);
+
+/* A semantic color resolved against a concrete terminal color profile, ready to
+ * realize as an SGR sequence (stream surface) or a curses color. This is the
+ * single shared degradation result that both render surfaces and the CLI
+ * styling layer agree on. */
+typedef enum app_ui_resolved_kind_id {
+  APP_UI_RESOLVED_NONE = 0, /* emit nothing (token absent) */
+  APP_UI_RESOLVED_INDEXED,  /* ANSI index 0..255 */
+  APP_UI_RESOLVED_RGB,      /* truecolor */
+  APP_UI_RESOLVED_DEFAULT,  /* terminal default fg/bg */
+} app_ui_resolved_kind_id;
+
+typedef struct app_ui_resolved_color {
+  app_ui_resolved_kind_id kind;
+  uint16_t index;
+  app_rgb_t rgb;
+} app_ui_resolved_color_t;
+
+/* Degrade one semantic color to a concrete profile. This is THE shared
+ * resolver: truecolor keeps RGB; ANSI256 downsamples through the xterm-256
+ * cube; ANSI16 prefers each color's semantic ansi16 hint and folds bright
+ * indices onto the base 8 when the terminal only has 8 colors. The CLI styling
+ * layer (app_cli_styles_compile) delegates here so the stream surface, the
+ * curses surface, and the help/error renderers all degrade identically. */
+app_ui_resolved_color_t app_ui_color_resolve(app_ui_color_t color,
+                                             app_cli_color_profile_id profile,
+                                             int color_count);
+
+/* Resolve a role from a scheme for a mode + profile in one call. */
+app_ui_resolved_color_t app_ui_theme_resolve(const app_ui_color_scheme_t *scheme,
+                                             app_ui_role_id role,
+                                             app_ui_theme_mode_id mode,
+                                             app_cli_color_profile_id profile,
+                                             int color_count);
+
+/* Parse "#rrggbb"/"rrggbb" RGB or decimal ANSI palette index 0..255. */
+bool app_ui_color_parse(const char *spec, app_ui_color_t *out);
+
+/* Apply a concrete accent to every role that represents the product accent. */
+void app_ui_theme_apply_accent(app_ui_color_scheme_t *scheme,
+                               app_ui_color_t accent);
+
+/* Apply environment overrides. Currently honors APP_CLI_ACCENT for both the
+ * styled CLI and generated TUI; the name is kept for compatibility. */
+void app_ui_theme_apply_env_overrides(app_ui_color_scheme_t *scheme);

--- a/src/surface/surface.c
+++ b/src/surface/surface.c
@@ -3,14 +3,14 @@
  *
  * This translation unit is linked into every build that has either front-end.
  * It contains NO curses code; the curses backend lives in surface_curses.c and
- * is reached only through the ops vtable, so a CLI-only or unit-test build links
- * this file without pulling in ncurses.
+ * is reached only through the ops vtable, so a CLI-only or unit-test build
+ * links this file without pulling in ncurses.
  */
-
-#include "surface_internal.h"
 
 #include <stdlib.h>
 #include <string.h>
+
+#include "surface_internal.h"
 
 cs_surface_t *cs_surface_alloc_(const cs_theme_t *theme) {
   cs_surface_t *s = calloc(1, sizeof *s);
@@ -89,7 +89,7 @@ static void stream_newline(cs_surface_t *s) {
 static void stream_move(cs_surface_t *s, int x, int y) {
   (void)s;
   (void)x;
-  (void)y; // a stream flows top-to-bottom; positioning is a no-op
+  (void)y;  // a stream flows top-to-bottom; positioning is a no-op
 }
 
 static void stream_destroy(cs_surface_t *s) {
@@ -135,9 +135,8 @@ cs_surface_t *cs_surface_stream_new(FILE *stream, const app_config_t *config,
   };
 #else
   (void)config;
-  s->caps = (cs_caps_t){.unicode = true,
-                        .profile = APP_CLI_COLOR_PROFILE_NONE,
-                        .width = 80};
+  s->caps = (cs_caps_t){
+      .unicode = true, .profile = APP_CLI_COLOR_PROFILE_NONE, .width = 80};
 #endif
   return s;
 }

--- a/src/surface/surface.c
+++ b/src/surface/surface.c
@@ -21,6 +21,41 @@ cs_surface_t *cs_surface_alloc_(const cs_theme_t *theme) {
   return s;
 }
 
+static bool contains_ascii_ci(const char *haystack, const char *needle) {
+  if (!haystack || !needle || !needle[0]) {
+    return false;
+  }
+  for (const char *h = haystack; *h; h++) {
+    const char *hp = h;
+    const char *np = needle;
+    while (*hp && *np) {
+      char hc = (*hp >= 'A' && *hp <= 'Z') ? (char)(*hp - 'A' + 'a') : *hp;
+      char nc = (*np >= 'A' && *np <= 'Z') ? (char)(*np - 'A' + 'a') : *np;
+      if (hc != nc) {
+        break;
+      }
+      hp++;
+      np++;
+    }
+    if (!*np) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool cs_surface_unicode_enabled_(void) {
+  const char *vars[] = {"LC_ALL", "LC_CTYPE", "LANG"};
+  for (size_t i = 0; i < sizeof(vars) / sizeof(vars[0]); i++) {
+    const char *value = getenv(vars[i]);
+    if (value && value[0]) {
+      return contains_ascii_ci(value, "utf-8") ||
+             contains_ascii_ci(value, "utf8");
+    }
+  }
+  return false;
+}
+
 // ---- stream backend -------------------------------------------------------
 
 static void stream_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
@@ -127,7 +162,7 @@ cs_surface_t *cs_surface_stream_new(FILE *stream, const app_config_t *config,
   s->caps = (cs_caps_t){
       .tty = s->term.is_tty,
       .color = styled,
-      .unicode = true,
+      .unicode = cs_surface_unicode_enabled_(),
       .interactive = s->term.is_tty,
       .profile = s->term.profile,
       .color_count = s->term.color_count,
@@ -135,8 +170,9 @@ cs_surface_t *cs_surface_stream_new(FILE *stream, const app_config_t *config,
   };
 #else
   (void)config;
-  s->caps = (cs_caps_t){
-      .unicode = true, .profile = APP_CLI_COLOR_PROFILE_NONE, .width = 80};
+  s->caps = (cs_caps_t){.unicode = cs_surface_unicode_enabled_(),
+                        .profile = APP_CLI_COLOR_PROFILE_NONE,
+                        .width = 80};
 #endif
   return s;
 }

--- a/src/surface/surface.c
+++ b/src/surface/surface.c
@@ -1,0 +1,238 @@
+/*
+ * cs_surface — public dispatch + the stream backend. See surface.h.
+ *
+ * This translation unit is linked into every build that has either front-end.
+ * It contains NO curses code; the curses backend lives in surface_curses.c and
+ * is reached only through the ops vtable, so a CLI-only or unit-test build links
+ * this file without pulling in ncurses.
+ */
+
+#include "surface_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+cs_surface_t *cs_surface_alloc_(const cs_theme_t *theme) {
+  cs_surface_t *s = calloc(1, sizeof *s);
+  if (!s) {
+    return NULL;
+  }
+  s->theme = theme ? *theme : cs_theme_default();
+  return s;
+}
+
+// ---- stream backend -------------------------------------------------------
+
+static void stream_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
+#ifdef APP_ENABLE_CLI_STYLE
+  app_ui_resolved_color_t r =
+      cs_theme_resolve(&s->theme, role, s->caps.profile, s->caps.color_count);
+  switch (r.kind) {
+  case APP_UI_RESOLVED_RGB:
+    app_cli_term_emit_truecolor(&s->term, bg, r.rgb);
+    break;
+  case APP_UI_RESOLVED_INDEXED:
+    app_cli_term_emit_indexed(&s->term, bg, r.index);
+    break;
+  case APP_UI_RESOLVED_DEFAULT:
+  case APP_UI_RESOLVED_NONE:
+  default:
+    break;
+  }
+#else
+  (void)s;
+  (void)role;
+  (void)bg;
+#endif
+}
+
+static void stream_set_attr(cs_surface_t *s, cs_attr_t attrs) {
+#ifdef APP_ENABLE_CLI_STYLE
+  if (attrs & CS_ATTR_BOLD) {
+    app_cli_term_emit_attr(&s->term, APP_CLI_ATTR_BOLD);
+  }
+  if (attrs & CS_ATTR_DIM) {
+    app_cli_term_emit_attr(&s->term, APP_CLI_ATTR_DIM);
+  }
+  if (attrs & CS_ATTR_UNDERLINE) {
+    app_cli_term_emit_attr(&s->term, APP_CLI_ATTR_UNDERLINE);
+  }
+  if (attrs & CS_ATTR_ITALIC) {
+    app_cli_term_emit_attr(&s->term, APP_CLI_ATTR_ITALIC);
+  }
+#else
+  (void)s;
+  (void)attrs;
+#endif
+}
+
+static void stream_reset(cs_surface_t *s) {
+#ifdef APP_ENABLE_CLI_STYLE
+  app_cli_term_emit_reset(&s->term);
+#else
+  (void)s;
+#endif
+}
+
+static void stream_write_n(cs_surface_t *s, const char *text, size_t n) {
+  if (s->stream_fp && text && n) {
+    fwrite(text, 1, n, s->stream_fp);
+  }
+}
+
+static void stream_newline(cs_surface_t *s) {
+  if (s->stream_fp) {
+    fputc('\n', s->stream_fp);
+  }
+}
+
+static void stream_move(cs_surface_t *s, int x, int y) {
+  (void)s;
+  (void)x;
+  (void)y; // a stream flows top-to-bottom; positioning is a no-op
+}
+
+static void stream_destroy(cs_surface_t *s) {
+#ifdef APP_ENABLE_CLI_STYLE
+  if (s->have_term) {
+    app_cli_term_deinit(&s->term);
+  }
+#else
+  (void)s;
+#endif
+}
+
+static const cs_surface_ops_t cs_stream_ops = {
+    .set_color = stream_set_color,
+    .set_attr = stream_set_attr,
+    .reset = stream_reset,
+    .write_n = stream_write_n,
+    .newline = stream_newline,
+    .move = stream_move,
+    .destroy = stream_destroy,
+};
+
+cs_surface_t *cs_surface_stream_new(FILE *stream, const app_config_t *config,
+                                    const cs_theme_t *theme) {
+  cs_surface_t *s = cs_surface_alloc_(theme);
+  if (!s) {
+    return NULL;
+  }
+  s->ops = &cs_stream_ops;
+  s->stream_fp = stream;
+#ifdef APP_ENABLE_CLI_STYLE
+  app_cli_term_opts_t opts = {0};
+  bool styled = app_cli_term_init(&s->term, stream, config, &opts);
+  s->have_term = true;
+  s->caps = (cs_caps_t){
+      .tty = s->term.is_tty,
+      .color = styled,
+      .unicode = true,
+      .interactive = s->term.is_tty,
+      .profile = s->term.profile,
+      .color_count = s->term.color_count,
+      .width = s->term.width ? s->term.width : 80,
+  };
+#else
+  (void)config;
+  s->caps = (cs_caps_t){.unicode = true,
+                        .profile = APP_CLI_COLOR_PROFILE_NONE,
+                        .width = 80};
+#endif
+  return s;
+}
+
+// ---- public dispatch ------------------------------------------------------
+
+void cs_surface_free(cs_surface_t *s) {
+  if (!s) {
+    return;
+  }
+  if (s->ops && s->ops->destroy) {
+    s->ops->destroy(s);
+  }
+  free(s);
+}
+
+cs_caps_t cs_surface_caps(const cs_surface_t *s) {
+  return s ? s->caps : (cs_caps_t){0};
+}
+
+size_t cs_surface_width(const cs_surface_t *s) {
+  return s ? s->caps.width : 0;
+}
+
+const cs_theme_t *cs_surface_theme(const cs_surface_t *s) {
+  return s ? &s->theme : NULL;
+}
+
+void cs_surface_set_role(cs_surface_t *s, cs_role_t role) {
+  if (s && s->ops) {
+    s->ops->set_color(s, role, false);
+  }
+}
+
+void cs_surface_set_role_bg(cs_surface_t *s, cs_role_t role) {
+  if (s && s->ops) {
+    s->ops->set_color(s, role, true);
+  }
+}
+
+void cs_surface_set_attr(cs_surface_t *s, cs_attr_t attrs) {
+  if (s && s->ops) {
+    s->ops->set_attr(s, attrs);
+  }
+}
+
+void cs_surface_reset(cs_surface_t *s) {
+  if (s && s->ops) {
+    s->ops->reset(s);
+  }
+}
+
+void cs_surface_write_n(cs_surface_t *s, const char *text, size_t n) {
+  if (s && s->ops) {
+    s->ops->write_n(s, text, n);
+  }
+}
+
+void cs_surface_write(cs_surface_t *s, const char *utf8) {
+  if (utf8) {
+    cs_surface_write_n(s, utf8, strlen(utf8));
+  }
+}
+
+void cs_surface_repeat(cs_surface_t *s, const char *glyph, size_t count) {
+  if (!s || !glyph || !glyph[0]) {
+    return;
+  }
+  size_t len = strlen(glyph);
+  for (size_t i = 0; i < count; i++) {
+    cs_surface_write_n(s, glyph, len);
+  }
+}
+
+void cs_surface_newline(cs_surface_t *s) {
+  if (s && s->ops) {
+    s->ops->newline(s);
+  }
+}
+
+void cs_surface_move(cs_surface_t *s, int x, int y) {
+  if (s && s->ops) {
+    s->ops->move(s, x, y);
+  }
+}
+
+void cs_surface_styled(cs_surface_t *s, cs_role_t role, cs_attr_t attrs,
+                       const char *text) {
+  if (!s || !text) {
+    return;
+  }
+  cs_surface_set_role(s, role);
+  if (attrs) {
+    cs_surface_set_attr(s, attrs);
+  }
+  cs_surface_write(s, text);
+  cs_surface_reset(s);
+}

--- a/src/surface/surface.h
+++ b/src/surface/surface.h
@@ -30,8 +30,8 @@
 typedef struct app_config app_config_t;
 typedef struct tui_window tui_window_t;
 
-// Text attributes (bit mask). Bit positions mirror the CLI attribute bits so the
-// stream backend maps them directly; the curses backend maps to A_BOLD etc.
+// Text attributes (bit mask). Bit positions mirror the CLI attribute bits so
+// the stream backend maps them directly; the curses backend maps to A_BOLD etc.
 typedef uint32_t cs_attr_t;
 enum {
   CS_ATTR_NONE = 0,
@@ -83,8 +83,9 @@ void cs_surface_set_attr(cs_surface_t *s, cs_attr_t attrs);
 void cs_surface_reset(cs_surface_t *s);
 
 // Output. Writes are UTF-8. repeat() emits `glyph` `count` times (for rules and
-// padding); newline() moves to the next row at the left margin; move() positions
-// the cursor (curses only — a no-op on a stream, which flows top-to-bottom).
+// padding); newline() moves to the next row at the left margin; move()
+// positions the cursor (curses only — a no-op on a stream, which flows
+// top-to-bottom).
 void cs_surface_write(cs_surface_t *s, const char *utf8);
 void cs_surface_write_n(cs_surface_t *s, const char *utf8, size_t n);
 void cs_surface_repeat(cs_surface_t *s, const char *glyph, size_t count);

--- a/src/surface/surface.h
+++ b/src/surface/surface.h
@@ -1,0 +1,96 @@
+/*
+ * cs_surface — the neutral render surface every Curspan component draws to.
+ *
+ * A surface is a styled, role-aware drawing target that hides whether output
+ * goes to a byte stream (CLI: SGR escapes, degrades by color profile) or an
+ * ncurses window (TUI: color pairs). Components call the same small API on
+ * either, so one component renders identically on a piped CLI, a truecolor
+ * terminal, and inside a TUI screen — the surface owns capability detection and
+ * color degradation; components stay pure layout + semantics.
+ *
+ *   cs_surface_t *s = cs_surface_stream_new(stdout, config, &theme);
+ *   cs_surface_set_role(s, CS_ROLE_TITLE);
+ *   cs_surface_write(s, "Hello");
+ *   cs_surface_reset(s);
+ *   cs_surface_newline(s);
+ *   cs_surface_free(s);
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../style/cs_theme.h"
+
+// Forward declarations keep this header free of <ncurses.h> and config.h, so it
+// is safe to include from the umbrella header in any build configuration.
+typedef struct app_config app_config_t;
+typedef struct tui_window tui_window_t;
+
+// Text attributes (bit mask). Bit positions mirror the CLI attribute bits so the
+// stream backend maps them directly; the curses backend maps to A_BOLD etc.
+typedef uint32_t cs_attr_t;
+enum {
+  CS_ATTR_NONE = 0,
+  CS_ATTR_BOLD = 1u << 0,
+  CS_ATTR_DIM = 1u << 1,
+  CS_ATTR_UNDERLINE = 1u << 2,
+  CS_ATTR_ITALIC = 1u << 3,
+};
+
+// What a surface can do. Components branch on these to degrade gracefully (e.g.
+// ASCII glyphs when !unicode, no interactive prompts when !interactive).
+typedef struct cs_caps {
+  bool tty;                          // attached to a terminal
+  bool color;                        // styling will actually be emitted
+  bool unicode;                      // UTF-8 box/glyph drawing is safe
+  bool interactive;                  // can read keys (TUI / TTY)
+  app_cli_color_profile_id profile;  // none/16/256/truecolor
+  int color_count;                   // palette size, when known
+  size_t width;                      // usable columns
+} cs_caps_t;
+
+typedef struct cs_surface cs_surface_t;
+
+// Create a stream surface over `stream` (e.g. stdout/stderr). `config` supplies
+// the color policy (NO_COLOR/--plain/--json/...); pass NULL for capability-only
+// detection. `theme` is copied; pass NULL for the default theme. Never returns
+// NULL on success; returns NULL only on allocation failure.
+cs_surface_t *cs_surface_stream_new(FILE *stream, const app_config_t *config,
+                                    const cs_theme_t *theme);
+
+#ifdef ENABLE_TUI
+// Create a curses surface that draws into `window`. Requires tui_init() and
+// tui_init_colors() to have run. `theme` is copied; pass NULL for the default.
+cs_surface_t *cs_surface_curses_new(tui_window_t *window,
+                                    const cs_theme_t *theme);
+#endif
+
+void cs_surface_free(cs_surface_t *s);
+
+// Introspection.
+cs_caps_t cs_surface_caps(const cs_surface_t *s);
+size_t cs_surface_width(const cs_surface_t *s);
+const cs_theme_t *cs_surface_theme(const cs_surface_t *s);
+
+// Styling. set_role/set_role_bg/set_attr are additive until cs_surface_reset.
+void cs_surface_set_role(cs_surface_t *s, cs_role_t role);
+void cs_surface_set_role_bg(cs_surface_t *s, cs_role_t role);
+void cs_surface_set_attr(cs_surface_t *s, cs_attr_t attrs);
+void cs_surface_reset(cs_surface_t *s);
+
+// Output. Writes are UTF-8. repeat() emits `glyph` `count` times (for rules and
+// padding); newline() moves to the next row at the left margin; move() positions
+// the cursor (curses only — a no-op on a stream, which flows top-to-bottom).
+void cs_surface_write(cs_surface_t *s, const char *utf8);
+void cs_surface_write_n(cs_surface_t *s, const char *utf8, size_t n);
+void cs_surface_repeat(cs_surface_t *s, const char *glyph, size_t count);
+void cs_surface_newline(cs_surface_t *s);
+void cs_surface_move(cs_surface_t *s, int x, int y);
+
+// Convenience: write `text` in `role` (with optional attrs) then reset.
+void cs_surface_styled(cs_surface_t *s, cs_role_t role, cs_attr_t attrs,
+                       const char *text);

--- a/src/surface/surface_curses.c
+++ b/src/surface/surface_curses.c
@@ -1,0 +1,162 @@
+/*
+ * cs_surface — curses backend. See surface.h.
+ *
+ * Linked only into TUI builds (ENABLE_TUI). All ncurses contact is isolated
+ * here; surface.c reaches these functions solely through the ops vtable, so a
+ * CLI-only or unit-test build never references a curses symbol.
+ *
+ * Curses color pairs fix foreground and background together, so a role maps to
+ * the nearest existing TUI_COLOR_* pair (set up by tui_init_colors). This keeps
+ * components visually consistent with the rest of the TUI without managing a
+ * second, parallel pool of init_color slots.
+ */
+
+#include "surface_internal.h"
+
+#ifdef ENABLE_TUI
+
+#include "../tui/tui.h"
+
+static tui_color_pair_t cs_role_to_pair(cs_role_t role) {
+  switch (role) {
+  case APP_UI_ROLE_TITLE:
+  case APP_UI_ROLE_PROGRAM:
+  case APP_UI_ROLE_COMMAND:
+  case APP_UI_ROLE_FLAG:
+  case APP_UI_ROLE_HELP:
+    return TUI_COLOR_TITLE;
+  case APP_UI_ROLE_ACCENT:
+  case APP_UI_ROLE_CODE:
+    return TUI_COLOR_ACCENT;
+  case APP_UI_ROLE_MUTED:
+  case APP_UI_ROLE_COMMENT:
+  case APP_UI_ROLE_FLAG_DEFAULT:
+  case APP_UI_ROLE_DASH:
+    return TUI_COLOR_DIM;
+  case APP_UI_ROLE_BORDER:
+    return TUI_COLOR_BORDER;
+  case APP_UI_ROLE_SUCCESS:
+  case APP_UI_ROLE_QUOTED_STRING:
+    return TUI_COLOR_SUCCESS;
+  case APP_UI_ROLE_WARNING:
+    return TUI_COLOR_WARNING;
+  case APP_UI_ROLE_INFO:
+    return TUI_COLOR_INFO;
+  case APP_UI_ROLE_ERROR_DETAILS:
+  case APP_UI_ROLE_ERROR_HEADER_FG:
+  case APP_UI_ROLE_ERROR_HEADER_BG:
+    return TUI_COLOR_ERROR;
+  case APP_UI_ROLE_SELECTION_FG:
+  case APP_UI_ROLE_SELECTION_BG:
+    return TUI_COLOR_HIGHLIGHT;
+  case APP_UI_ROLE_TEXT:
+  case APP_UI_ROLE_DESCRIPTION:
+  case APP_UI_ROLE_ARGUMENT:
+  default:
+    return TUI_COLOR_MENU_NORMAL;
+  }
+}
+
+static WINDOW *curses_win(cs_surface_t *s) {
+  return s->window ? s->window->win : NULL;
+}
+
+static void curses_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
+  (void)bg; // pairs fix fg+bg together; see cs_surface_set_role_bg
+  WINDOW *w = curses_win(s);
+  if (w && tui_colors_enabled()) {
+    wattron(w, COLOR_PAIR(cs_role_to_pair(role)));
+  }
+}
+
+static void curses_set_attr(cs_surface_t *s, cs_attr_t attrs) {
+  WINDOW *w = curses_win(s);
+  if (!w) {
+    return;
+  }
+  if (attrs & CS_ATTR_BOLD) {
+    wattron(w, A_BOLD);
+  }
+  if (attrs & CS_ATTR_DIM) {
+    wattron(w, A_DIM);
+  }
+  if (attrs & CS_ATTR_UNDERLINE) {
+    wattron(w, A_UNDERLINE);
+  }
+#ifdef A_ITALIC
+  if (attrs & CS_ATTR_ITALIC) {
+    wattron(w, A_ITALIC);
+  }
+#endif
+}
+
+static void curses_reset(cs_surface_t *s) {
+  WINDOW *w = curses_win(s);
+  if (w) {
+    wattrset(w, A_NORMAL);
+  }
+}
+
+static void curses_write_n(cs_surface_t *s, const char *text, size_t n) {
+  WINDOW *w = curses_win(s);
+  if (w && text && n) {
+    waddnstr(w, text, (int)n);
+  }
+}
+
+static void curses_newline(cs_surface_t *s) {
+  WINDOW *w = curses_win(s);
+  if (!w) {
+    return;
+  }
+  int y, x;
+  getyx(w, y, x);
+  (void)x;
+  wmove(w, y + 1, 0);
+}
+
+static void curses_move(cs_surface_t *s, int x, int y) {
+  WINDOW *w = curses_win(s);
+  if (w) {
+    wmove(w, y, x);
+  }
+}
+
+static void curses_destroy(cs_surface_t *s) {
+  (void)s; // the window is owned by the caller
+}
+
+static const cs_surface_ops_t cs_curses_ops = {
+    .set_color = curses_set_color,
+    .set_attr = curses_set_attr,
+    .reset = curses_reset,
+    .write_n = curses_write_n,
+    .newline = curses_newline,
+    .move = curses_move,
+    .destroy = curses_destroy,
+};
+
+cs_surface_t *cs_surface_curses_new(tui_window_t *window,
+                                    const cs_theme_t *theme) {
+  cs_surface_t *s = cs_surface_alloc_(theme);
+  if (!s) {
+    return NULL;
+  }
+  s->ops = &cs_curses_ops;
+  s->window = window;
+  WINDOW *w = window ? window->win : NULL;
+  int cols = w ? getmaxx(w) : 0;
+  s->caps = (cs_caps_t){
+      .tty = true,
+      .color = tui_colors_enabled(),
+      .unicode = true,
+      .interactive = true,
+      .profile = (COLORS >= 256) ? APP_CLI_COLOR_PROFILE_ANSI256
+                                 : APP_CLI_COLOR_PROFILE_ANSI16,
+      .color_count = COLORS,
+      .width = (cols > 0) ? (size_t)cols : 80,
+  };
+  return s;
+}
+
+#endif // ENABLE_TUI

--- a/src/surface/surface_curses.c
+++ b/src/surface/surface_curses.c
@@ -5,10 +5,13 @@
  * here; surface.c reaches these functions solely through the ops vtable, so a
  * CLI-only or unit-test build never references a curses symbol.
  *
- * Curses color pairs fix foreground and background together, so a role maps to
- * the nearest existing TUI_COLOR_* pair (set up by tui_init_colors). This keeps
- * components visually consistent with the rest of the TUI without managing a
- * second, parallel pool of init_color slots.
+ * Color: a foreground role is resolved through the caller's cs_theme — the same
+ * shared resolver the stream backend uses — and bound to a dedicated pair drawn
+ * from a block reserved above the TUI's own pairs, so a per-surface theme (e.g.
+ * "mono") renders the same on curses as on a stream. When the theme doesn't
+ * resolve to a palette index, curses has no free pair, or a background role is
+ * set (curses pairs fix fg+bg together), we fall back to the nearest pre-seeded
+ * TUI_COLOR_* pair from tui_init_colors.
  */
 
 #include "surface_internal.h"
@@ -61,18 +64,51 @@ static WINDOW *curses_win(cs_surface_t *s) {
   return s->window ? s->window->win : NULL;
 }
 
-static void curses_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
-  (void)bg;  // pairs fix fg+bg together; see cs_surface_set_role_bg
-  WINDOW *w = curses_win(s);
-  if (w && tui_colors_enabled()) {
-    // Clear any current color pair before applying the new one. wattron ORs the
-    // pair bits, so two set_role calls before a reset (which the surface API
-    // documents as legal — "additive until reset") would otherwise combine into
-    // a corrupted third pair index. A_COLOR is just the color field, so this
-    // leaves bold/dim/underline intact.
-    wattroff(w, A_COLOR);
-    wattron(w, COLOR_PAIR(cs_role_to_pair(role)));
+// Bind a reserved pair to the theme-resolved foreground for `role` and return
+// it, or -1 when the theme resolves to no palette index (e.g. terminal-default)
+// or curses has no free pair. The pair block lives above TUI_COLOR_MAX so it
+// never collides with the TUI's own pairs; we re-bind on each call (cheap) to
+// stay correct across theme changes and tui re-init without per-pair state.
+static short cs_curses_role_pair(cs_surface_t *s, cs_role_t role) {
+  app_ui_resolved_color_t r =
+      cs_theme_resolve(&s->theme, role, s->caps.profile, s->caps.color_count);
+  if (r.kind != APP_UI_RESOLVED_INDEXED) {
+    return -1;
   }
+  short pair = (short)(TUI_COLOR_MAX + (int)role);
+  if (pair >= COLOR_PAIRS) {
+    return -1;
+  }
+  if (init_pair(pair, (short)r.index, tui_default_bg()) == ERR) {
+    return -1;
+  }
+  return pair;
+}
+
+static void curses_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
+  WINDOW *w = curses_win(s);
+  if (!w || !tui_colors_enabled()) {
+    return;
+  }
+  // Clear any current color pair before applying the new one. wattron ORs the
+  // pair bits, so two set_role calls before a reset (which the surface API
+  // documents as legal — "additive until reset") would otherwise combine into
+  // a corrupted third pair index. A_COLOR is just the color field, so this
+  // leaves bold/dim/underline intact.
+  wattroff(w, A_COLOR);
+
+  // Foreground roles resolve through the caller's theme so a custom theme looks
+  // the same here as on the stream backend. A background role keeps the static
+  // fg+bg TUI pair (which already carries the surrounding background), as does
+  // any case where the themed pair is unavailable.
+  if (!bg) {
+    short pair = cs_curses_role_pair(s, role);
+    if (pair > 0) {
+      wattron(w, COLOR_PAIR(pair));
+      return;
+    }
+  }
+  wattron(w, COLOR_PAIR(cs_role_to_pair(role)));
 }
 
 static void curses_set_attr(cs_surface_t *s, cs_attr_t attrs) {

--- a/src/surface/surface_curses.c
+++ b/src/surface/surface_curses.c
@@ -191,7 +191,7 @@ cs_surface_t *cs_surface_curses_new(tui_window_t *window,
   s->caps = (cs_caps_t){
       .tty = true,
       .color = tui_colors_enabled(),
-      .unicode = true,
+      .unicode = cs_surface_unicode_enabled_(),
       .interactive = true,
       .profile = (COLORS >= 256) ? APP_CLI_COLOR_PROFILE_ANSI256
                                  : APP_CLI_COLOR_PROFILE_ANSI16,

--- a/src/surface/surface_curses.c
+++ b/src/surface/surface_curses.c
@@ -62,7 +62,7 @@ static WINDOW *curses_win(cs_surface_t *s) {
 }
 
 static void curses_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
-  (void)bg; // pairs fix fg+bg together; see cs_surface_set_role_bg
+  (void)bg;  // pairs fix fg+bg together; see cs_surface_set_role_bg
   WINDOW *w = curses_win(s);
   if (w && tui_colors_enabled()) {
     wattron(w, COLOR_PAIR(cs_role_to_pair(role)));
@@ -123,7 +123,7 @@ static void curses_move(cs_surface_t *s, int x, int y) {
 }
 
 static void curses_destroy(cs_surface_t *s) {
-  (void)s; // the window is owned by the caller
+  (void)s;  // the window is owned by the caller
 }
 
 static const cs_surface_ops_t cs_curses_ops = {
@@ -159,4 +159,4 @@ cs_surface_t *cs_surface_curses_new(tui_window_t *window,
   return s;
 }
 
-#endif // ENABLE_TUI
+#endif  // ENABLE_TUI

--- a/src/surface/surface_curses.c
+++ b/src/surface/surface_curses.c
@@ -65,6 +65,12 @@ static void curses_set_color(cs_surface_t *s, cs_role_t role, bool bg) {
   (void)bg;  // pairs fix fg+bg together; see cs_surface_set_role_bg
   WINDOW *w = curses_win(s);
   if (w && tui_colors_enabled()) {
+    // Clear any current color pair before applying the new one. wattron ORs the
+    // pair bits, so two set_role calls before a reset (which the surface API
+    // documents as legal — "additive until reset") would otherwise combine into
+    // a corrupted third pair index. A_COLOR is just the color field, so this
+    // leaves bold/dim/underline intact.
+    wattroff(w, A_COLOR);
     wattron(w, COLOR_PAIR(cs_role_to_pair(role)));
   }
 }

--- a/src/surface/surface_internal.h
+++ b/src/surface/surface_internal.h
@@ -46,3 +46,8 @@ struct cs_surface {
 
 // Allocate a zeroed surface with the theme copied in. Returns NULL on OOM.
 cs_surface_t *cs_surface_alloc_(const cs_theme_t *theme);
+
+// Locale/environment capability shared by stream and curses surfaces. Returns
+// true only when the active locale advertises UTF-8, so glyph-using components
+// can fall back to ASCII on legacy terminals.
+bool cs_surface_unicode_enabled_(void);

--- a/src/surface/surface_internal.h
+++ b/src/surface/surface_internal.h
@@ -1,0 +1,48 @@
+/*
+ * Private surface internals shared by the backends (surface.c stream backend
+ * and surface_curses.c curses backend). Not a public header.
+ *
+ * The backends are decoupled through a small ops vtable so surface.c never
+ * names a curses symbol: the curses backend lives in its own translation unit
+ * that is only linked into TUI builds. This mirrors the cli_term terminfo/ANSI
+ * backend split.
+ *
+ * Every translation unit that includes this header within a single build target
+ * is compiled with the same feature macros, so the struct layout is consistent;
+ * the APP_ENABLE_CLI_STYLE-gated field is therefore safe.
+ */
+
+#pragma once
+
+#include "surface.h"
+
+#ifdef APP_ENABLE_CLI_STYLE
+#include "../cli/style/cli_term.h"
+#endif
+
+typedef struct cs_surface_ops {
+  void (*set_color)(cs_surface_t *s, cs_role_t role, bool bg);
+  void (*set_attr)(cs_surface_t *s, cs_attr_t attrs);
+  void (*reset)(cs_surface_t *s);
+  void (*write_n)(cs_surface_t *s, const char *text, size_t n);
+  void (*newline)(cs_surface_t *s);
+  void (*move)(cs_surface_t *s, int x, int y);
+  void (*destroy)(cs_surface_t *s); // backend teardown before free()
+} cs_surface_ops_t;
+
+struct cs_surface {
+  const cs_surface_ops_t *ops;
+  cs_theme_t theme;
+  cs_caps_t caps;
+
+  FILE *stream_fp; // stream backend
+#ifdef APP_ENABLE_CLI_STYLE
+  app_cli_term_t term;
+  bool have_term;
+#endif
+
+  tui_window_t *window; // curses backend
+};
+
+// Allocate a zeroed surface with the theme copied in. Returns NULL on OOM.
+cs_surface_t *cs_surface_alloc_(const cs_theme_t *theme);

--- a/src/surface/surface_internal.h
+++ b/src/surface/surface_internal.h
@@ -27,7 +27,7 @@ typedef struct cs_surface_ops {
   void (*write_n)(cs_surface_t *s, const char *text, size_t n);
   void (*newline)(cs_surface_t *s);
   void (*move)(cs_surface_t *s, int x, int y);
-  void (*destroy)(cs_surface_t *s); // backend teardown before free()
+  void (*destroy)(cs_surface_t *s);  // backend teardown before free()
 } cs_surface_ops_t;
 
 struct cs_surface {
@@ -35,13 +35,13 @@ struct cs_surface {
   cs_theme_t theme;
   cs_caps_t caps;
 
-  FILE *stream_fp; // stream backend
+  FILE *stream_fp;  // stream backend
 #ifdef APP_ENABLE_CLI_STYLE
   app_cli_term_t term;
   bool have_term;
 #endif
 
-  tui_window_t *window; // curses backend
+  tui_window_t *window;  // curses backend
 };
 
 // Allocate a zeroed surface with the theme copied in. Returns NULL on OOM.

--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -19,6 +19,7 @@
 
 #include "../io/terminal.h"
 #include "../style/design_tokens.h"
+#include "../style/ui_theme.h"
 #include "../ui/text_layout.h"
 #include "../utils/logging.h"
 #include "tui_internal.h"
@@ -36,6 +37,7 @@ static bool tui_colors_active = false;
 static volatile sig_atomic_t tui_interrupted_signal = 0;
 static int tui_saved_cursor_state = 0;
 static tui_window_t *tui_background_win = NULL;
+static bool tui_color_env_disabled(void);
 #define TUI_BACKGROUND_STACK_MAX 16
 static tui_window_t *tui_background_stack[TUI_BACKGROUND_STACK_MAX];
 static size_t tui_background_stack_depth = 0;
@@ -261,7 +263,7 @@ app_error tui_init(void) {
   // capability. When disabled we skip start_color() entirely and leave
   // tui_colors_active false, so tui_set_color() becomes a no-op and the whole
   // UI renders in the terminal's default monochrome.
-  if (tui_color_policy != 0 && has_colors()) {
+  if (tui_color_policy != 0 && !tui_color_env_disabled() && has_colors()) {
     if (start_color() != ERR) {
       tui_default_colors = use_default_colors() != ERR;
       (void)tui_init_colors();
@@ -323,41 +325,224 @@ app_error tui_take_interrupt_error(void) {
 
 /* ---- color management --------------------------------------------------- */
 
-/* Warm "amber on near-black" palette inspired by gitlogue's ayu/gruvbox
- * themes. When the terminal can redefine palette entries we mix exact RGB
- * tones; otherwise we fall back to a coherent warm mapping over the 8 base
- * colors. Custom entries live at indices 16+ so the base colors stay intact
- * for any code that references COLOR_RED/GREEN/... directly. */
+/* Curses cannot portably emit per-cell 24-bit SGR without desynchronizing its
+ * screen model. The closest high-fidelity path is a programmable palette: seed
+ * custom slots from the shared UI roles, then bind small semantic color pairs
+ * to those slots. When palette mutation is unavailable, use the same RGB ->
+ * xterm256 / semantic ANSI-16 degradation the styled CLI uses. */
 enum {
-  TUI_RGB_AMBER = 16, /* accent: titles, numbers, markers */
-  TUI_RGB_FG,         /* primary warm foreground */
-  TUI_RGB_MUTED,      /* dim gray: borders, separators, hints */
-  TUI_RGB_GREEN,      /* soft success green */
+  TUI_RGB_TEXT = 16,
+  TUI_RGB_TITLE,
+  TUI_RGB_MUTED,
+  TUI_RGB_ACCENT,
+  TUI_RGB_SUCCESS,
+  TUI_RGB_WARNING,
+  TUI_RGB_INFO,
+  TUI_RGB_ERROR,
+  TUI_RGB_SELECTION_FG,
+  TUI_RGB_SELECTION_BG,
   TUI_RGB_LAST,
 };
 
-static bool tui_palette_is_truecolor(void) {
-  return can_change_color() && COLORS >= TUI_RGB_LAST;
+static bool tui_color_env_disabled(void) {
+  const char *color = getenv("APP_CLI_COLOR");
+  return color && strcmp(color, "never") == 0;
 }
 
-/* Seed one custom palette entry from a design-token RGB triple, converting the
- * 0..255 channels to the 0..1000 scale init_color() expects. */
+static app_cli_color_profile_id tui_requested_color_profile(void) {
+  const char *color = getenv("APP_CLI_COLOR");
+  if (!color || color[0] == '\0' || strcmp(color, "auto") == 0 ||
+      strcmp(color, "never") == 0) {
+    return APP_CLI_COLOR_PROFILE_NONE;
+  }
+  if (strcmp(color, "truecolor") == 0) {
+    return APP_CLI_COLOR_PROFILE_TRUECOLOR;
+  }
+  if (strcmp(color, "256") == 0) {
+    return APP_CLI_COLOR_PROFILE_ANSI256;
+  }
+  if (strcmp(color, "16") == 0) {
+    return APP_CLI_COLOR_PROFILE_ANSI16;
+  }
+  return APP_CLI_COLOR_PROFILE_NONE;
+}
+
+static app_ui_theme_mode_id tui_resolve_theme_mode(void) {
+  const char *theme = getenv("APP_CLI_TEST_THEME");
+  if (!theme) {
+    theme = getenv("APP_CLI_THEME");
+  }
+  if (theme && strcmp(theme, "light") == 0) {
+    return APP_UI_THEME_MODE_LIGHT;
+  }
+  return APP_UI_THEME_MODE_DARK;
+}
+
+static bool tui_accent_override_is_indexed(void) {
+  const char *accent = getenv("APP_CLI_ACCENT");
+  if (!accent || !accent[0]) {
+    return false;
+  }
+  app_ui_color_t color;
+  if (!app_ui_color_parse(accent, &color)) {
+    return false;
+  }
+  return color.kind == APP_UI_COLOR_ANSI16 || color.kind == APP_UI_COLOR_ANSI256;
+}
+
+static bool tui_palette_is_programmable(void) {
+  return can_change_color() && COLORS >= TUI_RGB_LAST &&
+         COLOR_PAIRS > TUI_COLOR_MAX;
+}
+
+static app_rgb_t tui_role_rgb(const app_ui_color_scheme_t *scheme,
+                              app_ui_theme_mode_id mode, app_ui_role_id role,
+                              app_rgb_t fallback) {
+  app_ui_color_t color = app_ui_theme_pick(scheme, role, mode);
+  if (color.kind == APP_UI_COLOR_RGB) {
+    return color.rgb;
+  }
+  color = app_ui_theme_pick(app_ui_theme_default_scheme(), role, mode);
+  return color.kind == APP_UI_COLOR_RGB ? color.rgb : fallback;
+}
+
+/* Seed one custom palette entry from an 8-bit RGB triple, converting to the
+ * 0..1000 scale init_color() expects. */
 static void tui_init_color_from(short slot, app_rgb_t c) {
-  init_color(slot, (short)app_design_chan_to_curses(c.r),
-             (short)app_design_chan_to_curses(c.g),
-             (short)app_design_chan_to_curses(c.b));
+  (void)init_color(slot, (short)app_design_chan_to_curses(c.r),
+                   (short)app_design_chan_to_curses(c.g),
+                   (short)app_design_chan_to_curses(c.b));
 }
 
-static void tui_define_rgb_palette(void) {
-  /* Drive the truecolor palette from the shared design tokens so the TUI and
-   * the CLI styling layer stay one source of truth (see design_tokens.h);
-   * init_color() takes the 0..1000 scale. The dead selection slots
-   * (TUI_RGB_SEL_FG/SEL_BG) were removed with the detail-pane cleanup. */
+static void tui_define_rgb_palette(const app_ui_color_scheme_t *scheme,
+                                   app_ui_theme_mode_id mode) {
   const app_design_palette_t *p = &APP_DESIGN_PALETTE;
-  tui_init_color_from(TUI_RGB_AMBER, p->amber);
-  tui_init_color_from(TUI_RGB_FG, p->fg);
-  tui_init_color_from(TUI_RGB_MUTED, p->muted);
-  tui_init_color_from(TUI_RGB_GREEN, p->green);
+  tui_init_color_from(TUI_RGB_TEXT, tui_role_rgb(scheme, mode, APP_UI_ROLE_TEXT,
+                                                 p->fg));
+  tui_init_color_from(TUI_RGB_TITLE, tui_role_rgb(scheme, mode, APP_UI_ROLE_TITLE,
+                                                  p->amber));
+  tui_init_color_from(TUI_RGB_MUTED, tui_role_rgb(scheme, mode, APP_UI_ROLE_MUTED,
+                                                  p->muted));
+  tui_init_color_from(TUI_RGB_ACCENT, tui_role_rgb(scheme, mode, APP_UI_ROLE_ACCENT,
+                                                   p->amber));
+  tui_init_color_from(TUI_RGB_SUCCESS,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SUCCESS, p->green));
+  tui_init_color_from(TUI_RGB_WARNING,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_WARNING, p->yellow));
+  tui_init_color_from(TUI_RGB_INFO, tui_role_rgb(scheme, mode, APP_UI_ROLE_INFO,
+                                                 p->blue));
+  tui_init_color_from(TUI_RGB_ERROR, tui_role_rgb(scheme, mode, APP_UI_ROLE_ERROR_DETAILS,
+                                                  p->red));
+  tui_init_color_from(TUI_RGB_SELECTION_FG,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_FG,
+                                   p->near_black));
+  tui_init_color_from(TUI_RGB_SELECTION_BG,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_BG,
+                                   p->amber));
+}
+
+static short tui_fold_ansi16(uint8_t index, short fallback) {
+  if (COLORS > 0 && COLORS < 16 && index >= 8) {
+    if (index == 8 && fallback >= 0) {
+      return fallback;
+    }
+    index = (uint8_t)(index - 8);
+  }
+  if (COLORS > 0 && index >= (uint8_t)COLORS) {
+    return fallback;
+  }
+  return (short)index;
+}
+
+static short tui_color_index(app_ui_color_t color,
+                             app_cli_color_profile_id profile,
+                             short fallback) {
+  switch (color.kind) {
+  case APP_UI_COLOR_ANSI16:
+    return tui_fold_ansi16(color.ansi16, fallback);
+  case APP_UI_COLOR_ANSI256:
+    if (profile == APP_CLI_COLOR_PROFILE_ANSI256 && COLORS >= 256) {
+      return (short)color.ansi256;
+    }
+    return color.ansi256 < 16 ? tui_fold_ansi16(color.ansi256, fallback)
+                              : fallback;
+  case APP_UI_COLOR_RGB:
+    if (profile == APP_CLI_COLOR_PROFILE_ANSI256 && COLORS >= 256) {
+      return (short)app_color_rgb_to_xterm256(color.rgb);
+    }
+    if (color.has_ansi16_hint) {
+      return tui_fold_ansi16(color.ansi16_hint, fallback);
+    }
+    return tui_fold_ansi16(app_color_rgb_to_ansi16(color.rgb), fallback);
+  case APP_UI_COLOR_DEFAULT:
+    return fallback;
+  case APP_UI_COLOR_UNSET:
+  default:
+    return fallback;
+  }
+}
+
+static short tui_role_index(const app_ui_color_scheme_t *scheme,
+                            app_ui_theme_mode_id mode, app_ui_role_id role,
+                            app_cli_color_profile_id profile,
+                            short fallback) {
+  return tui_color_index(app_ui_theme_pick(scheme, role, mode), profile,
+                         fallback);
+}
+
+static void tui_init_programmable_pairs(const app_ui_color_scheme_t *scheme,
+                                        app_ui_theme_mode_id mode, short bg) {
+  tui_define_rgb_palette(scheme, mode);
+  init_pair(TUI_COLOR_HIGHLIGHT, TUI_RGB_SELECTION_FG, TUI_RGB_SELECTION_BG);
+  init_pair(TUI_COLOR_ERROR, TUI_RGB_ERROR, bg);
+  init_pair(TUI_COLOR_SUCCESS, TUI_RGB_SUCCESS, bg);
+  init_pair(TUI_COLOR_WARNING, TUI_RGB_WARNING, bg);
+  init_pair(TUI_COLOR_INFO, TUI_RGB_INFO, bg);
+  init_pair(TUI_COLOR_MENU_NORMAL, TUI_RGB_TEXT, bg);
+  init_pair(TUI_COLOR_BORDER, TUI_RGB_MUTED, bg);
+  init_pair(TUI_COLOR_TITLE, TUI_RGB_TITLE, bg);
+  init_pair(TUI_COLOR_ACCENT, TUI_RGB_ACCENT, bg);
+  init_pair(TUI_COLOR_DIM, TUI_RGB_MUTED, bg);
+}
+
+static void tui_init_indexed_pairs(const app_ui_color_scheme_t *scheme,
+                                   app_ui_theme_mode_id mode,
+                                   app_cli_color_profile_id profile, short bg) {
+  const short text = tui_role_index(scheme, mode, APP_UI_ROLE_TEXT, profile,
+                                    tui_default_fg());
+  const short title = tui_role_index(scheme, mode, APP_UI_ROLE_TITLE, profile,
+                                     COLOR_YELLOW);
+  const short accent = tui_role_index(scheme, mode, APP_UI_ROLE_ACCENT, profile,
+                                      COLOR_YELLOW);
+  const short muted = tui_role_index(scheme, mode, APP_UI_ROLE_MUTED, profile,
+                                     COLOR_WHITE);
+  init_pair(TUI_COLOR_HIGHLIGHT,
+            tui_role_index(scheme, mode, APP_UI_ROLE_SELECTION_FG, profile,
+                           COLOR_BLACK),
+            tui_role_index(scheme, mode, APP_UI_ROLE_SELECTION_BG, profile,
+                           COLOR_YELLOW));
+  init_pair(TUI_COLOR_ERROR,
+            tui_role_index(scheme, mode, APP_UI_ROLE_ERROR_DETAILS, profile,
+                           COLOR_RED),
+            bg);
+  init_pair(TUI_COLOR_SUCCESS,
+            tui_role_index(scheme, mode, APP_UI_ROLE_SUCCESS, profile,
+                           COLOR_GREEN),
+            bg);
+  init_pair(TUI_COLOR_WARNING,
+            tui_role_index(scheme, mode, APP_UI_ROLE_WARNING, profile,
+                           COLOR_YELLOW),
+            bg);
+  init_pair(TUI_COLOR_INFO,
+            tui_role_index(scheme, mode, APP_UI_ROLE_INFO, profile, COLOR_BLUE),
+            bg);
+  init_pair(TUI_COLOR_MENU_NORMAL, text, bg);
+  init_pair(TUI_COLOR_BORDER,
+            tui_role_index(scheme, mode, APP_UI_ROLE_BORDER, profile, muted),
+            bg);
+  init_pair(TUI_COLOR_TITLE, title, bg);
+  init_pair(TUI_COLOR_ACCENT, accent, bg);
+  init_pair(TUI_COLOR_DIM, muted, bg);
 }
 
 app_error tui_init_colors(void) {
@@ -366,37 +551,25 @@ app_error tui_init_colors(void) {
     return APP_SUCCESS;
   }
 
+  app_ui_color_scheme_t scheme = *app_ui_theme_default_scheme();
+  app_ui_theme_apply_env_overrides(&scheme);
+  const app_ui_theme_mode_id mode = tui_resolve_theme_mode();
+  const app_cli_color_profile_id requested = tui_requested_color_profile();
   const short bg = tui_default_bg();
 
-  if (tui_palette_is_truecolor()) {
-    tui_define_rgb_palette();
-    init_pair(TUI_COLOR_HIGHLIGHT, COLOR_BLACK, TUI_RGB_AMBER);
-    init_pair(TUI_COLOR_ERROR, COLOR_RED, bg);
-    init_pair(TUI_COLOR_SUCCESS, TUI_RGB_GREEN, bg);
-    init_pair(TUI_COLOR_WARNING, TUI_RGB_AMBER, bg);
-    init_pair(TUI_COLOR_INFO, TUI_RGB_AMBER, bg);
-    init_pair(TUI_COLOR_MENU_NORMAL, TUI_RGB_FG, bg);
-    init_pair(TUI_COLOR_BORDER, TUI_RGB_MUTED, bg);
-    init_pair(TUI_COLOR_TITLE, TUI_RGB_FG, bg);
-    init_pair(TUI_COLOR_ACCENT, TUI_RGB_AMBER, bg);
-    init_pair(TUI_COLOR_DIM, TUI_RGB_MUTED, bg);
+  if ((requested == APP_CLI_COLOR_PROFILE_NONE ||
+       requested == APP_CLI_COLOR_PROFILE_TRUECOLOR) &&
+      !tui_accent_override_is_indexed() && tui_palette_is_programmable()) {
+    tui_init_programmable_pairs(&scheme, mode, bg);
     return APP_SUCCESS;
   }
 
-  /* Fallback: warm mapping over the 8 base colors (amber -> yellow, a
-   * calmer blue selection bar instead of loud cyan). */
-  const short default_fg = tui_default_fg();
-  init_pair(TUI_COLOR_HIGHLIGHT, COLOR_BLACK, COLOR_WHITE);
-  init_pair(TUI_COLOR_ERROR, COLOR_RED, bg);
-  init_pair(TUI_COLOR_SUCCESS, COLOR_GREEN, bg);
-  init_pair(TUI_COLOR_WARNING, COLOR_YELLOW, bg);
-  init_pair(TUI_COLOR_INFO, COLOR_YELLOW, bg);
-  init_pair(TUI_COLOR_MENU_NORMAL, default_fg, bg);
-  init_pair(TUI_COLOR_BORDER, COLOR_BLUE, bg);
-  init_pair(TUI_COLOR_TITLE, default_fg, bg);
-  init_pair(TUI_COLOR_ACCENT, COLOR_YELLOW, bg);
-  init_pair(TUI_COLOR_DIM, COLOR_WHITE, bg);
+  if (requested != APP_CLI_COLOR_PROFILE_ANSI16 && COLORS >= 256) {
+    tui_init_indexed_pairs(&scheme, mode, APP_CLI_COLOR_PROFILE_ANSI256, bg);
+    return APP_SUCCESS;
+  }
 
+  tui_init_indexed_pairs(&scheme, mode, APP_CLI_COLOR_PROFILE_ANSI16, bg);
   return APP_SUCCESS;
 }
 

--- a/src/tui/tui.c
+++ b/src/tui/tui.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "../io/terminal.h"
+#include "../style/cs_theme.h"
 #include "../style/design_tokens.h"
 #include "../style/ui_theme.h"
 #include "../ui/text_layout.h"
@@ -195,7 +196,7 @@ static short tui_default_fg(void) {
   return tui_default_colors ? -1 : COLOR_WHITE;
 }
 
-static short tui_default_bg(void) {
+short tui_default_bg(void) {
   return tui_default_colors ? -1 : COLOR_BLACK;
 }
 
@@ -367,17 +368,6 @@ static app_cli_color_profile_id tui_requested_color_profile(void) {
   return APP_CLI_COLOR_PROFILE_NONE;
 }
 
-static app_ui_theme_mode_id tui_resolve_theme_mode(void) {
-  const char *theme = getenv("APP_CLI_TEST_THEME");
-  if (!theme) {
-    theme = getenv("APP_CLI_THEME");
-  }
-  if (theme && strcmp(theme, "light") == 0) {
-    return APP_UI_THEME_MODE_LIGHT;
-  }
-  return APP_UI_THEME_MODE_DARK;
-}
-
 static bool tui_accent_override_is_indexed(void) {
   const char *accent = getenv("APP_CLI_ACCENT");
   if (!accent || !accent[0]) {
@@ -387,7 +377,8 @@ static bool tui_accent_override_is_indexed(void) {
   if (!app_ui_color_parse(accent, &color)) {
     return false;
   }
-  return color.kind == APP_UI_COLOR_ANSI16 || color.kind == APP_UI_COLOR_ANSI256;
+  return color.kind == APP_UI_COLOR_ANSI16 ||
+         color.kind == APP_UI_COLOR_ANSI256;
 }
 
 static bool tui_palette_is_programmable(void) {
@@ -417,28 +408,31 @@ static void tui_init_color_from(short slot, app_rgb_t c) {
 static void tui_define_rgb_palette(const app_ui_color_scheme_t *scheme,
                                    app_ui_theme_mode_id mode) {
   const app_design_palette_t *p = &APP_DESIGN_PALETTE;
-  tui_init_color_from(TUI_RGB_TEXT, tui_role_rgb(scheme, mode, APP_UI_ROLE_TEXT,
-                                                 p->fg));
-  tui_init_color_from(TUI_RGB_TITLE, tui_role_rgb(scheme, mode, APP_UI_ROLE_TITLE,
-                                                  p->amber));
-  tui_init_color_from(TUI_RGB_MUTED, tui_role_rgb(scheme, mode, APP_UI_ROLE_MUTED,
-                                                  p->muted));
-  tui_init_color_from(TUI_RGB_ACCENT, tui_role_rgb(scheme, mode, APP_UI_ROLE_ACCENT,
-                                                   p->amber));
-  tui_init_color_from(TUI_RGB_SUCCESS,
-                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SUCCESS, p->green));
-  tui_init_color_from(TUI_RGB_WARNING,
-                      tui_role_rgb(scheme, mode, APP_UI_ROLE_WARNING, p->yellow));
-  tui_init_color_from(TUI_RGB_INFO, tui_role_rgb(scheme, mode, APP_UI_ROLE_INFO,
-                                                 p->blue));
-  tui_init_color_from(TUI_RGB_ERROR, tui_role_rgb(scheme, mode, APP_UI_ROLE_ERROR_DETAILS,
-                                                  p->red));
-  tui_init_color_from(TUI_RGB_SELECTION_FG,
-                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_FG,
-                                   p->near_black));
-  tui_init_color_from(TUI_RGB_SELECTION_BG,
-                      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_BG,
-                                   p->amber));
+  tui_init_color_from(TUI_RGB_TEXT,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_TEXT, p->fg));
+  tui_init_color_from(TUI_RGB_TITLE,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_TITLE, p->amber));
+  tui_init_color_from(TUI_RGB_MUTED,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_MUTED, p->muted));
+  tui_init_color_from(TUI_RGB_ACCENT,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_ACCENT, p->amber));
+  tui_init_color_from(
+      TUI_RGB_SUCCESS,
+      tui_role_rgb(scheme, mode, APP_UI_ROLE_SUCCESS, p->green));
+  tui_init_color_from(
+      TUI_RGB_WARNING,
+      tui_role_rgb(scheme, mode, APP_UI_ROLE_WARNING, p->yellow));
+  tui_init_color_from(TUI_RGB_INFO,
+                      tui_role_rgb(scheme, mode, APP_UI_ROLE_INFO, p->blue));
+  tui_init_color_from(
+      TUI_RGB_ERROR,
+      tui_role_rgb(scheme, mode, APP_UI_ROLE_ERROR_DETAILS, p->red));
+  tui_init_color_from(
+      TUI_RGB_SELECTION_FG,
+      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_FG, p->near_black));
+  tui_init_color_from(
+      TUI_RGB_SELECTION_BG,
+      tui_role_rgb(scheme, mode, APP_UI_ROLE_SELECTION_BG, p->amber));
 }
 
 static short tui_fold_ansi16(uint8_t index, short fallback) {
@@ -455,8 +449,7 @@ static short tui_fold_ansi16(uint8_t index, short fallback) {
 }
 
 static short tui_color_index(app_ui_color_t color,
-                             app_cli_color_profile_id profile,
-                             short fallback) {
+                             app_cli_color_profile_id profile, short fallback) {
   switch (color.kind) {
   case APP_UI_COLOR_ANSI16:
     return tui_fold_ansi16(color.ansi16, fallback);
@@ -484,8 +477,7 @@ static short tui_color_index(app_ui_color_t color,
 
 static short tui_role_index(const app_ui_color_scheme_t *scheme,
                             app_ui_theme_mode_id mode, app_ui_role_id role,
-                            app_cli_color_profile_id profile,
-                            short fallback) {
+                            app_cli_color_profile_id profile, short fallback) {
   return tui_color_index(app_ui_theme_pick(scheme, role, mode), profile,
                          fallback);
 }
@@ -508,14 +500,14 @@ static void tui_init_programmable_pairs(const app_ui_color_scheme_t *scheme,
 static void tui_init_indexed_pairs(const app_ui_color_scheme_t *scheme,
                                    app_ui_theme_mode_id mode,
                                    app_cli_color_profile_id profile, short bg) {
-  const short text = tui_role_index(scheme, mode, APP_UI_ROLE_TEXT, profile,
-                                    tui_default_fg());
-  const short title = tui_role_index(scheme, mode, APP_UI_ROLE_TITLE, profile,
-                                     COLOR_YELLOW);
-  const short accent = tui_role_index(scheme, mode, APP_UI_ROLE_ACCENT, profile,
-                                      COLOR_YELLOW);
-  const short muted = tui_role_index(scheme, mode, APP_UI_ROLE_MUTED, profile,
-                                     COLOR_WHITE);
+  const short text =
+      tui_role_index(scheme, mode, APP_UI_ROLE_TEXT, profile, tui_default_fg());
+  const short title =
+      tui_role_index(scheme, mode, APP_UI_ROLE_TITLE, profile, COLOR_YELLOW);
+  const short accent =
+      tui_role_index(scheme, mode, APP_UI_ROLE_ACCENT, profile, COLOR_YELLOW);
+  const short muted =
+      tui_role_index(scheme, mode, APP_UI_ROLE_MUTED, profile, COLOR_WHITE);
   init_pair(TUI_COLOR_HIGHLIGHT,
             tui_role_index(scheme, mode, APP_UI_ROLE_SELECTION_FG, profile,
                            COLOR_BLACK),
@@ -525,14 +517,14 @@ static void tui_init_indexed_pairs(const app_ui_color_scheme_t *scheme,
             tui_role_index(scheme, mode, APP_UI_ROLE_ERROR_DETAILS, profile,
                            COLOR_RED),
             bg);
-  init_pair(TUI_COLOR_SUCCESS,
-            tui_role_index(scheme, mode, APP_UI_ROLE_SUCCESS, profile,
-                           COLOR_GREEN),
-            bg);
-  init_pair(TUI_COLOR_WARNING,
-            tui_role_index(scheme, mode, APP_UI_ROLE_WARNING, profile,
-                           COLOR_YELLOW),
-            bg);
+  init_pair(
+      TUI_COLOR_SUCCESS,
+      tui_role_index(scheme, mode, APP_UI_ROLE_SUCCESS, profile, COLOR_GREEN),
+      bg);
+  init_pair(
+      TUI_COLOR_WARNING,
+      tui_role_index(scheme, mode, APP_UI_ROLE_WARNING, profile, COLOR_YELLOW),
+      bg);
   init_pair(TUI_COLOR_INFO,
             tui_role_index(scheme, mode, APP_UI_ROLE_INFO, profile, COLOR_BLUE),
             bg);
@@ -553,7 +545,7 @@ app_error tui_init_colors(void) {
 
   app_ui_color_scheme_t scheme = *app_ui_theme_default_scheme();
   app_ui_theme_apply_env_overrides(&scheme);
-  const app_ui_theme_mode_id mode = tui_resolve_theme_mode();
+  const app_ui_theme_mode_id mode = cs_theme_mode_resolve();
   const app_cli_color_profile_id requested = tui_requested_color_profile();
   const short bg = tui_default_bg();
 

--- a/src/tui/tui.h
+++ b/src/tui/tui.h
@@ -71,6 +71,12 @@ void tui_set_color_enabled(bool enabled);
 // allowed it, the terminal supports color, and start_color() succeeded).
 bool tui_colors_enabled(void);
 
+// The background color index the TUI binds its pairs against (-1 when the
+// terminal's default background is in use). Exposed so a cs_surface can bind
+// its own theme-resolved pairs against the same background the surrounding TUI
+// uses.
+short tui_default_bg(void);
+
 // Window helpers
 APP_NODISCARD tui_window_t *tui_create_window(int height, int width, int y,
                                               int x);

--- a/src/utils/colors.c
+++ b/src/utils/colors.c
@@ -59,6 +59,15 @@ bool app_use_colors(const app_config_t *config) {
     return false;
   }
 
+  // Shared UI style policy: APP_CLI_COLOR=never disables both the styled CLI
+  // layer and the generated TUI color bridge. The APP_CLI_ prefix is kept for
+  // compatibility with the existing public environment contract. Treat it as a
+  // hard disable, like NO_COLOR, so it wins over FORCE_COLOR=1.
+  const char *cli_color = getenv("APP_CLI_COLOR");
+  if (cli_color && strcmp(cli_color, "never") == 0) {
+    return false;
+  }
+
   // FORCE_COLOR / CLICOLOR_FORCE / CLICOLOR, parsed per the de-facto spec:
   // FORCE_COLOR=0 disables, a force flag enables even off a TTY.
   switch (app_color_env_force()) {

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -1,19 +1,22 @@
 /*
  * Unit tests for the Curspan component catalog.
  *
- * Each component is rendered to a non-TTY tmpfile() stream surface, which means
- * styling is disabled and the output is plain (escape-free). The invariants we
- * pin are the ones a downstream app depends on: the right text appears, layout
- * is stable, and a component NEVER emits an escape sequence onto a pipe.
+ * Most components are rendered to a non-TTY tmpfile() stream surface, which
+ * means styling is disabled and the output is plain (escape-free). The
+ * invariants we pin are the ones a downstream app depends on: the right text
+ * appears, layout is stable, and a component NEVER emits an escape sequence
+ * onto a pipe unless styling is explicitly forced for a color regression test.
  */
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../src/components/components.h"
 #include "../src/style/cs_theme.h"
 #include "../src/surface/surface.h"
+#include "../src/ui/text_layout.h"
 #include "unit_support.h"
 
 // Render through `s`, then return the captured bytes in `buf`. The surface is
@@ -37,8 +40,56 @@ static cs_surface_t *open_capture(FILE **stream_out) {
   return cs_surface_stream_new(stream, NULL, NULL);
 }
 
+static cs_surface_t *open_capture_theme(FILE **stream_out,
+                                        const cs_theme_t *theme) {
+  FILE *stream = tmpfile();
+  if (!stream) {
+    return NULL;
+  }
+  *stream_out = stream;
+  return cs_surface_stream_new(stream, NULL, theme);
+}
+
 static bool no_escapes(const char *buf) {
   return strstr(buf, "\x1b") == NULL;
+}
+
+static char *copy_env(const char *name) {
+  const char *value = getenv(name);
+  if (!value) {
+    return NULL;
+  }
+  size_t len = strlen(value) + 1;
+  char *copy = malloc(len);
+  if (copy) {
+    memcpy(copy, value, len);
+  }
+  return copy;
+}
+
+static void restore_env(const char *name, char *value) {
+  if (value) {
+    setenv(name, value, 1);
+    free(value);
+  } else {
+    unsetenv(name);
+  }
+}
+
+static bool rows_within_width(const char *buf, int width) {
+  const char *line = buf;
+  while (*line) {
+    const char *end = strchr(line, '\n');
+    size_t len = end ? (size_t)(end - line) : strlen(line);
+    if (app_text_width_utf8_n(line, len) > width) {
+      return false;
+    }
+    if (!end) {
+      break;
+    }
+    line = end + 1;
+  }
+  return true;
 }
 
 static bool test_surface_caps_plain(void) {
@@ -227,11 +278,10 @@ static bool test_progress_nan_is_safe(void) {
   if (!s) {
     return false;
   }
-  cs_progress_render(&(cs_progress_t){.value = NAN,
-                                      .total = 0,
-                                      .width = 20,
-                                      .show_percent = true},
-                     s);
+  cs_progress_render(
+      &(cs_progress_t){
+          .value = NAN, .total = 0, .width = 20, .show_percent = true},
+      s);
   char buf[256];
   capture(s, stream, buf, sizeof(buf));
   // NaN folds to 0%, and the call returns promptly (no hang).
@@ -260,6 +310,31 @@ static bool test_table_null_cells_is_safe(void) {
   return buf[0] == '\0';
 }
 
+// Even when there are more columns than can fit with one visible cell per
+// column, table rendering must honor the caller's total width budget rather
+// than raising the budget and smearing into neighboring UI.
+static bool test_table_respects_narrow_width_budget(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_table_column_t cols[] = {
+      {.header = "Alpha"}, {.header = "Beta"}, {.header = "Gamma"}};
+  const char *cells[] = {"one", "two", "three"};
+  const int width = 2;
+  cs_table_render(&(cs_table_t){.columns = cols,
+                                .column_count = 3,
+                                .cells = cells,
+                                .row_count = 1,
+                                .header = true,
+                                .width = (size_t)width},
+                  s);
+  char buf[512];
+  capture(s, stream, buf, sizeof(buf));
+  return rows_within_width(buf, width) && no_escapes(buf);
+}
+
 // The all-indexed "mono" theme must still resolve to concrete colors on a
 // truecolor terminal. (Regression: explicit indices collapsed to NONE there.)
 static bool test_mono_theme_colored_on_truecolor(void) {
@@ -273,6 +348,84 @@ static bool test_mono_theme_colored_on_truecolor(void) {
       &mono, CS_ROLE_BORDER, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
   return text.kind == APP_UI_RESOLVED_INDEXED &&
          border.kind == APP_UI_RESOLVED_INDEXED;
+}
+
+static bool test_explicit_text_role_overrides_non_text_default(void) {
+#ifdef APP_ENABLE_CLI_STYLE
+  char *previous_profile = copy_env("APP_CLI_TEST_PROFILE");
+  char *previous_no_color = copy_env("NO_COLOR");
+  char *previous_color = copy_env("APP_CLI_COLOR");
+  char *previous_term = copy_env("TERM");
+  char *previous_force = copy_env("FORCE_COLOR");
+  char *previous_clicolor = copy_env("CLICOLOR");
+  char *previous_clicolor_force = copy_env("CLICOLOR_FORCE");
+
+  unsetenv("NO_COLOR");
+  unsetenv("APP_CLI_COLOR");
+  unsetenv("FORCE_COLOR");
+  unsetenv("CLICOLOR");
+  unsetenv("CLICOLOR_FORCE");
+  setenv("TERM", "xterm-256color", 1);
+  setenv("APP_CLI_TEST_PROFILE", "truecolor", 1);
+
+  cs_theme_t theme = cs_theme_default();
+  bool ok = cs_theme_set_role_spec(&theme, CS_ROLE_TEXT, "#010203") &&
+            cs_theme_set_role_spec(&theme, CS_ROLE_MUTED, "#040506");
+
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture_theme(&stream, &theme);
+  if (!s) {
+    ok = false;
+  } else {
+    cs_keyvalue_pair_t pairs[] = {{"Key", "Value"}};
+    cs_keyvalue_render(&(cs_keyvalue_t){.pairs = pairs,
+                                        .count = 1,
+                                        .key_role = CS_ROLE_TEXT,
+                                        .key_role_set = true},
+                       s);
+    char buf[256];
+    capture(s, stream, buf, sizeof(buf));
+    ok = ok && strstr(buf, "\x1b[38;2;1;2;3mKey") != NULL &&
+         strstr(buf, "\x1b[38;2;4;5;6mKey") == NULL;
+  }
+
+  restore_env("APP_CLI_TEST_PROFILE", previous_profile);
+  restore_env("NO_COLOR", previous_no_color);
+  restore_env("APP_CLI_COLOR", previous_color);
+  restore_env("TERM", previous_term);
+  restore_env("FORCE_COLOR", previous_force);
+  restore_env("CLICOLOR", previous_clicolor);
+  restore_env("CLICOLOR_FORCE", previous_clicolor_force);
+  return ok;
+#else
+  return true;
+#endif
+}
+
+// A label that nearly fills the budget must be truncated, not allowed to push
+// the rendered line past `width`. (Regression: the label and percent were
+// written untruncated even after the bar was clamped to its 1-column floor, so
+// a 20-column budget rendered 31 columns.)
+static bool test_progress_respects_width_budget(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  const int width = 20;
+  cs_progress_render(&(cs_progress_t){.label = "A very long build label",
+                                      .current = 10,
+                                      .total = 10,
+                                      .width = (size_t)width,
+                                      .show_percent = true},
+                     s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  size_t len = strlen(buf);
+  if (len > 0 && buf[len - 1] == '\n') {
+    buf[len - 1] = '\0';  // measure the row, not the trailing newline
+  }
+  return app_text_width_utf8(buf) <= width && no_escapes(buf);
 }
 
 void run_components_unit_tests(unit_stats_t *stats) {
@@ -295,8 +448,14 @@ void run_components_unit_tests(unit_stats_t *stats) {
               "cs_theme resolves named themes and the default");
   unit_record(stats, test_progress_nan_is_safe(),
               "cs_progress tolerates a non-finite fraction");
+  unit_record(stats, test_progress_respects_width_budget(),
+              "cs_progress truncates a long label to its width budget");
   unit_record(stats, test_table_null_cells_is_safe(),
               "cs_table rejects row_count>0 with NULL cells");
+  unit_record(stats, test_table_respects_narrow_width_budget(),
+              "cs_table respects narrow width budgets");
   unit_record(stats, test_mono_theme_colored_on_truecolor(),
               "mono theme stays colored on a truecolor profile");
+  unit_record(stats, test_explicit_text_role_overrides_non_text_default(),
+              "explicit CS_ROLE_TEXT overrides non-text role defaults");
 }

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -1,0 +1,239 @@
+/*
+ * Unit tests for the Curspan component catalog.
+ *
+ * Each component is rendered to a non-TTY tmpfile() stream surface, which means
+ * styling is disabled and the output is plain (escape-free). The invariants we
+ * pin are the ones a downstream app depends on: the right text appears, layout
+ * is stable, and a component NEVER emits an escape sequence onto a pipe.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../src/components/components.h"
+#include "../src/style/cs_theme.h"
+#include "../src/surface/surface.h"
+#include "unit_support.h"
+
+// Render through `s`, then return the captured bytes in `buf`. The surface is
+// read before being freed so the test never depends on teardown order.
+static size_t capture(cs_surface_t *s, FILE *stream, char *buf, size_t cap) {
+  fflush(stream);
+  rewind(stream);
+  size_t n = fread(buf, 1, cap - 1, stream);
+  buf[n] = '\0';
+  cs_surface_free(s);
+  fclose(stream);
+  return n;
+}
+
+static cs_surface_t *open_capture(FILE **stream_out) {
+  FILE *stream = tmpfile();
+  if (!stream) {
+    return NULL;
+  }
+  *stream_out = stream;
+  return cs_surface_stream_new(stream, NULL, NULL);
+}
+
+static bool no_escapes(const char *buf) {
+  return strstr(buf, "\x1b") == NULL;
+}
+
+static bool test_surface_caps_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_caps_t caps = cs_surface_caps(s);
+  bool ok = !caps.color && caps.unicode && caps.width > 0 && !caps.tty;
+  char buf[64];
+  capture(s, stream, buf, sizeof(buf));
+  return ok;
+}
+
+static bool test_rule_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_rule_render(&(cs_rule_t){.label = "OPTIONS", .width = 20, .glyph = "-"},
+                 s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "OPTIONS") && strstr(buf, "-") &&
+         buf[strlen(buf) - 1] == '\n' && no_escapes(buf);
+}
+
+static bool test_heading_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_heading_render(
+      &(cs_heading_t){.text = "Usage", .uppercase = true, .underline = true},
+      s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "USAGE") && no_escapes(buf);
+}
+
+static bool test_badge_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_badge_render(&(cs_badge_t){.text = "OK", .variant = CS_BADGE_SUCCESS}, s);
+  char buf[128];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "[") && strstr(buf, "OK") && strstr(buf, "]") &&
+         no_escapes(buf);
+}
+
+static bool test_note_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_note_render(&(cs_note_t){.variant = CS_NOTE_WARNING,
+                              .title = "Heads up",
+                              .body = "This cannot be undone",
+                              .width = 40},
+                 s);
+  char buf[512];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "Heads up") && strstr(buf, "This cannot be undone") &&
+         no_escapes(buf);
+}
+
+static bool test_keyvalue_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_keyvalue_pair_t pairs[] = {
+      {"Application", "myapp"},
+      {"Version", "0.1.0"},
+  };
+  cs_keyvalue_render(&(cs_keyvalue_t){.pairs = pairs, .count = 2}, s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  // Keys pad to the widest ("Application" = 11). "Application" then takes only
+  // the 2-space separator; "Version" (7) gets 4 pad + 2 separator = 6 spaces.
+  return strstr(buf, "Application  myapp") &&
+         strstr(buf, "Version      0.1.0") && no_escapes(buf);
+}
+
+static bool test_list_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  const char *items[] = {"Alpha", "Beta"};
+  cs_list_render(
+      &(cs_list_t){.items = items, .count = 2, .style = CS_LIST_NUMBERED}, s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "1. Alpha") && strstr(buf, "2. Beta") && no_escapes(buf);
+}
+
+static bool test_table_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_table_column_t cols[] = {{.header = "Name"}, {.header = "Status"}};
+  const char *cells[] = {"build", "ok", "tests", "ok"};
+  cs_table_render(&(cs_table_t){.columns = cols,
+                                .column_count = 2,
+                                .cells = cells,
+                                .row_count = 2,
+                                .header = true,
+                                .width = 40},
+                  s);
+  char buf[512];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "Name") && strstr(buf, "Status") && strstr(buf, "build") &&
+         strstr(buf, "tests") && no_escapes(buf);
+}
+
+static bool test_progress_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_progress_render(&(cs_progress_t){.label = "Building",
+                                      .current = 7,
+                                      .total = 10,
+                                      .width = 40,
+                                      .show_percent = true},
+                     s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  return strstr(buf, "Building") && strstr(buf, "70%") && no_escapes(buf);
+}
+
+static bool test_spinner_plain(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_spinner_render(&(cs_spinner_t){.label = "Working"}, 0, s);
+  char buf[128];
+  capture(s, stream, buf, sizeof(buf));
+  bool frames_ok = cs_spinner_frame_count(CS_SPINNER_LINE, false) == 4 &&
+                   cs_spinner_frame_count(CS_SPINNER_DOTS, true) == 10;
+  return strstr(buf, "Working") && no_escapes(buf) && frames_ok;
+}
+
+static bool test_theme_registry(void) {
+  cs_theme_t theme;
+  bool ok =
+      cs_theme_by_name("amber", &theme) && strcmp(theme.name, "amber") == 0;
+  ok =
+      ok && cs_theme_by_name("mono", &theme) && strcmp(theme.name, "mono") == 0;
+  ok = ok && !cs_theme_by_name("does-not-exist", &theme);
+  cs_theme_t def = cs_theme_default();
+  ok = ok && def.name && strcmp(def.name, "amber") == 0;
+  const char *const *names = cs_theme_names();
+  bool saw_amber = false, saw_mono = false;
+  for (size_t i = 0; names[i]; i++) {
+    if (strcmp(names[i], "amber") == 0) {
+      saw_amber = true;
+    }
+    if (strcmp(names[i], "mono") == 0) {
+      saw_mono = true;
+    }
+  }
+  return ok && saw_amber && saw_mono;
+}
+
+void run_components_unit_tests(unit_stats_t *stats) {
+  unit_record(stats, test_surface_caps_plain(),
+              "surface reports plain caps on a non-tty stream");
+  unit_record(stats, test_rule_plain(), "cs_rule renders a labelled divider");
+  unit_record(stats, test_heading_plain(),
+              "cs_heading upper-cases and renders a title");
+  unit_record(stats, test_badge_plain(), "cs_badge renders a bracketed label");
+  unit_record(stats, test_note_plain(),
+              "cs_note renders title and wrapped body");
+  unit_record(stats, test_keyvalue_plain(),
+              "cs_keyvalue aligns keys to a column");
+  unit_record(stats, test_list_plain(), "cs_list numbers items");
+  unit_record(stats, test_table_plain(), "cs_table renders headers and rows");
+  unit_record(stats, test_progress_plain(),
+              "cs_progress renders a bar and percentage");
+  unit_record(stats, test_spinner_plain(), "cs_spinner renders a frame");
+  unit_record(stats, test_theme_registry(),
+              "cs_theme resolves named themes and the default");
+}

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -40,16 +40,6 @@ static cs_surface_t *open_capture(FILE **stream_out) {
   return cs_surface_stream_new(stream, NULL, NULL);
 }
 
-static cs_surface_t *open_capture_theme(FILE **stream_out,
-                                        const cs_theme_t *theme) {
-  FILE *stream = tmpfile();
-  if (!stream) {
-    return NULL;
-  }
-  *stream_out = stream;
-  return cs_surface_stream_new(stream, NULL, theme);
-}
-
 static bool no_escapes(const char *buf) {
   return strstr(buf, "\x1b") == NULL;
 }
@@ -92,6 +82,18 @@ static bool rows_within_width(const char *buf, int width) {
   return true;
 }
 
+#ifdef APP_ENABLE_CLI_STYLE
+static cs_surface_t *open_capture_theme(FILE **stream_out,
+                                        const cs_theme_t *theme) {
+  FILE *stream = tmpfile();
+  if (!stream) {
+    return NULL;
+  }
+  *stream_out = stream;
+  return cs_surface_stream_new(stream, NULL, theme);
+}
+#endif
+
 static bool test_surface_caps_plain(void) {
   FILE *stream = NULL;
   cs_surface_t *s = open_capture(&stream);
@@ -102,6 +104,33 @@ static bool test_surface_caps_plain(void) {
   bool ok = !caps.color && caps.unicode && caps.width > 0 && !caps.tty;
   char buf[64];
   capture(s, stream, buf, sizeof(buf));
+  return ok;
+}
+
+static bool test_surface_caps_ascii_locale(void) {
+  char *previous_lc_all = copy_env("LC_ALL");
+  char *previous_lc_ctype = copy_env("LC_CTYPE");
+  char *previous_lang = copy_env("LANG");
+
+  setenv("LC_ALL", "C", 1);
+  unsetenv("LC_CTYPE");
+  unsetenv("LANG");
+
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  bool ok = s != NULL;
+  if (s) {
+    cs_caps_t caps = cs_surface_caps(s);
+    ok = ok && !caps.unicode;
+    cs_rule_render(&(cs_rule_t){.width = 3}, s);
+    char buf[64];
+    capture(s, stream, buf, sizeof(buf));
+    ok = ok && strcmp(buf, "---\n") == 0;
+  }
+
+  restore_env("LC_ALL", previous_lc_all);
+  restore_env("LC_CTYPE", previous_lc_ctype);
+  restore_env("LANG", previous_lang);
   return ok;
 }
 
@@ -431,6 +460,8 @@ static bool test_progress_respects_width_budget(void) {
 void run_components_unit_tests(unit_stats_t *stats) {
   unit_record(stats, test_surface_caps_plain(),
               "surface reports plain caps on a non-tty stream");
+  unit_record(stats, test_surface_caps_ascii_locale(),
+              "surface reports ASCII glyph fallback under C locale");
   unit_record(stats, test_rule_plain(), "cs_rule renders a labelled divider");
   unit_record(stats, test_heading_plain(),
               "cs_heading upper-cases and renders a title");

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -44,27 +44,10 @@ static bool no_escapes(const char *buf) {
   return strstr(buf, "\x1b") == NULL;
 }
 
-static char *copy_env(const char *name) {
-  const char *value = getenv(name);
-  if (!value) {
-    return NULL;
-  }
-  size_t len = strlen(value) + 1;
-  char *copy = malloc(len);
-  if (copy) {
-    memcpy(copy, value, len);
-  }
-  return copy;
-}
-
-static void restore_env(const char *name, char *value) {
-  if (value) {
-    setenv(name, value, 1);
-    free(value);
-  } else {
-    unsetenv(name);
-  }
-}
+typedef struct test_env_save {
+  const char *name;
+  char *value;
+} test_env_save_t;
 
 static bool rows_within_width(const char *buf, int width) {
   const char *line = buf;
@@ -108,9 +91,21 @@ static bool test_surface_caps_plain(void) {
 }
 
 static bool test_surface_caps_ascii_locale(void) {
-  char *previous_lc_all = copy_env("LC_ALL");
-  char *previous_lc_ctype = copy_env("LC_CTYPE");
-  char *previous_lang = copy_env("LANG");
+  test_env_save_t env[] = {
+      {"LC_ALL", NULL}, {"LC_CTYPE", NULL}, {"LANG", NULL}};
+  bool ok = true;
+  for (size_t i = 0; i < sizeof(env) / sizeof(env[0]); i++) {
+    const char *value = getenv(env[i].name);
+    if (value) {
+      size_t len = strlen(value) + 1;
+      env[i].value = malloc(len);
+      if (!env[i].value) {
+        ok = false;
+      } else {
+        memcpy(env[i].value, value, len);
+      }
+    }
+  }
 
   setenv("LC_ALL", "C", 1);
   unsetenv("LC_CTYPE");
@@ -118,7 +113,7 @@ static bool test_surface_caps_ascii_locale(void) {
 
   FILE *stream = NULL;
   cs_surface_t *s = open_capture(&stream);
-  bool ok = s != NULL;
+  ok = ok && s != NULL;
   if (s) {
     cs_caps_t caps = cs_surface_caps(s);
     ok = ok && !caps.unicode;
@@ -128,9 +123,14 @@ static bool test_surface_caps_ascii_locale(void) {
     ok = ok && strcmp(buf, "---\n") == 0;
   }
 
-  restore_env("LC_ALL", previous_lc_all);
-  restore_env("LC_CTYPE", previous_lc_ctype);
-  restore_env("LANG", previous_lang);
+  for (size_t i = 0; i < sizeof(env) / sizeof(env[0]); i++) {
+    if (env[i].value) {
+      setenv(env[i].name, env[i].value, 1);
+      free(env[i].value);
+    } else {
+      unsetenv(env[i].name);
+    }
+  }
   return ok;
 }
 
@@ -381,13 +381,23 @@ static bool test_mono_theme_colored_on_truecolor(void) {
 
 static bool test_explicit_text_role_overrides_non_text_default(void) {
 #ifdef APP_ENABLE_CLI_STYLE
-  char *previous_profile = copy_env("APP_CLI_TEST_PROFILE");
-  char *previous_no_color = copy_env("NO_COLOR");
-  char *previous_color = copy_env("APP_CLI_COLOR");
-  char *previous_term = copy_env("TERM");
-  char *previous_force = copy_env("FORCE_COLOR");
-  char *previous_clicolor = copy_env("CLICOLOR");
-  char *previous_clicolor_force = copy_env("CLICOLOR_FORCE");
+  test_env_save_t env[] = {{"APP_CLI_TEST_PROFILE", NULL}, {"NO_COLOR", NULL},
+                           {"APP_CLI_COLOR", NULL},        {"TERM", NULL},
+                           {"FORCE_COLOR", NULL},          {"CLICOLOR", NULL},
+                           {"CLICOLOR_FORCE", NULL}};
+  bool ok = true;
+  for (size_t i = 0; i < sizeof(env) / sizeof(env[0]); i++) {
+    const char *value = getenv(env[i].name);
+    if (value) {
+      size_t len = strlen(value) + 1;
+      env[i].value = malloc(len);
+      if (!env[i].value) {
+        ok = false;
+      } else {
+        memcpy(env[i].value, value, len);
+      }
+    }
+  }
 
   unsetenv("NO_COLOR");
   unsetenv("APP_CLI_COLOR");
@@ -398,8 +408,8 @@ static bool test_explicit_text_role_overrides_non_text_default(void) {
   setenv("APP_CLI_TEST_PROFILE", "truecolor", 1);
 
   cs_theme_t theme = cs_theme_default();
-  bool ok = cs_theme_set_role_spec(&theme, CS_ROLE_TEXT, "#010203") &&
-            cs_theme_set_role_spec(&theme, CS_ROLE_MUTED, "#040506");
+  ok = ok && cs_theme_set_role_spec(&theme, CS_ROLE_TEXT, "#010203") &&
+       cs_theme_set_role_spec(&theme, CS_ROLE_MUTED, "#040506");
 
   FILE *stream = NULL;
   cs_surface_t *s = open_capture_theme(&stream, &theme);
@@ -418,13 +428,14 @@ static bool test_explicit_text_role_overrides_non_text_default(void) {
          strstr(buf, "\x1b[38;2;4;5;6mKey") == NULL;
   }
 
-  restore_env("APP_CLI_TEST_PROFILE", previous_profile);
-  restore_env("NO_COLOR", previous_no_color);
-  restore_env("APP_CLI_COLOR", previous_color);
-  restore_env("TERM", previous_term);
-  restore_env("FORCE_COLOR", previous_force);
-  restore_env("CLICOLOR", previous_clicolor);
-  restore_env("CLICOLOR_FORCE", previous_clicolor_force);
+  for (size_t i = 0; i < sizeof(env) / sizeof(env[0]); i++) {
+    if (env[i].value) {
+      setenv(env[i].name, env[i].value, 1);
+      free(env[i].value);
+    } else {
+      unsetenv(env[i].name);
+    }
+  }
   return ok;
 #else
   return true;

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -84,7 +84,7 @@ static bool test_surface_caps_plain(void) {
     return false;
   }
   cs_caps_t caps = cs_surface_caps(s);
-  bool ok = !caps.color && caps.unicode && caps.width > 0 && !caps.tty;
+  bool ok = !caps.color && caps.width > 0 && !caps.tty;
   char buf[64];
   capture(s, stream, buf, sizeof(buf));
   return ok;
@@ -409,7 +409,8 @@ static bool test_explicit_text_role_overrides_non_text_default(void) {
 
   cs_theme_t theme = cs_theme_default();
   ok = ok && cs_theme_set_role_spec(&theme, CS_ROLE_TEXT, "#010203") &&
-       cs_theme_set_role_spec(&theme, CS_ROLE_MUTED, "#040506");
+       cs_theme_set_role_spec(&theme, CS_ROLE_MUTED, "#040506") &&
+       cs_theme_set_role_spec(&theme, CS_ROLE_BORDER, "#070809");
 
   FILE *stream = NULL;
   cs_surface_t *s = open_capture_theme(&stream, &theme);
@@ -426,6 +427,22 @@ static bool test_explicit_text_role_overrides_non_text_default(void) {
     capture(s, stream, buf, sizeof(buf));
     ok = ok && strstr(buf, "\x1b[38;2;1;2;3mKey") != NULL &&
          strstr(buf, "\x1b[38;2;4;5;6mKey") == NULL;
+  }
+
+  stream = NULL;
+  s = open_capture_theme(&stream, &theme);
+  if (!s) {
+    ok = false;
+  } else {
+    cs_heading_render(&(cs_heading_t){.text = "Head",
+                                      .underline = true,
+                                      .role = CS_ROLE_TEXT,
+                                      .role_set = true},
+                      s);
+    char buf[512];
+    capture(s, stream, buf, sizeof(buf));
+    ok = ok && strstr(buf, "\x1b[38;2;1;2;3m") != NULL &&
+         strstr(buf, "Head") != NULL && strstr(buf, "\x1b[38;2;7;8;9m") == NULL;
   }
 
   for (size_t i = 0; i < sizeof(env) / sizeof(env[0]); i++) {

--- a/test/unit_components_tests.c
+++ b/test/unit_components_tests.c
@@ -7,6 +7,7 @@
  * is stable, and a component NEVER emits an escape sequence onto a pipe.
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -218,6 +219,62 @@ static bool test_theme_registry(void) {
   return ok && saw_amber && saw_mono;
 }
 
+// A non-finite progress fraction must not hang or emit garbage. (Regression: a
+// NaN escaped the [0,1] clamp, making the bar-fill repeat counts wrap huge.)
+static bool test_progress_nan_is_safe(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_progress_render(&(cs_progress_t){.value = NAN,
+                                      .total = 0,
+                                      .width = 20,
+                                      .show_percent = true},
+                     s);
+  char buf[256];
+  capture(s, stream, buf, sizeof(buf));
+  // NaN folds to 0%, and the call returns promptly (no hang).
+  return strstr(buf, "0%") && no_escapes(buf);
+}
+
+// A table with row_count > 0 but cells == NULL must not dereference NULL.
+// (Regression: the natural-width scan loaded through the NULL cells pointer.)
+static bool test_table_null_cells_is_safe(void) {
+  FILE *stream = NULL;
+  cs_surface_t *s = open_capture(&stream);
+  if (!s) {
+    return false;
+  }
+  cs_table_column_t cols[] = {{.header = "Name"}, {.header = "Status"}};
+  cs_table_render(&(cs_table_t){.columns = cols,
+                                .column_count = 2,
+                                .cells = NULL,
+                                .row_count = 3,
+                                .header = true,
+                                .width = 40},
+                  s);
+  char buf[64];
+  capture(s, stream, buf, sizeof(buf));
+  // Invalid prop combo is rejected (no output), and nothing crashes.
+  return buf[0] == '\0';
+}
+
+// The all-indexed "mono" theme must still resolve to concrete colors on a
+// truecolor terminal. (Regression: explicit indices collapsed to NONE there.)
+static bool test_mono_theme_colored_on_truecolor(void) {
+  cs_theme_t mono;
+  if (!cs_theme_by_name("mono", &mono)) {
+    return false;
+  }
+  app_ui_resolved_color_t text = cs_theme_resolve(
+      &mono, CS_ROLE_TEXT, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
+  app_ui_resolved_color_t border = cs_theme_resolve(
+      &mono, CS_ROLE_BORDER, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
+  return text.kind == APP_UI_RESOLVED_INDEXED &&
+         border.kind == APP_UI_RESOLVED_INDEXED;
+}
+
 void run_components_unit_tests(unit_stats_t *stats) {
   unit_record(stats, test_surface_caps_plain(),
               "surface reports plain caps on a non-tty stream");
@@ -236,4 +293,10 @@ void run_components_unit_tests(unit_stats_t *stats) {
   unit_record(stats, test_spinner_plain(), "cs_spinner renders a frame");
   unit_record(stats, test_theme_registry(),
               "cs_theme resolves named themes and the default");
+  unit_record(stats, test_progress_nan_is_safe(),
+              "cs_progress tolerates a non-finite fraction");
+  unit_record(stats, test_table_null_cells_is_safe(),
+              "cs_table rejects row_count>0 with NULL cells");
+  unit_record(stats, test_mono_theme_colored_on_truecolor(),
+              "mono theme stays colored on a truecolor profile");
 }

--- a/test/unit_config_tests.c
+++ b/test/unit_config_tests.c
@@ -142,6 +142,25 @@ static bool test_use_colors_no_color_beats_force_color(void) {
   free(save_fc);
   return ok;
 }
+
+static bool test_use_colors_honors_cli_color_never(void) {
+  char *save_color = cfg_env_dup("APP_CLI_COLOR");
+  char *save_fc = cfg_env_dup("FORCE_COLOR");
+  char *save_nc = cfg_env_dup("NO_COLOR");
+
+  cfg_env_set("NO_COLOR", NULL);
+  cfg_env_set("FORCE_COLOR", "1");
+  cfg_env_set("APP_CLI_COLOR", "never");
+  const bool ok = !app_use_colors(NULL);
+
+  cfg_env_set("APP_CLI_COLOR", save_color);
+  cfg_env_set("FORCE_COLOR", save_fc);
+  cfg_env_set("NO_COLOR", save_nc);
+  free(save_color);
+  free(save_fc);
+  free(save_nc);
+  return ok;
+}
 #endif
 
 static bool test_strerror_covers_every_code(void) {
@@ -510,6 +529,8 @@ void run_config_unit_tests(unit_stats_t *stats) {
               "color env resolver follows FORCE_COLOR/CLICOLOR conventions");
   unit_record(stats, test_use_colors_no_color_beats_force_color(),
               "NO_COLOR beats FORCE_COLOR=1 in app_use_colors");
+  unit_record(stats, test_use_colors_honors_cli_color_never(),
+              "APP_CLI_COLOR=never disables app_use_colors");
   unit_record(stats, test_config_load_reports_not_found(),
               "config load maps a missing explicit path to NOT_FOUND");
   unit_record(stats, test_config_load_reports_permission(),

--- a/test/unit_runner.c
+++ b/test/unit_runner.c
@@ -19,6 +19,7 @@ int main(void) {
   run_cli_style_unit_tests(&stats);
   run_cli_osc11_unit_tests(&stats);
   run_shared_primitives_unit_tests(&stats);
+  run_components_unit_tests(&stats);
 
   printf("1..%d\n", stats.passed + stats.failed);
   fprintf(stderr, "%d passed, %d failed\n", stats.passed, stats.failed);

--- a/test/unit_runner.c
+++ b/test/unit_runner.c
@@ -15,6 +15,7 @@ int main(void) {
   run_config_unit_tests(&stats);
   run_input_unit_tests(&stats);
   run_tui_menu_unit_tests(&stats);
+  run_ui_theme_unit_tests(&stats);
   run_cli_style_unit_tests(&stats);
   run_cli_osc11_unit_tests(&stats);
   run_shared_primitives_unit_tests(&stats);

--- a/test/unit_support.h
+++ b/test/unit_support.h
@@ -37,6 +37,7 @@ static inline void unit_record(unit_stats_t *stats, bool ok, const char *name) {
 void run_config_unit_tests(unit_stats_t *stats);
 void run_input_unit_tests(unit_stats_t *stats);
 void run_tui_menu_unit_tests(unit_stats_t *stats);
+void run_ui_theme_unit_tests(unit_stats_t *stats);
 void run_cli_style_unit_tests(unit_stats_t *stats);
 void run_cli_osc11_unit_tests(unit_stats_t *stats);
 void run_shared_primitives_unit_tests(unit_stats_t *stats);

--- a/test/unit_support.h
+++ b/test/unit_support.h
@@ -41,3 +41,4 @@ void run_ui_theme_unit_tests(unit_stats_t *stats);
 void run_cli_style_unit_tests(unit_stats_t *stats);
 void run_cli_osc11_unit_tests(unit_stats_t *stats);
 void run_shared_primitives_unit_tests(unit_stats_t *stats);
+void run_components_unit_tests(unit_stats_t *stats);

--- a/test/unit_ui_theme_tests.c
+++ b/test/unit_ui_theme_tests.c
@@ -98,6 +98,32 @@ static bool test_light_title_preserves_cli_literal(void) {
          title.rgb.g == 94 && title.rgb.b == 20;
 }
 
+// An explicit palette index must survive a truecolor profile as INDEXED, not
+// collapse to NONE — otherwise an all-indexed theme (e.g. "mono") renders
+// colorless on the common truecolor terminal. (Regression: the resolver
+// previously emitted color under TRUECOLOR only for RGB inputs.)
+static bool test_indexed_color_survives_truecolor(void) {
+  const app_ui_color_t ansi16 = {.kind = APP_UI_COLOR_ANSI16, .ansi16 = 7};
+  const app_ui_color_t ansi256 = {.kind = APP_UI_COLOR_ANSI256, .ansi256 = 200};
+  const app_ui_color_t rgb = {.kind = APP_UI_COLOR_RGB,
+                              .rgb = {.r = 0x10, .g = 0x20, .b = 0x30}};
+
+  app_ui_resolved_color_t r16 =
+      app_ui_color_resolve(ansi16, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
+  app_ui_resolved_color_t r256 =
+      app_ui_color_resolve(ansi256, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
+  app_ui_resolved_color_t rrgb =
+      app_ui_color_resolve(rgb, APP_CLI_COLOR_PROFILE_TRUECOLOR, 256);
+  // Lower profiles already handled indices; confirm they still do.
+  app_ui_resolved_color_t r16_at_256 =
+      app_ui_color_resolve(ansi16, APP_CLI_COLOR_PROFILE_ANSI256, 256);
+
+  return r16.kind == APP_UI_RESOLVED_INDEXED && r16.index == 7 &&
+         r256.kind == APP_UI_RESOLVED_INDEXED && r256.index == 200 &&
+         rrgb.kind == APP_UI_RESOLVED_RGB && rrgb.rgb.r == 0x10 &&
+         r16_at_256.kind == APP_UI_RESOLVED_INDEXED && r16_at_256.index == 7;
+}
+
 void run_ui_theme_unit_tests(unit_stats_t *stats) {
   unit_record(stats, test_default_dark_roles_use_design_palette(),
               "ui theme dark roles derive from design palette");
@@ -107,4 +133,6 @@ void run_ui_theme_unit_tests(unit_stats_t *stats) {
               "APP_CLI_ACCENT recolors shared accent roles");
   unit_record(stats, test_light_title_preserves_cli_literal(),
               "ui theme light title preserves existing CLI literal");
+  unit_record(stats, test_indexed_color_survives_truecolor(),
+              "ui resolver passes explicit palette indices through truecolor");
 }

--- a/test/unit_ui_theme_tests.c
+++ b/test/unit_ui_theme_tests.c
@@ -56,8 +56,7 @@ static bool test_color_parse_matches_cli_contract(void) {
   app_ui_color_t color;
   bool ok = app_ui_color_parse("#3aa0ff", &color) &&
             color.kind == APP_UI_COLOR_RGB && color.rgb.r == 0x3a &&
-            color.rgb.g == 0xa0 && color.rgb.b == 0xff &&
-            color.has_ansi16_hint;
+            color.rgb.g == 0xa0 && color.rgb.b == 0xff && color.has_ansi16_hint;
   ok = ok && app_ui_color_parse("ff8800", &color) &&
        color.kind == APP_UI_COLOR_RGB;
   ok = ok && app_ui_color_parse("12", &color) &&
@@ -65,8 +64,7 @@ static bool test_color_parse_matches_cli_contract(void) {
   ok = ok && app_ui_color_parse("200", &color) &&
        color.kind == APP_UI_COLOR_ANSI256 && color.ansi256 == 200;
   ok = ok && !app_ui_color_parse("#ggg", &color) &&
-       !app_ui_color_parse("300", &color) &&
-       !app_ui_color_parse("", &color);
+       !app_ui_color_parse("300", &color) && !app_ui_color_parse("", &color);
   return ok;
 }
 
@@ -92,8 +90,9 @@ static bool test_accent_override_updates_shared_roles(void) {
 }
 
 static bool test_light_title_preserves_cli_literal(void) {
-  const app_ui_color_t title = app_ui_theme_pick(
-      app_ui_theme_default_scheme(), APP_UI_ROLE_TITLE, APP_UI_THEME_MODE_LIGHT);
+  const app_ui_color_t title =
+      app_ui_theme_pick(app_ui_theme_default_scheme(), APP_UI_ROLE_TITLE,
+                        APP_UI_THEME_MODE_LIGHT);
   return title.kind == APP_UI_COLOR_RGB && title.rgb.r == 135 &&
          title.rgb.g == 94 && title.rgb.b == 20;
 }

--- a/test/unit_ui_theme_tests.c
+++ b/test/unit_ui_theme_tests.c
@@ -1,0 +1,110 @@
+/*
+ * Unit tests for the shared semantic UI theme.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/style/design_tokens.h"
+#include "../src/style/ui_theme.h"
+#include "unit_support.h"
+
+static char *ui_env_dup(const char *name) {
+  const char *value = getenv(name);
+  if (!value) {
+    return NULL;
+  }
+  const size_t len = strlen(value) + 1;
+  char *copy = malloc(len);
+  if (copy) {
+    memcpy(copy, value, len);
+  }
+  return copy;
+}
+
+static void ui_env_restore(const char *name, char *value) {
+  if (value) {
+    setenv(name, value, 1);
+    free(value);
+  } else {
+    unsetenv(name);
+  }
+}
+
+static bool rgb_eq(app_rgb_t a, app_rgb_t b) {
+  return a.r == b.r && a.g == b.g && a.b == b.b;
+}
+
+static bool test_default_dark_roles_use_design_palette(void) {
+  const app_ui_color_scheme_t *scheme = app_ui_theme_default_scheme();
+  const app_ui_color_t title =
+      app_ui_theme_pick(scheme, APP_UI_ROLE_TITLE, APP_UI_THEME_MODE_DARK);
+  const app_ui_color_t border =
+      app_ui_theme_pick(scheme, APP_UI_ROLE_BORDER, APP_UI_THEME_MODE_DARK);
+  const app_ui_color_t error = app_ui_theme_pick(
+      scheme, APP_UI_ROLE_ERROR_DETAILS, APP_UI_THEME_MODE_DARK);
+  return title.kind == APP_UI_COLOR_RGB &&
+         rgb_eq(title.rgb, APP_DESIGN_PALETTE.amber) &&
+         border.kind == APP_UI_COLOR_RGB &&
+         rgb_eq(border.rgb, APP_DESIGN_PALETTE.muted) &&
+         border.has_ansi16_hint && border.ansi16_hint == 7 &&
+         error.kind == APP_UI_COLOR_RGB &&
+         rgb_eq(error.rgb, APP_DESIGN_PALETTE.red);
+}
+
+static bool test_color_parse_matches_cli_contract(void) {
+  app_ui_color_t color;
+  bool ok = app_ui_color_parse("#3aa0ff", &color) &&
+            color.kind == APP_UI_COLOR_RGB && color.rgb.r == 0x3a &&
+            color.rgb.g == 0xa0 && color.rgb.b == 0xff &&
+            color.has_ansi16_hint;
+  ok = ok && app_ui_color_parse("ff8800", &color) &&
+       color.kind == APP_UI_COLOR_RGB;
+  ok = ok && app_ui_color_parse("12", &color) &&
+       color.kind == APP_UI_COLOR_ANSI16 && color.ansi16 == 12;
+  ok = ok && app_ui_color_parse("200", &color) &&
+       color.kind == APP_UI_COLOR_ANSI256 && color.ansi256 == 200;
+  ok = ok && !app_ui_color_parse("#ggg", &color) &&
+       !app_ui_color_parse("300", &color) &&
+       !app_ui_color_parse("", &color);
+  return ok;
+}
+
+static bool test_accent_override_updates_shared_roles(void) {
+  char *previous = ui_env_dup("APP_CLI_ACCENT");
+  bool ok = setenv("APP_CLI_ACCENT", "#102030", 1) == 0;
+  app_ui_color_scheme_t scheme = *app_ui_theme_default_scheme();
+  app_ui_theme_apply_env_overrides(&scheme);
+
+  const app_ui_color_t title =
+      app_ui_theme_pick(&scheme, APP_UI_ROLE_TITLE, APP_UI_THEME_MODE_DARK);
+  const app_ui_color_t accent =
+      app_ui_theme_pick(&scheme, APP_UI_ROLE_ACCENT, APP_UI_THEME_MODE_DARK);
+  const app_ui_color_t selection = app_ui_theme_pick(
+      &scheme, APP_UI_ROLE_SELECTION_BG, APP_UI_THEME_MODE_DARK);
+  ok = ok && title.kind == APP_UI_COLOR_RGB && title.rgb.r == 0x10 &&
+       title.rgb.g == 0x20 && title.rgb.b == 0x30 &&
+       accent.kind == APP_UI_COLOR_RGB && accent.rgb.r == 0x10 &&
+       selection.kind == APP_UI_COLOR_RGB && selection.rgb.b == 0x30;
+
+  ui_env_restore("APP_CLI_ACCENT", previous);
+  return ok;
+}
+
+static bool test_light_title_preserves_cli_literal(void) {
+  const app_ui_color_t title = app_ui_theme_pick(
+      app_ui_theme_default_scheme(), APP_UI_ROLE_TITLE, APP_UI_THEME_MODE_LIGHT);
+  return title.kind == APP_UI_COLOR_RGB && title.rgb.r == 135 &&
+         title.rgb.g == 94 && title.rgb.b == 20;
+}
+
+void run_ui_theme_unit_tests(unit_stats_t *stats) {
+  unit_record(stats, test_default_dark_roles_use_design_palette(),
+              "ui theme dark roles derive from design palette");
+  unit_record(stats, test_color_parse_matches_cli_contract(),
+              "ui color parser supports hex and ANSI indexes");
+  unit_record(stats, test_accent_override_updates_shared_roles(),
+              "APP_CLI_ACCENT recolors shared accent roles");
+  unit_record(stats, test_light_title_preserves_cli_literal(),
+              "ui theme light title preserves existing CLI literal");
+}

--- a/tools/curspan/main.zig
+++ b/tools/curspan/main.zig
@@ -1,0 +1,356 @@
+//! curspan — the framework's component CLI.
+//!
+//! ShadCN-style distribution for terminal-UI components: a local-first registry
+//! (registry/registry.json) plus an `add` command that copies a component and
+//! its transitive dependency closure into your project, so you OWN the source.
+//!
+//!   curspan list                 # the catalog, grouped by category
+//!   curspan info <name>          # a component's files + dependency closure
+//!   curspan add <name> [opts]    # copy the component + deps into your project
+//!   curspan check                # validate the registry (files exist, deps resolve)
+//!
+//! Options: --registry PATH (default registry/registry.json), --root PATH
+//! (source tree root, default "."), --dest PATH (add target, default "."),
+//! --dry-run (print actions without writing).
+
+const std = @import("std");
+const Io = std.Io;
+const Dir = std.Io.Dir;
+const File = std.Io.File;
+const Allocator = std.mem.Allocator;
+
+const Component = struct {
+    name: []const u8,
+    title: []const u8 = "",
+    category: []const u8 = "component",
+    surfaces: []const []const u8 = &.{},
+    description: []const u8 = "",
+    files: []const []const u8 = &.{},
+    dependencies: []const []const u8 = &.{},
+    since: []const u8 = "",
+};
+
+const Registry = struct {
+    name: []const u8 = "",
+    version: []const u8 = "",
+    components: []const Component,
+};
+
+const Options = struct {
+    registry: []const u8 = "registry/registry.json",
+    root: []const u8 = ".",
+    dest: []const u8 = ".",
+    dry_run: bool = false,
+};
+
+// Everything a command needs: the Io handle to touch stdout and the filesystem,
+// and an arena for scratch allocations (freed when the process exits).
+const Ctx = struct {
+    io: Io,
+    alloc: Allocator,
+};
+
+fn fail(comptime fmt: []const u8, args: anytype) noreturn {
+    std.debug.print("curspan: " ++ fmt ++ "\n", args);
+    std.process.exit(1);
+}
+
+fn findComponent(reg: Registry, name: []const u8) ?Component {
+    for (reg.components) |c| {
+        if (std.mem.eql(u8, c.name, name)) return c;
+    }
+    return null;
+}
+
+fn contains(list: []const []const u8, name: []const u8) bool {
+    for (list) |n| {
+        if (std.mem.eql(u8, n, name)) return true;
+    }
+    return false;
+}
+
+// Post-order dependency closure: dependencies appear before their dependents,
+// which is also the order to add the sources to a build. Detects cycles.
+fn addClosure(
+    alloc: Allocator,
+    reg: Registry,
+    name: []const u8,
+    seen: *std.ArrayList([]const u8),
+    visiting: *std.ArrayList([]const u8),
+) !void {
+    if (contains(seen.items, name)) return;
+    if (contains(visiting.items, name)) {
+        fail("dependency cycle through '{s}'", .{name});
+    }
+    const comp = findComponent(reg, name) orelse
+        fail("unknown component '{s}'", .{name});
+    try visiting.append(alloc, name);
+    for (comp.dependencies) |dep| try addClosure(alloc, reg, dep, seen, visiting);
+    _ = visiting.pop();
+    try seen.append(alloc, name);
+}
+
+fn closureOf(alloc: Allocator, reg: Registry, name: []const u8) ![]const []const u8 {
+    var seen: std.ArrayList([]const u8) = .empty;
+    var visiting: std.ArrayList([]const u8) = .empty;
+    try addClosure(alloc, reg, name, &seen, &visiting);
+    return seen.items;
+}
+
+fn loadRegistry(ctx: Ctx, path: []const u8) !std.json.Parsed(Registry) {
+    const bytes = Dir.cwd().readFileAlloc(ctx.io, path, ctx.alloc, .limited(4 * 1024 * 1024)) catch
+        fail("cannot read registry '{s}' (try --registry PATH)", .{path});
+    return std.json.parseFromSlice(Registry, ctx.alloc, bytes, .{ .ignore_unknown_fields = true }) catch
+        fail("registry '{s}' is not valid JSON", .{path});
+}
+
+// Append `fmt`-formatted text to `buf`. Output is built fully in memory, then
+// written to stdout once in `flush` — so the body of a command never touches Io.
+fn emit(buf: *std.ArrayList(u8), alloc: Allocator, comptime fmt: []const u8, args: anytype) !void {
+    const line = try std.fmt.allocPrint(alloc, fmt, args);
+    try buf.appendSlice(alloc, line);
+}
+
+// Append `text` left-justified into a field `width` columns wide (byte width;
+// registry names are ASCII). Avoids relying on std.fmt alignment specifiers.
+fn emitPadded(buf: *std.ArrayList(u8), alloc: Allocator, text: []const u8, width: usize) !void {
+    try buf.appendSlice(alloc, text);
+    var i: usize = text.len;
+    while (i < width) : (i += 1) try buf.append(alloc, ' ');
+}
+
+fn flush(ctx: Ctx, buf: *std.ArrayList(u8)) !void {
+    try File.stdout().writeStreamingAll(ctx.io, buf.items);
+}
+
+// A registry file path must be relative and stay within the tree. Reject
+// absolute paths and any ".." segment so `add`/`check` can never reach outside
+// the source root or the destination project.
+fn pathIsUnsafe(p: []const u8) bool {
+    if (std.fs.path.isAbsolute(p)) return true;
+    var it = std.mem.splitScalar(u8, p, '/');
+    while (it.next()) |seg| {
+        if (std.mem.eql(u8, seg, "..")) return true;
+    }
+    return false;
+}
+
+// One catalog row: "  <name padded>  <description>".
+fn emitCatalogRow(buf: *std.ArrayList(u8), alloc: Allocator, c: Component, name_width: usize) !void {
+    try buf.appendSlice(alloc, "  ");
+    try emitPadded(buf, alloc, c.name, name_width);
+    try emit(buf, alloc, "  {s}\n", .{c.description});
+}
+
+fn cmdList(ctx: Ctx, reg: Registry) !void {
+    const alloc = ctx.alloc;
+    var buf: std.ArrayList(u8) = .empty;
+    try emit(&buf, alloc, "{s} registry v{s}\n\n", .{ reg.name, reg.version });
+
+    // Pad the name column to the widest name so descriptions line up.
+    var name_width: usize = 1;
+    for (reg.components) |c| {
+        if (c.name.len > name_width) name_width = c.name.len;
+    }
+
+    const categories = [_][]const u8{ "foundation", "component" };
+    for (categories) |cat| {
+        try emit(&buf, alloc, "{s}s:\n", .{cat});
+        for (reg.components) |c| {
+            if (!std.mem.eql(u8, c.category, cat)) continue;
+            try emitCatalogRow(&buf, alloc, c, name_width);
+        }
+        try buf.append(alloc, '\n');
+    }
+
+    // Any component whose category is not one of the known sections still
+    // belongs in the catalog; group the leftovers so `list` never hides them.
+    var printed_other = false;
+    for (reg.components) |c| {
+        if (std.mem.eql(u8, c.category, "foundation") or
+            std.mem.eql(u8, c.category, "component")) continue;
+        if (!printed_other) {
+            try buf.appendSlice(alloc, "other:\n");
+            printed_other = true;
+        }
+        try emitCatalogRow(&buf, alloc, c, name_width);
+    }
+    if (printed_other) try buf.append(alloc, '\n');
+
+    try buf.appendSlice(alloc, "Add one with: curspan add <name>\n");
+    try flush(ctx, &buf);
+}
+
+fn cmdInfo(ctx: Ctx, reg: Registry, name: []const u8) !void {
+    const alloc = ctx.alloc;
+    const comp = findComponent(reg, name) orelse
+        fail("unknown component '{s}'", .{name});
+    var buf: std.ArrayList(u8) = .empty;
+    try emit(&buf, alloc, "{s} ({s})\n  {s}\n\n", .{ comp.name, comp.category, comp.description });
+    try buf.appendSlice(alloc, "files:\n");
+    for (comp.files) |f| try emit(&buf, alloc, "  {s}\n", .{f});
+    try buf.appendSlice(alloc, "\ndependency closure (add order):\n");
+    const closure = try closureOf(alloc, reg, name);
+    for (closure) |n| try emit(&buf, alloc, "  {s}\n", .{n});
+    try flush(ctx, &buf);
+}
+
+fn cmdAdd(ctx: Ctx, reg: Registry, name: []const u8, opts: Options) !void {
+    const alloc = ctx.alloc;
+    const closure = try closureOf(alloc, reg, name);
+    var buf: std.ArrayList(u8) = .empty;
+    var copied: usize = 0;
+    var added_files: std.ArrayList([]const u8) = .empty;
+
+    try emit(&buf, alloc, "Adding '{s}' ({d} units in closure) into {s}\n", .{ name, closure.len, opts.dest });
+    for (closure) |unit_name| {
+        const comp = findComponent(reg, unit_name).?;
+        for (comp.files) |rel| {
+            // Never write outside --dest, even from an untrusted --registry.
+            if (pathIsUnsafe(rel)) {
+                fail("unsafe file path '{s}' in component '{s}'", .{ rel, unit_name });
+            }
+            const src = try std.fs.path.join(alloc, &.{ opts.root, rel });
+            const dst = try std.fs.path.join(alloc, &.{ opts.dest, rel });
+            if (opts.dry_run) {
+                try emit(&buf, alloc, "  would copy {s}\n", .{rel});
+            } else {
+                const data = Dir.cwd().readFileAlloc(ctx.io, src, alloc, .limited(4 * 1024 * 1024)) catch
+                    fail("missing source file '{s}'", .{src});
+                if (std.fs.path.dirname(dst)) |dir| {
+                    Dir.cwd().createDirPath(ctx.io, dir) catch |e|
+                        fail("cannot create '{s}': {s}", .{ dir, @errorName(e) });
+                }
+                Dir.cwd().writeFile(ctx.io, .{ .sub_path = dst, .data = data }) catch |e|
+                    fail("cannot write '{s}': {s}", .{ dst, @errorName(e) });
+                try emit(&buf, alloc, "  copied {s}\n", .{rel});
+            }
+            copied += 1;
+            if (std.mem.endsWith(u8, rel, ".c")) try added_files.append(alloc, rel);
+        }
+    }
+
+    try emit(&buf, alloc, "\n{s} {d} file(s).\n", .{ if (opts.dry_run) "Would copy" else "Copied", copied });
+    if (added_files.items.len > 0) {
+        try buf.appendSlice(alloc, "\nAdd these sources to your build.zig:\n");
+        for (added_files.items) |f| try emit(&buf, alloc, "    \"{s}\",\n", .{f});
+    }
+    try flush(ctx, &buf);
+}
+
+fn cmdCheck(ctx: Ctx, reg: Registry, opts: Options) !void {
+    const alloc = ctx.alloc;
+    var problems: usize = 0;
+    var buf: std.ArrayList(u8) = .empty;
+    for (reg.components) |c| {
+        for (c.files) |rel| {
+            if (pathIsUnsafe(rel)) {
+                try emit(&buf, alloc, "  unsafe file path: {s} (in '{s}')\n", .{ rel, c.name });
+                problems += 1;
+                continue;
+            }
+            const path = try std.fs.path.join(alloc, &.{ opts.root, rel });
+            Dir.cwd().access(ctx.io, path, .{}) catch {
+                try emit(&buf, alloc, "  missing file: {s} (in '{s}')\n", .{ rel, c.name });
+                problems += 1;
+            };
+        }
+        for (c.dependencies) |dep| {
+            if (findComponent(reg, dep) == null) {
+                try emit(&buf, alloc, "  unresolved dependency: {s} -> {s}\n", .{ c.name, dep });
+                problems += 1;
+            }
+        }
+    }
+    // Closure resolution also detects cycles, but it aborts on the first one;
+    // run it only once the per-component report is clean so that report is never
+    // suppressed by a terse closure error.
+    if (problems == 0) {
+        for (reg.components) |c| _ = try closureOf(alloc, reg, c.name);
+    }
+
+    if (problems == 0) {
+        try emit(&buf, alloc, "registry ok: {d} components, all files present and dependencies resolve\n", .{reg.components.len});
+        try flush(ctx, &buf);
+    } else {
+        try emit(&buf, alloc, "registry has {d} problem(s)\n", .{problems});
+        try flush(ctx, &buf);
+        std.process.exit(1);
+    }
+}
+
+fn usage() void {
+    std.debug.print(
+        \\curspan — Curspan component CLI
+        \\
+        \\Usage:
+        \\  curspan list
+        \\  curspan info <name>
+        \\  curspan add <name> [--dest DIR] [--root DIR] [--dry-run]
+        \\  curspan check
+        \\
+        \\Options:
+        \\  --registry PATH   registry file (default registry/registry.json)
+        \\  --root DIR        source tree root to copy from (default .)
+        \\  --dest DIR        destination project root (default .)
+        \\  --dry-run         print actions without writing files
+        \\
+    , .{});
+}
+
+pub fn main(init: std.process.Init) !void {
+    const ctx = Ctx{ .io = init.io, .alloc = init.arena.allocator() };
+
+    const args = try std.process.Args.toSlice(init.minimal.args, ctx.alloc);
+    if (args.len < 2) {
+        usage();
+        std.process.exit(2);
+    }
+
+    const cmd = args[1];
+    var opts = Options{};
+    var positional: ?[]const u8 = null;
+
+    var i: usize = 2;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.eql(u8, a, "--registry")) {
+            i += 1;
+            if (i >= args.len) fail("--registry needs a path", .{});
+            opts.registry = args[i];
+        } else if (std.mem.eql(u8, a, "--root")) {
+            i += 1;
+            if (i >= args.len) fail("--root needs a path", .{});
+            opts.root = args[i];
+        } else if (std.mem.eql(u8, a, "--dest")) {
+            i += 1;
+            if (i >= args.len) fail("--dest needs a path", .{});
+            opts.dest = args[i];
+        } else if (std.mem.eql(u8, a, "--dry-run")) {
+            opts.dry_run = true;
+        } else if (std.mem.startsWith(u8, a, "--")) {
+            fail("unknown option '{s}'", .{a});
+        } else if (positional == null) {
+            positional = a;
+        } else {
+            fail("unexpected argument '{s}'", .{a});
+        }
+    }
+
+    const parsed = try loadRegistry(ctx, opts.registry);
+    const reg = parsed.value;
+
+    if (std.mem.eql(u8, cmd, "list")) {
+        try cmdList(ctx, reg);
+    } else if (std.mem.eql(u8, cmd, "info")) {
+        try cmdInfo(ctx, reg, positional orelse fail("info needs a component name", .{}));
+    } else if (std.mem.eql(u8, cmd, "add")) {
+        try cmdAdd(ctx, reg, positional orelse fail("add needs a component name", .{}), opts);
+    } else if (std.mem.eql(u8, cmd, "check")) {
+        try cmdCheck(ctx, reg, opts);
+    } else if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "--help")) {
+        usage();
+    } else {
+        fail("unknown command '{s}' (try: list, info, add, check)", .{cmd});
+    }
+}

--- a/tools/curspan/main.zig
+++ b/tools/curspan/main.zig
@@ -127,10 +127,18 @@ fn flush(ctx: Ctx, buf: *std.ArrayList(u8)) !void {
 // absolute paths and any ".." segment so `add`/`check` can never reach outside
 // the source root or the destination project. Split on both POSIX and Windows
 // separators regardless of the build host: on a Windows host `std.fs.path.join`
-// honors `\`, so a "..\\.." segment in an untrusted `--registry` would escape a
-// gate that only split on '/'.
+// honors `\`, so a "..\\.." segment in an untrusted registry entry would escape
+// a gate that only split on '/'.
 fn pathIsUnsafe(p: []const u8) bool {
     if (std.fs.path.isAbsolute(p)) return true;
+    return pathHasParentSegment(p);
+}
+
+// CLI options such as --registry and --root may be absolute because build.zig
+// passes LazyPath values to `curspan check`, but they must not contain parent
+// traversal segments. Keep this separate from pathIsUnsafe(), which guards
+// untrusted registry entries that are always expected to be relative.
+fn pathHasParentSegment(p: []const u8) bool {
     var it = std.mem.splitAny(u8, p, "/\\");
     while (it.next()) |seg| {
         if (std.mem.eql(u8, seg, "..")) return true;
@@ -143,6 +151,24 @@ test "pathIsUnsafe rejects traversal with either path separator" {
     try std.testing.expect(pathIsUnsafe("foo/../bar"));
     try std.testing.expect(pathIsUnsafe("foo\\..\\bar"));
     try std.testing.expect(!pathIsUnsafe("src/components/cs_table.c"));
+}
+
+test "pathHasParentSegment allows absolute LazyPaths but rejects traversal" {
+    try std.testing.expect(pathHasParentSegment("../registry.json"));
+    try std.testing.expect(pathHasParentSegment("foo\\..\\bar"));
+    try std.testing.expect(!pathHasParentSegment("/abs/path/registry.json"));
+}
+
+fn validateOptions(opts: Options) void {
+    if (pathHasParentSegment(opts.registry)) {
+        fail("unsafe --registry path '{s}'", .{opts.registry});
+    }
+    if (pathHasParentSegment(opts.root)) {
+        fail("unsafe --root path '{s}'", .{opts.root});
+    }
+    if (pathIsUnsafe(opts.dest)) {
+        fail("unsafe --dest path '{s}'", .{opts.dest});
+    }
 }
 
 // One catalog row: "  <name padded>  <description>".
@@ -346,6 +372,8 @@ pub fn main(init: std.process.Init) !void {
             fail("unexpected argument '{s}'", .{a});
         }
     }
+
+    validateOptions(opts);
 
     const parsed = try loadRegistry(ctx, opts.registry);
     const reg = parsed.value;

--- a/tools/curspan/main.zig
+++ b/tools/curspan/main.zig
@@ -125,14 +125,24 @@ fn flush(ctx: Ctx, buf: *std.ArrayList(u8)) !void {
 
 // A registry file path must be relative and stay within the tree. Reject
 // absolute paths and any ".." segment so `add`/`check` can never reach outside
-// the source root or the destination project.
+// the source root or the destination project. Split on both POSIX and Windows
+// separators regardless of the build host: on a Windows host `std.fs.path.join`
+// honors `\`, so a "..\\.." segment in an untrusted `--registry` would escape a
+// gate that only split on '/'.
 fn pathIsUnsafe(p: []const u8) bool {
     if (std.fs.path.isAbsolute(p)) return true;
-    var it = std.mem.splitScalar(u8, p, '/');
+    var it = std.mem.splitAny(u8, p, "/\\");
     while (it.next()) |seg| {
         if (std.mem.eql(u8, seg, "..")) return true;
     }
     return false;
+}
+
+test "pathIsUnsafe rejects traversal with either path separator" {
+    try std.testing.expect(pathIsUnsafe("../registry.json"));
+    try std.testing.expect(pathIsUnsafe("foo/../bar"));
+    try std.testing.expect(pathIsUnsafe("foo\\..\\bar"));
+    try std.testing.expect(!pathIsUnsafe("src/components/cs_table.c"));
 }
 
 // One catalog row: "  <name padded>  <description>".


### PR DESCRIPTION
Reframes Curspan from a starter template into a terminal UI framework with open-code components, a shared theme/surface layer, and a registry-backed `curspan add` workflow. The reference app remains wired as the default template while the new catalog can render on stream or curses surfaces.

**Framework Surface**

Adds `curspan.h`, semantic theme APIs, stream/curses render surfaces, and a catalog of rule, heading, badge, note, key/value, list, table, progress, and spinner components.

**Component Distribution**

Adds `registry/registry.json` and a host-built Zig `curspan` CLI for `list`, `info`, `add`, and `check`, with registry validation wired into `zig build test`.

**Docs and Examples**

Updates the README, architecture/contracts docs, theming/components references, and custom TUI examples to describe the framework model and open-code workflow.

Validated locally with `zig build test -Dterminal-backend=none`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface area (build graph, new public `cs_*` APIs, registry tooling) with contract-sensitive CLI env metadata; existing byte-pinned CLI tests are the main guardrail.
> 
> **Overview**
> Repositions the repo as a **terminal UI framework** (ShadCN-style open-code components) while keeping the reference app as a starter path. Adds a **theme → `cs_surface` → component catalog** stack (`curspan.h`, `cs_theme`, stream/curses surfaces, nine `cs_*` widgets) and wires those sources into shared UI builds, unit tests, and `tui-menu-lib`.
> 
> Introduces **`registry/registry.json`** and a host Zig **`curspan`** CLI (`list` / `info` / `add` / `check`), with registry validation hooked into **`zig build test`**. CLI theming now projects from shared **`ui_theme`** / **`app_ui_color_resolve`**; mode resolution moves to **`cs_theme_mode_resolve`**.
> 
> Documentation and **`opencli.json`** env wording are reframed around framework usage, **COMPONENTS.md** / **THEMING.md**, and updated examples; **`AGENTS.md`** documents agent workflows and build boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c6a4bbdde6710ac3d7e31c8aae50e4f413cbe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->